### PR TITLE
feat(db): task, handoff, and event repositories

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,0 +1,41 @@
+import { openDatabase, type ConcordDatabase } from './connection.js';
+import { createEventRepository, type EventRepository } from './repositories/events.js';
+import { createHandoffRepository, type HandoffRepository } from './repositories/handoffs.js';
+import { createTaskRepository, type TaskRepository } from './repositories/tasks.js';
+
+export type { ConcordDatabase } from './connection.js';
+export { openDatabase } from './connection.js';
+export type { NewTask, TaskRepository } from './repositories/tasks.js';
+export type { NewHandoff, HandoffRepository } from './repositories/handoffs.js';
+export type { NewEvent, EventRepository } from './repositories/events.js';
+export type {
+  TaskRecord,
+  TaskStatus,
+  HandoffRecord,
+  EventRecord,
+  EventStatus,
+  ToolName,
+} from './rows.js';
+
+/** The full set of Concord repositories bound to one database. */
+export interface Repositories {
+  db: ConcordDatabase;
+  tasks: TaskRepository;
+  handoffs: HandoffRepository;
+  events: EventRepository;
+}
+
+/** Bind all repositories to an already-open database. */
+export function createRepositories(db: ConcordDatabase): Repositories {
+  return {
+    db,
+    tasks: createTaskRepository(db),
+    handoffs: createHandoffRepository(db),
+    events: createEventRepository(db),
+  };
+}
+
+/** Open the database at `filename` and bind all repositories. */
+export function openRepositories(filename: string): Repositories {
+  return createRepositories(openDatabase(filename));
+}

--- a/src/db/repositories/events.ts
+++ b/src/db/repositories/events.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+
+import type { ConcordDatabase } from '../connection.js';
+import { parseEventRow, type EventRecord, type EventStatus, type ToolName } from '../rows.js';
+
+/** Input for recording a tool-invocation event (adoption + provenance log). */
+export interface NewEvent {
+  taskId: string | null;
+  tool: ToolName;
+  status: EventStatus;
+  detail: string | null;
+}
+
+export interface EventRepository {
+  record(event: NewEvent): EventRecord;
+  list(): EventRecord[];
+  listByTask(taskId: string): EventRecord[];
+}
+
+const rawListSchema = z.array(z.unknown());
+
+export function createEventRepository(db: ConcordDatabase): EventRepository {
+  const insertStmt = db.prepare(`
+    INSERT INTO events (task_id, tool, status, detail, created_at)
+    VALUES (@task_id, @tool, @status, @detail, @created_at)
+  `);
+  const getByIdStmt = db.prepare('SELECT * FROM events WHERE id = ?');
+  const listStmt = db.prepare('SELECT * FROM events ORDER BY created_at ASC, id ASC');
+  const listByTaskStmt = db.prepare(
+    'SELECT * FROM events WHERE task_id = ? ORDER BY created_at ASC, id ASC',
+  );
+
+  return {
+    record(event) {
+      const info = insertStmt.run({
+        task_id: event.taskId,
+        tool: event.tool,
+        status: event.status,
+        detail: event.detail,
+        created_at: new Date().toISOString(),
+      });
+      const raw: unknown = getByIdStmt.get(info.lastInsertRowid);
+      if (raw === undefined) {
+        throw new Error(`Event ${String(info.lastInsertRowid)} could not be read back`);
+      }
+      return parseEventRow(raw);
+    },
+    list() {
+      const raw: unknown = listStmt.all();
+      return rawListSchema.parse(raw).map(parseEventRow);
+    },
+    listByTask(taskId) {
+      const raw: unknown = listByTaskStmt.all(taskId);
+      return rawListSchema.parse(raw).map(parseEventRow);
+    },
+  };
+}

--- a/src/db/repositories/handoffs.ts
+++ b/src/db/repositories/handoffs.ts
@@ -1,0 +1,83 @@
+import { z } from 'zod';
+
+import type { ConcordDatabase } from '../connection.js';
+import { parseHandoffRow, serializeStringArray, type HandoffRecord } from '../rows.js';
+
+/** Input for recording a handoff. Array fields default to `[]` at the caller. */
+export interface NewHandoff {
+  taskId: string;
+  status: string;
+  changedFiles: readonly string[];
+  whatChanged: string;
+  testsRun: readonly string[];
+  knownRisks: readonly string[];
+  assumptions: readonly string[];
+  decisions: readonly string[];
+  guardrailsChecked: readonly string[];
+  needsReviewFrom: readonly string[];
+  nextSteps: readonly string[];
+}
+
+export interface HandoffRepository {
+  create(handoff: NewHandoff): HandoffRecord;
+  listByTask(taskId: string): HandoffRecord[];
+  latestForTask(taskId: string): HandoffRecord | undefined;
+}
+
+const rawListSchema = z.array(z.unknown());
+
+export function createHandoffRepository(db: ConcordDatabase): HandoffRepository {
+  const insertStmt = db.prepare(`
+    INSERT INTO handoffs (
+      task_id, status, changed_files, what_changed, tests_run, known_risks,
+      assumptions, decisions, guardrails_checked, needs_review_from, next_steps,
+      created_at
+    ) VALUES (
+      @task_id, @status, @changed_files, @what_changed, @tests_run, @known_risks,
+      @assumptions, @decisions, @guardrails_checked, @needs_review_from, @next_steps,
+      @created_at
+    )
+  `);
+  const getByIdStmt = db.prepare('SELECT * FROM handoffs WHERE id = ?');
+  const listByTaskStmt = db.prepare(
+    'SELECT * FROM handoffs WHERE task_id = ? ORDER BY created_at ASC, id ASC',
+  );
+  const latestStmt = db.prepare(
+    'SELECT * FROM handoffs WHERE task_id = ? ORDER BY created_at DESC, id DESC LIMIT 1',
+  );
+
+  return {
+    create(handoff) {
+      const info = insertStmt.run({
+        task_id: handoff.taskId,
+        status: handoff.status,
+        changed_files: serializeStringArray(handoff.changedFiles),
+        what_changed: handoff.whatChanged,
+        tests_run: serializeStringArray(handoff.testsRun),
+        known_risks: serializeStringArray(handoff.knownRisks),
+        assumptions: serializeStringArray(handoff.assumptions),
+        decisions: serializeStringArray(handoff.decisions),
+        guardrails_checked: serializeStringArray(handoff.guardrailsChecked),
+        needs_review_from: serializeStringArray(handoff.needsReviewFrom),
+        next_steps: serializeStringArray(handoff.nextSteps),
+        created_at: new Date().toISOString(),
+      });
+      const raw: unknown = getByIdStmt.get(info.lastInsertRowid);
+      if (raw === undefined) {
+        throw new Error(`Handoff ${String(info.lastInsertRowid)} could not be read back`);
+      }
+      return parseHandoffRow(raw);
+    },
+    listByTask(taskId) {
+      const raw: unknown = listByTaskStmt.all(taskId);
+      return rawListSchema.parse(raw).map(parseHandoffRow);
+    },
+    latestForTask(taskId) {
+      const raw: unknown = latestStmt.get(taskId);
+      if (raw === undefined) {
+        return undefined;
+      }
+      return parseHandoffRow(raw);
+    },
+  };
+}

--- a/src/db/repositories/tasks.ts
+++ b/src/db/repositories/tasks.ts
@@ -1,0 +1,91 @@
+import { z } from 'zod';
+
+import type { ConcordDatabase } from '../connection.js';
+import { parseTaskRow, serializeStringArray, type TaskRecord, type TaskStatus } from '../rows.js';
+
+/** Input for creating a task claim. Optional string fields are explicit `null`. */
+export interface NewTask {
+  taskId: string;
+  title: string;
+  owner: string | null;
+  agent: string | null;
+  branch: string | null;
+  worktree: string | null;
+  expectedFiles: readonly string[];
+  modules: readonly string[];
+  domains: readonly string[];
+  riskTags: readonly string[];
+  notes: string | null;
+}
+
+export interface TaskRepository {
+  create(task: NewTask): TaskRecord;
+  get(taskId: string): TaskRecord | undefined;
+  list(): TaskRecord[];
+  updateStatus(taskId: string, status: TaskStatus): TaskRecord | undefined;
+}
+
+const rawListSchema = z.array(z.unknown());
+
+export function createTaskRepository(db: ConcordDatabase): TaskRepository {
+  const insertStmt = db.prepare(`
+    INSERT INTO tasks (
+      task_id, title, owner, agent, branch, worktree,
+      expected_files, modules, domains, risk_tags, notes, status,
+      created_at, updated_at
+    ) VALUES (
+      @task_id, @title, @owner, @agent, @branch, @worktree,
+      @expected_files, @modules, @domains, @risk_tags, @notes, @status,
+      @created_at, @updated_at
+    )
+  `);
+  const getStmt = db.prepare('SELECT * FROM tasks WHERE task_id = ?');
+  const listStmt = db.prepare('SELECT * FROM tasks ORDER BY created_at ASC, task_id ASC');
+  const updateStatusStmt = db.prepare(
+    'UPDATE tasks SET status = @status, updated_at = @updated_at WHERE task_id = @task_id',
+  );
+
+  function get(taskId: string): TaskRecord | undefined {
+    const raw: unknown = getStmt.get(taskId);
+    if (raw === undefined) {
+      return undefined;
+    }
+    return parseTaskRow(raw);
+  }
+
+  return {
+    create(task) {
+      const now = new Date().toISOString();
+      insertStmt.run({
+        task_id: task.taskId,
+        title: task.title,
+        owner: task.owner,
+        agent: task.agent,
+        branch: task.branch,
+        worktree: task.worktree,
+        expected_files: serializeStringArray(task.expectedFiles),
+        modules: serializeStringArray(task.modules),
+        domains: serializeStringArray(task.domains),
+        risk_tags: serializeStringArray(task.riskTags),
+        notes: task.notes,
+        status: 'active',
+        created_at: now,
+        updated_at: now,
+      });
+      const created = get(task.taskId);
+      if (created === undefined) {
+        throw new Error(`Task ${task.taskId} could not be read back after insert`);
+      }
+      return created;
+    },
+    get,
+    list() {
+      const raw: unknown = listStmt.all();
+      return rawListSchema.parse(raw).map(parseTaskRow);
+    },
+    updateStatus(taskId, status) {
+      updateStatusStmt.run({ task_id: taskId, status, updated_at: new Date().toISOString() });
+      return get(taskId);
+    },
+  };
+}

--- a/test/db/storage.test.ts
+++ b/test/db/storage.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { openDatabase } from '../../src/db/connection.js';
+import { createRepositories, type Repositories } from '../../src/db/index.js';
+
+function newRepos(): Repositories {
+  return createRepositories(openDatabase(':memory:'));
+}
+
+const baseTask = {
+  taskId: 'TASK-12',
+  title: 'Add Stripe retry handling',
+  owner: 'alex',
+  agent: 'claude-code',
+  branch: 'feat/billing-retry',
+  worktree: null,
+  expectedFiles: ['src/billing/retry.ts'],
+  modules: ['billing', 'stripe'],
+  domains: ['payments'],
+  riskTags: ['payment-flow'],
+  notes: null,
+} as const;
+
+describe('migrations', () => {
+  it('applies migrations and creates the core tables', () => {
+    const { db } = newRepos();
+    const raw: unknown = db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
+      .all();
+    const rows = z.array(z.object({ name: z.string() })).parse(raw);
+    const names = new Set(rows.map((row) => row.name));
+    expect(names.has('tasks')).toBe(true);
+    expect(names.has('handoffs')).toBe(true);
+    expect(names.has('events')).toBe(true);
+  });
+
+  it('is idempotent when reopening (user_version already at head)', () => {
+    const { db } = newRepos();
+    const version: unknown = db.pragma('user_version', { simple: true });
+    expect(version).toBe(1);
+  });
+});
+
+describe('task repository', () => {
+  let repos: Repositories;
+  beforeEach(() => {
+    repos = newRepos();
+  });
+
+  it('creates and reads back a task with array fields intact', () => {
+    const created = repos.tasks.create(baseTask);
+    expect(created.taskId).toBe('TASK-12');
+    expect(created.modules).toEqual(['billing', 'stripe']);
+    expect(created.status).toBe('active');
+
+    const fetched = repos.tasks.get('TASK-12');
+    expect(fetched?.expectedFiles).toEqual(['src/billing/retry.ts']);
+    expect(fetched?.owner).toBe('alex');
+    expect(fetched?.worktree).toBeNull();
+  });
+
+  it('returns undefined for a missing task', () => {
+    expect(repos.tasks.get('NOPE')).toBeUndefined();
+  });
+
+  it('lists tasks in insertion order', () => {
+    repos.tasks.create(baseTask);
+    repos.tasks.create({ ...baseTask, taskId: 'TASK-14', title: 'Signup copy' });
+    expect(repos.tasks.list().map((t) => t.taskId)).toEqual(['TASK-12', 'TASK-14']);
+  });
+
+  it('updates status', () => {
+    repos.tasks.create(baseTask);
+    const updated = repos.tasks.updateStatus('TASK-12', 'review_ready');
+    expect(updated?.status).toBe('review_ready');
+  });
+});
+
+describe('handoff repository', () => {
+  let repos: Repositories;
+  beforeEach(() => {
+    repos = newRepos();
+    repos.tasks.create(baseTask);
+  });
+
+  it('records a handoff and reads it back', () => {
+    const handoff = repos.handoffs.create({
+      taskId: 'TASK-12',
+      status: 'done',
+      changedFiles: ['src/billing/retry.ts'],
+      whatChanged: 'Queued retries instead of synchronous',
+      testsRun: ['pnpm test billing'],
+      knownRisks: [],
+      assumptions: ['retries are idempotent'],
+      decisions: ['use a queue'],
+      guardrailsChecked: ['stripe payment test'],
+      needsReviewFrom: ['payments-team'],
+      nextSteps: [],
+    });
+    expect(handoff.id).toBeGreaterThan(0);
+    expect(handoff.assumptions).toEqual(['retries are idempotent']);
+  });
+
+  it('returns the latest handoff for a task', () => {
+    const common = {
+      taskId: 'TASK-12',
+      changedFiles: [],
+      testsRun: [],
+      knownRisks: [],
+      assumptions: [],
+      decisions: [],
+      guardrailsChecked: [],
+      needsReviewFrom: [],
+      nextSteps: [],
+    };
+    repos.handoffs.create({ ...common, status: 'blocked', whatChanged: 'first' });
+    repos.handoffs.create({ ...common, status: 'done', whatChanged: 'second' });
+    expect(repos.handoffs.latestForTask('TASK-12')?.whatChanged).toBe('second');
+    expect(repos.handoffs.listByTask('TASK-12')).toHaveLength(2);
+  });
+
+  it('rejects a handoff for an unknown task (foreign key)', () => {
+    expect(() =>
+      repos.handoffs.create({
+        taskId: 'MISSING',
+        status: 'done',
+        changedFiles: [],
+        whatChanged: 'x',
+        testsRun: [],
+        knownRisks: [],
+        assumptions: [],
+        decisions: [],
+        guardrailsChecked: [],
+        needsReviewFrom: [],
+        nextSteps: [],
+      }),
+    ).toThrow();
+  });
+});
+
+describe('event repository', () => {
+  let repos: Repositories;
+  beforeEach(() => {
+    repos = newRepos();
+    repos.tasks.create(baseTask);
+  });
+
+  it('records events and lists them by task', () => {
+    repos.events.record({ taskId: 'TASK-12', tool: 'claim_work', status: 'success', detail: null });
+    repos.events.record({ taskId: 'TASK-12', tool: 'handoff', status: 'success', detail: 'ok' });
+    repos.events.record({ taskId: null, tool: 'review_ready', status: 'error', detail: 'no task' });
+
+    expect(repos.events.list()).toHaveLength(3);
+    const forTask = repos.events.listByTask('TASK-12');
+    expect(forTask.map((e) => e.tool)).toEqual(['claim_work', 'handoff']);
+  });
+});


### PR DESCRIPTION
## PR 2b of the initial buildout (storage repositories)

Repositories on top of the storage foundation from #2. Completes the storage layer that the MCP tools (PR 3+) build on.

### What's here
- **`db/repositories/tasks.ts`** — `create` / `get` / `list` / `updateStatus` over the `tasks` table.
- **`db/repositories/handoffs.ts`** — `create` / `listByTask` / `latestForTask`.
- **`db/repositories/events.ts`** — `record` / `list` / `listByTask` (adoption + provenance log).
- **`db/index.ts`** — `createRepositories(db)` / `openRepositories(filename)` binders and public type re-exports.

All repositories are factory functions over prepared statements. Array fields are serialized to JSON TEXT columns and parsed back through the Zod row parsers — no typecasts.

### Tests
CRUD + array round-trip, insertion ordering, status update, latest/list handoffs, foreign-key rejection for unknown tasks, event listing by task. 6 tests (13 total across the storage layer), `:memory:`.

### Verification
`pnpm lint && pnpm typecheck && pnpm test && pnpm build` green locally.