### PR TITLE
feat(db): SQLite connection, migrations, and typed row parsers

### DIFF
--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -1,0 +1,37 @@
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+/** Directory name that holds all Concord state within a repo. */
+export const CONCORD_DIR = '.concord';
+
+/** Filename of the SQLite source-of-truth database. */
+export const DB_FILENAME = 'concord.db';
+
+/**
+ * Walk upward from `startDir` looking for a `.git` directory and return the
+ * repository root. Falls back to `startDir` when no `.git` is found so Concord
+ * still works outside a git repo.
+ */
+export function findRepoRoot(startDir: string): string {
+  let dir = resolve(startDir);
+  for (;;) {
+    if (existsSync(join(dir, '.git'))) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      return resolve(startDir);
+    }
+    dir = parent;
+  }
+}
+
+/** Absolute path to the `.concord/` directory for a given repo root. */
+export function concordDir(repoRoot: string): string {
+  return join(repoRoot, CONCORD_DIR);
+}
+
+/** Absolute path to the SQLite database for a given repo root. */
+export function databasePath(repoRoot: string): string {
+  return join(concordDir(repoRoot), DB_FILENAME);
+}

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -1,0 +1,45 @@
+import { mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import Database from 'better-sqlite3';
+import { z } from 'zod';
+
+import { migrations } from './schema.js';
+
+/** An open better-sqlite3 database instance. */
+export type ConcordDatabase = Database.Database;
+
+const userVersionSchema = z.number().int().nonnegative();
+
+/**
+ * Open (creating if needed) the Concord SQLite database at `filename`, enable
+ * WAL + foreign keys, and apply any outstanding migrations. Pass `':memory:'`
+ * for an ephemeral database (used in tests).
+ */
+export function openDatabase(filename: string): ConcordDatabase {
+  if (filename !== ':memory:') {
+    mkdirSync(dirname(filename), { recursive: true });
+  }
+  const db = new Database(filename);
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  runMigrations(db);
+  return db;
+}
+
+function runMigrations(db: ConcordDatabase): void {
+  const applied = readUserVersion(db);
+  for (let index = applied; index < migrations.length; index += 1) {
+    const migration = migrations[index];
+    if (migration === undefined) {
+      continue;
+    }
+    db.exec(migration);
+    db.pragma(`user_version = ${String(index + 1)}`);
+  }
+}
+
+function readUserVersion(db: ConcordDatabase): number {
+  const raw: unknown = db.pragma('user_version', { simple: true });
+  return userVersionSchema.parse(raw);
+}

--- a/src/db/rows.ts
+++ b/src/db/rows.ts
@@ -1,0 +1,174 @@
+import { z } from 'zod';
+
+/**
+ * Row parsing lives here so the "never typecast" rule holds across the db layer:
+ * every raw better-sqlite3 result enters as `unknown` and is narrowed by a Zod
+ * schema into a typed, camelCased record. See CLAUDE.md.
+ */
+
+/** Lifecycle states a task can be in. */
+export const taskStatusValues = ['active', 'handed_off', 'review_ready'] as const;
+export type TaskStatus = (typeof taskStatusValues)[number];
+const taskStatusSchema = z.enum(taskStatusValues);
+
+/** Tools that can be recorded as events (used for adoption tracking). */
+export const toolNameValues = ['claim_work', 'handoff', 'review_ready'] as const;
+export type ToolName = (typeof toolNameValues)[number];
+const toolNameSchema = z.enum(toolNameValues);
+
+/** Outcome recorded for an event. */
+export const eventStatusValues = ['success', 'error'] as const;
+export type EventStatus = (typeof eventStatusValues)[number];
+const eventStatusSchema = z.enum(eventStatusValues);
+
+/** Parse a JSON-encoded TEXT column into a validated `string[]`. */
+export function parseStringArray(json: string): string[] {
+  const parsed: unknown = JSON.parse(json);
+  return z.array(z.string()).parse(parsed);
+}
+
+/** Serialize a `string[]` for storage in a TEXT column. */
+export function serializeStringArray(values: readonly string[]): string {
+  return JSON.stringify(values);
+}
+
+// --- tasks -----------------------------------------------------------------
+
+export interface TaskRecord {
+  taskId: string;
+  title: string;
+  owner: string | null;
+  agent: string | null;
+  branch: string | null;
+  worktree: string | null;
+  expectedFiles: string[];
+  modules: string[];
+  domains: string[];
+  riskTags: string[];
+  notes: string | null;
+  status: TaskStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+const taskDbRowSchema = z.object({
+  task_id: z.string(),
+  title: z.string(),
+  owner: z.string().nullable(),
+  agent: z.string().nullable(),
+  branch: z.string().nullable(),
+  worktree: z.string().nullable(),
+  expected_files: z.string(),
+  modules: z.string(),
+  domains: z.string(),
+  risk_tags: z.string(),
+  notes: z.string().nullable(),
+  status: taskStatusSchema,
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+
+export function parseTaskRow(raw: unknown): TaskRecord {
+  const row = taskDbRowSchema.parse(raw);
+  return {
+    taskId: row.task_id,
+    title: row.title,
+    owner: row.owner,
+    agent: row.agent,
+    branch: row.branch,
+    worktree: row.worktree,
+    expectedFiles: parseStringArray(row.expected_files),
+    modules: parseStringArray(row.modules),
+    domains: parseStringArray(row.domains),
+    riskTags: parseStringArray(row.risk_tags),
+    notes: row.notes,
+    status: row.status,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+// --- handoffs --------------------------------------------------------------
+
+export interface HandoffRecord {
+  id: number;
+  taskId: string;
+  status: string;
+  changedFiles: string[];
+  whatChanged: string;
+  testsRun: string[];
+  knownRisks: string[];
+  assumptions: string[];
+  decisions: string[];
+  guardrailsChecked: string[];
+  needsReviewFrom: string[];
+  nextSteps: string[];
+  createdAt: string;
+}
+
+const handoffDbRowSchema = z.object({
+  id: z.number().int(),
+  task_id: z.string(),
+  status: z.string(),
+  changed_files: z.string(),
+  what_changed: z.string(),
+  tests_run: z.string(),
+  known_risks: z.string(),
+  assumptions: z.string(),
+  decisions: z.string(),
+  guardrails_checked: z.string(),
+  needs_review_from: z.string(),
+  next_steps: z.string(),
+  created_at: z.string(),
+});
+
+export function parseHandoffRow(raw: unknown): HandoffRecord {
+  const row = handoffDbRowSchema.parse(raw);
+  return {
+    id: row.id,
+    taskId: row.task_id,
+    status: row.status,
+    changedFiles: parseStringArray(row.changed_files),
+    whatChanged: row.what_changed,
+    testsRun: parseStringArray(row.tests_run),
+    knownRisks: parseStringArray(row.known_risks),
+    assumptions: parseStringArray(row.assumptions),
+    decisions: parseStringArray(row.decisions),
+    guardrailsChecked: parseStringArray(row.guardrails_checked),
+    needsReviewFrom: parseStringArray(row.needs_review_from),
+    nextSteps: parseStringArray(row.next_steps),
+    createdAt: row.created_at,
+  };
+}
+
+// --- events ----------------------------------------------------------------
+
+export interface EventRecord {
+  id: number;
+  taskId: string | null;
+  tool: ToolName;
+  status: EventStatus;
+  detail: string | null;
+  createdAt: string;
+}
+
+const eventDbRowSchema = z.object({
+  id: z.number().int(),
+  task_id: z.string().nullable(),
+  tool: toolNameSchema,
+  status: eventStatusSchema,
+  detail: z.string().nullable(),
+  created_at: z.string(),
+});
+
+export function parseEventRow(raw: unknown): EventRecord {
+  const row = eventDbRowSchema.parse(raw);
+  return {
+    id: row.id,
+    taskId: row.task_id,
+    tool: row.tool,
+    status: row.status,
+    detail: row.detail,
+    createdAt: row.created_at,
+  };
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,0 +1,55 @@
+/**
+ * Ordered, append-only list of SQL migrations. The migration runner in
+ * `connection.ts` uses `PRAGMA user_version` to track how many have been
+ * applied. Never edit or reorder an existing entry — only append new ones.
+ */
+export const migrations: readonly string[] = [
+  // 001 — v0 core tables: tasks, handoffs, events.
+  `
+  CREATE TABLE tasks (
+    task_id        TEXT PRIMARY KEY,
+    title          TEXT NOT NULL,
+    owner          TEXT,
+    agent          TEXT,
+    branch         TEXT,
+    worktree       TEXT,
+    expected_files TEXT NOT NULL DEFAULT '[]',
+    modules        TEXT NOT NULL DEFAULT '[]',
+    domains        TEXT NOT NULL DEFAULT '[]',
+    risk_tags      TEXT NOT NULL DEFAULT '[]',
+    notes          TEXT,
+    status         TEXT NOT NULL DEFAULT 'active',
+    created_at     TEXT NOT NULL,
+    updated_at     TEXT NOT NULL
+  );
+
+  CREATE TABLE handoffs (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id            TEXT NOT NULL REFERENCES tasks(task_id),
+    status             TEXT NOT NULL,
+    changed_files      TEXT NOT NULL DEFAULT '[]',
+    what_changed       TEXT NOT NULL,
+    tests_run          TEXT NOT NULL DEFAULT '[]',
+    known_risks        TEXT NOT NULL DEFAULT '[]',
+    assumptions        TEXT NOT NULL DEFAULT '[]',
+    decisions          TEXT NOT NULL DEFAULT '[]',
+    guardrails_checked TEXT NOT NULL DEFAULT '[]',
+    needs_review_from  TEXT NOT NULL DEFAULT '[]',
+    next_steps         TEXT NOT NULL DEFAULT '[]',
+    created_at         TEXT NOT NULL
+  );
+
+  CREATE INDEX idx_handoffs_task_id ON handoffs(task_id);
+
+  CREATE TABLE events (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id    TEXT,
+    tool       TEXT NOT NULL,
+    status     TEXT NOT NULL,
+    detail     TEXT,
+    created_at TEXT NOT NULL
+  );
+
+  CREATE INDEX idx_events_task_id ON events(task_id);
+  `,
+];

--- a/test/config/paths.test.ts
+++ b/test/config/paths.test.ts
@@ -1,0 +1,27 @@
+import { mkdirSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { concordDir, databasePath, findRepoRoot } from '../../src/config/paths.js';
+
+describe('paths', () => {
+  it('derives .concord and db paths from a repo root', () => {
+    expect(concordDir('/repo')).toBe(join('/repo', '.concord'));
+    expect(databasePath('/repo')).toBe(join('/repo', '.concord', 'concord.db'));
+  });
+
+  it('finds the repo root by walking up to a .git directory', () => {
+    const root = mkdtempSync(join(tmpdir(), 'concord-'));
+    mkdirSync(join(root, '.git'));
+    const nested = join(root, 'a', 'b');
+    mkdirSync(nested, { recursive: true });
+    expect(findRepoRoot(nested)).toBe(root);
+  });
+
+  it('falls back to the start dir when no .git is found', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'concord-nogit-'));
+    expect(findRepoRoot(dir)).toBe(dir);
+  });
+});

--- a/test/db/connection.test.ts
+++ b/test/db/connection.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { openDatabase } from '../../src/db/connection.js';
+import { parseStringArray, parseTaskRow, serializeStringArray } from '../../src/db/rows.js';
+
+describe('openDatabase', () => {
+  it('applies all migrations (user_version at head) and creates tables', () => {
+    const db = openDatabase(':memory:');
+    const version: unknown = db.pragma('user_version', { simple: true });
+    expect(version).toBe(1);
+
+    const raw: unknown = db.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all();
+    const names = new Set(
+      z
+        .array(z.object({ name: z.string() }))
+        .parse(raw)
+        .map((r) => r.name),
+    );
+    expect(names.has('tasks')).toBe(true);
+    expect(names.has('handoffs')).toBe(true);
+    expect(names.has('events')).toBe(true);
+  });
+});
+
+describe('row parsing', () => {
+  it('round-trips a string array through serialize/parse', () => {
+    expect(parseStringArray(serializeStringArray(['a', 'b']))).toEqual(['a', 'b']);
+    expect(parseStringArray('[]')).toEqual([]);
+  });
+
+  it('parses a raw task row into a camelCased record', () => {
+    const record = parseTaskRow({
+      task_id: 'TASK-1',
+      title: 'Test',
+      owner: null,
+      agent: 'codex',
+      branch: null,
+      worktree: null,
+      expected_files: '["src/a.ts"]',
+      modules: '["billing"]',
+      domains: '[]',
+      risk_tags: '[]',
+      notes: null,
+      status: 'active',
+      created_at: '2026-07-17T00:00:00.000Z',
+      updated_at: '2026-07-17T00:00:00.000Z',
+    });
+    expect(record.taskId).toBe('TASK-1');
+    expect(record.expectedFiles).toEqual(['src/a.ts']);
+    expect(record.modules).toEqual(['billing']);
+    expect(record.agent).toBe('codex');
+  });
+
+  it('rejects a malformed row (unknown status)', () => {
+    expect(() => parseTaskRow({ task_id: 'x', status: 'bogus' })).toThrow();
+  });
+});


### PR DESCRIPTION
## PR 2a of the initial buildout (storage foundation)

The persistence foundation for Concord's source-of-truth SQLite database. Split from the larger storage work to keep the diff under the 600-LOC rule; repositories follow in PR 2b.

### What's here
- **`config/paths.ts`** — repo-root discovery (walks up to `.git`) and `.concord/` / `concord.db` path resolution.
- **`db/connection.ts`** — opens the DB with WAL + foreign keys and runs migrations via `PRAGMA user_version`. `:memory:` supported for tests.
- **`db/schema.ts`** — append-only migration list; migration 001 creates `tasks`, `handoffs`, `events`.
- **`db/rows.ts`** — Zod row schemas + parse functions. Every raw better-sqlite3 result enters as `unknown` and is narrowed by Zod into a typed, camelCased record — **no typecasts**, per `CLAUDE.md`.

### Tests
Path resolution, migration application (tables + `user_version`), string-array round-trip, task-row parsing, and malformed-row rejection. 7 tests, `:memory:`.

### Verification
`pnpm lint && pnpm typecheck && pnpm test && pnpm build` green locally.