### PR TITLE
feat(mcp): MCP server, stdio entry, and claim_work with overlap detection

### DIFF
--- a/src/domain/overlap.ts
+++ b/src/domain/overlap.ts
@@ -1,0 +1,95 @@
+import { dirname } from 'node:path';
+
+import type { TaskRecord } from '../db/index.js';
+
+/** The declared surface of a task, used to compare against other tasks. */
+export interface OverlapSurface {
+  taskId: string;
+  expectedFiles: readonly string[];
+  modules: readonly string[];
+  domains: readonly string[];
+  riskTags: readonly string[];
+}
+
+/** A flagged overlap between a candidate task and one existing task. */
+export interface OverlapWarning {
+  taskId: string;
+  title: string;
+  reasons: string[];
+}
+
+function sortedIntersection(a: readonly string[], b: readonly string[]): string[] {
+  const other = new Set(b);
+  const shared = new Set(a.filter((value) => other.has(value)));
+  return [...shared].sort((x, y) => x.localeCompare(y));
+}
+
+function directories(files: readonly string[]): string[] {
+  return files.map((file) => dirname(file)).filter((dir) => dir !== '.' && dir !== '');
+}
+
+function surfaceOf(task: TaskRecord): OverlapSurface {
+  return {
+    taskId: task.taskId,
+    expectedFiles: task.expectedFiles,
+    modules: task.modules,
+    domains: task.domains,
+    riskTags: task.riskTags,
+  };
+}
+
+function reasonsFor(candidate: OverlapSurface, existing: OverlapSurface): string[] {
+  const reasons: string[] = [];
+
+  const sameFiles = sortedIntersection(candidate.expectedFiles, existing.expectedFiles);
+  if (sameFiles.length > 0) {
+    reasons.push(`same file(s): ${sameFiles.join(', ')}`);
+  }
+
+  const sameDirs = sortedIntersection(
+    directories(candidate.expectedFiles),
+    directories(existing.expectedFiles),
+  );
+  if (sameDirs.length > 0 && sameFiles.length === 0) {
+    reasons.push(`same directory: ${sameDirs.join(', ')}`);
+  }
+
+  const sameModules = sortedIntersection(candidate.modules, existing.modules);
+  if (sameModules.length > 0) {
+    reasons.push(`shared module(s): ${sameModules.join(', ')}`);
+  }
+
+  const sameDomains = sortedIntersection(candidate.domains, existing.domains);
+  if (sameDomains.length > 0) {
+    reasons.push(`shared domain(s): ${sameDomains.join(', ')}`);
+  }
+
+  const sameRiskTags = sortedIntersection(candidate.riskTags, existing.riskTags);
+  if (sameRiskTags.length > 0) {
+    reasons.push(`shared risk tag(s): ${sameRiskTags.join(', ')}`);
+  }
+
+  return reasons;
+}
+
+/**
+ * Flag obvious overlaps between the candidate surface and existing tasks, based
+ * on declared files, directories, modules, domains, and risk tags. This is a
+ * deliberately naive v0: it does not perform semantic conflict detection.
+ */
+export function detectOverlaps(
+  candidate: OverlapSurface,
+  existing: readonly TaskRecord[],
+): OverlapWarning[] {
+  const warnings: OverlapWarning[] = [];
+  for (const task of existing) {
+    if (task.taskId === candidate.taskId) {
+      continue;
+    }
+    const reasons = reasonsFor(candidate, surfaceOf(task));
+    if (reasons.length > 0) {
+      warnings.push({ taskId: task.taskId, title: task.title, reasons });
+    }
+  }
+  return warnings;
+}

--- a/src/domain/schemas.ts
+++ b/src/domain/schemas.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+/**
+ * Zod input schemas for the MCP tools. Each tool exposes its schema as a raw
+ * shape (the form `McpServer.registerTool` expects) plus an inferred input type.
+ * Fields use snake_case to match the tool's public JSON contract.
+ */
+
+export const claimWorkInputShape = {
+  task_id: z.string().min(1).describe('Stable identifier for the task, e.g. TASK-12'),
+  title: z.string().min(1).describe('Short human-readable title'),
+  owner: z.string().optional().describe('Person accountable for the task'),
+  agent: z.string().optional().describe('Agent doing the work, e.g. claude-code'),
+  branch: z.string().optional().describe('Git branch, if known'),
+  worktree: z.string().optional().describe('Git worktree path, if used'),
+  expected_files: z.array(z.string()).optional().describe('Files the task expects to touch'),
+  modules: z.array(z.string()).optional().describe('Logical modules touched, e.g. billing'),
+  domains: z.array(z.string()).optional().describe('Product domains touched, e.g. payments'),
+  risk_tags: z.array(z.string()).optional().describe('Risk tags, e.g. payment-flow'),
+  notes: z.string().optional().describe('Freeform notes'),
+} as const;
+
+export const claimWorkInputSchema = z.object(claimWorkInputShape);
+export type ClaimWorkInput = z.infer<typeof claimWorkInputSchema>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,19 @@
 #!/usr/bin/env node
-/**
- * Entry point for the Concord MCP server (stdio transport).
- *
- * This is a scaffold placeholder. The MCP server and tool wiring land in a
- * later change (see the buildout plan, PR 3+).
- */
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
-function main(): void {
-  process.stdout.write('concord-mcp: server not yet implemented\n');
+import { databasePath, findRepoRoot } from './config/paths.js';
+import { openRepositories } from './db/index.js';
+import { createServer } from './server.js';
+
+async function main(): Promise<void> {
+  const repoRoot = findRepoRoot(process.cwd());
+  const repos = openRepositories(databasePath(repoRoot));
+  const server = createServer(repos);
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
 }
 
-main();
+main().catch((error: unknown) => {
+  process.stderr.write(`concord-mcp failed to start: ${String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,17 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import type { Repositories } from './db/index.js';
+import { registerClaimWork } from './tools/claim-work.js';
+
+/** Concord's advertised MCP server version. */
+export const SERVER_VERSION = '0.1.0';
+
+/**
+ * Build the Concord MCP server and register the v0 tools against the given
+ * repositories. Transport wiring lives in the entry points.
+ */
+export function createServer(repos: Repositories): McpServer {
+  const server = new McpServer({ name: 'concord-mcp', version: SERVER_VERSION });
+  registerClaimWork(server, repos);
+  return server;
+}

--- a/src/tools/claim-work.ts
+++ b/src/tools/claim-work.ts
@@ -1,0 +1,98 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import type { Repositories, TaskRecord } from '../db/index.js';
+import { detectOverlaps, type OverlapWarning } from '../domain/overlap.js';
+import { claimWorkInputShape, type ClaimWorkInput } from '../domain/schemas.js';
+
+export interface ClaimWorkResult {
+  task: TaskRecord;
+  alreadyClaimed: boolean;
+  overlaps: OverlapWarning[];
+}
+
+/**
+ * Record that an agent is working on a task and flag any overlaps with other
+ * active tasks. Idempotent: re-claiming an existing task returns it unchanged.
+ */
+export function handleClaimWork(repos: Repositories, input: ClaimWorkInput): ClaimWorkResult {
+  const activeOthers = repos.tasks
+    .list()
+    .filter((task) => task.taskId !== input.task_id && task.status === 'active');
+
+  const overlaps = detectOverlaps(
+    {
+      taskId: input.task_id,
+      expectedFiles: input.expected_files ?? [],
+      modules: input.modules ?? [],
+      domains: input.domains ?? [],
+      riskTags: input.risk_tags ?? [],
+    },
+    activeOthers,
+  );
+
+  const existing = repos.tasks.get(input.task_id);
+  const task =
+    existing ??
+    repos.tasks.create({
+      taskId: input.task_id,
+      title: input.title,
+      owner: input.owner ?? null,
+      agent: input.agent ?? null,
+      branch: input.branch ?? null,
+      worktree: input.worktree ?? null,
+      expectedFiles: input.expected_files ?? [],
+      modules: input.modules ?? [],
+      domains: input.domains ?? [],
+      riskTags: input.risk_tags ?? [],
+      notes: input.notes ?? null,
+    });
+
+  repos.events.record({
+    taskId: input.task_id,
+    tool: 'claim_work',
+    status: 'success',
+    detail: overlaps.length > 0 ? `${String(overlaps.length)} overlap(s)` : null,
+  });
+
+  return { task, alreadyClaimed: existing !== undefined, overlaps };
+}
+
+export function formatClaimWorkText(result: ClaimWorkResult): string {
+  const verb = result.alreadyClaimed ? 'Already claimed' : 'Claimed';
+  const lines = [`${verb} ${result.task.taskId} (${result.task.title}).`];
+
+  if (result.overlaps.length === 0) {
+    lines.push('No potential overlaps with active tasks.');
+    return lines.join('\n');
+  }
+
+  lines.push(`Potential overlaps (${String(result.overlaps.length)}):`);
+  for (const overlap of result.overlaps) {
+    lines.push(`  - ${overlap.taskId} (${overlap.title}): ${overlap.reasons.join('; ')}`);
+  }
+  return lines.join('\n');
+}
+
+export function registerClaimWork(server: McpServer, repos: Repositories): void {
+  server.registerTool(
+    'claim_work',
+    {
+      title: 'Claim work',
+      description:
+        'Record that an agent is starting a task and flag overlaps with other active tasks. ' +
+        'Call this before editing code.',
+      inputSchema: claimWorkInputShape,
+    },
+    (args) => {
+      const result = handleClaimWork(repos, args);
+      return {
+        content: [{ type: 'text', text: formatClaimWorkText(result) }],
+        structuredContent: {
+          task_id: result.task.taskId,
+          already_claimed: result.alreadyClaimed,
+          overlaps: result.overlaps,
+        },
+      };
+    },
+  );
+}

--- a/test/domain/overlap.test.ts
+++ b/test/domain/overlap.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import type { TaskRecord } from '../../src/db/index.js';
+import { detectOverlaps, type OverlapSurface } from '../../src/domain/overlap.js';
+
+function task(partial: Partial<TaskRecord> & { taskId: string }): TaskRecord {
+  return {
+    taskId: partial.taskId,
+    title: partial.title ?? partial.taskId,
+    owner: null,
+    agent: null,
+    branch: null,
+    worktree: null,
+    expectedFiles: partial.expectedFiles ?? [],
+    modules: partial.modules ?? [],
+    domains: partial.domains ?? [],
+    riskTags: partial.riskTags ?? [],
+    notes: null,
+    status: partial.status ?? 'active',
+    createdAt: '2026-07-17T00:00:00.000Z',
+    updatedAt: '2026-07-17T00:00:00.000Z',
+  };
+}
+
+const candidate: OverlapSurface = {
+  taskId: 'TASK-A',
+  expectedFiles: ['src/billing/retry.ts'],
+  modules: ['billing', 'stripe'],
+  domains: ['payments'],
+  riskTags: ['payment-flow'],
+};
+
+describe('detectOverlaps', () => {
+  it('flags a shared module and directory (the plan demo case)', () => {
+    const warnings = detectOverlaps(candidate, [
+      task({
+        taskId: 'TASK-B',
+        title: 'Invoices',
+        expectedFiles: ['src/billing/invoices.ts'],
+        modules: ['billing'],
+      }),
+    ]);
+    expect(warnings).toHaveLength(1);
+    const [warning] = warnings;
+    expect(warning?.taskId).toBe('TASK-B');
+    expect(warning?.reasons).toContain('shared module(s): billing');
+    expect(warning?.reasons).toContain('same directory: src/billing');
+  });
+
+  it('flags an exact same-file overlap and omits the directory reason', () => {
+    const warnings = detectOverlaps(candidate, [
+      task({ taskId: 'TASK-C', expectedFiles: ['src/billing/retry.ts'] }),
+    ]);
+    expect(warnings[0]?.reasons).toContain('same file(s): src/billing/retry.ts');
+    expect(warnings[0]?.reasons.some((r) => r.startsWith('same directory'))).toBe(false);
+  });
+
+  it('flags shared domains and risk tags', () => {
+    const warnings = detectOverlaps(candidate, [
+      task({ taskId: 'TASK-D', domains: ['payments'], riskTags: ['payment-flow'] }),
+    ]);
+    expect(warnings[0]?.reasons).toContain('shared domain(s): payments');
+    expect(warnings[0]?.reasons).toContain('shared risk tag(s): payment-flow');
+  });
+
+  it('returns nothing for disjoint tasks', () => {
+    expect(
+      detectOverlaps(candidate, [
+        task({ taskId: 'TASK-E', expectedFiles: ['src/signup/page.tsx'], modules: ['signup'] }),
+      ]),
+    ).toEqual([]);
+  });
+
+  it('never flags a task against itself', () => {
+    expect(detectOverlaps(candidate, [task({ taskId: 'TASK-A', modules: ['billing'] })])).toEqual(
+      [],
+    );
+  });
+});

--- a/test/tools/claim-work.test.ts
+++ b/test/tools/claim-work.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { openDatabase } from '../../src/db/connection.js';
+import { createRepositories, type Repositories } from '../../src/db/index.js';
+import { formatClaimWorkText, handleClaimWork } from '../../src/tools/claim-work.js';
+
+describe('handleClaimWork', () => {
+  let repos: Repositories;
+  beforeEach(() => {
+    repos = createRepositories(openDatabase(':memory:'));
+  });
+
+  it('creates a task, records an event, and reports no overlap on first claim', () => {
+    const result = handleClaimWork(repos, {
+      task_id: 'TASK-12',
+      title: 'Add Stripe retry handling',
+      modules: ['billing', 'stripe'],
+      expected_files: ['src/billing/retry.ts'],
+    });
+    expect(result.alreadyClaimed).toBe(false);
+    expect(result.overlaps).toEqual([]);
+    expect(repos.tasks.get('TASK-12')?.title).toBe('Add Stripe retry handling');
+    expect(repos.events.listByTask('TASK-12').map((e) => e.tool)).toEqual(['claim_work']);
+  });
+
+  it('flags an overlap when a second agent claims the same module', () => {
+    handleClaimWork(repos, { task_id: 'TASK-12', title: 'Retry', modules: ['billing'] });
+    const result = handleClaimWork(repos, {
+      task_id: 'TASK-14',
+      title: 'Invoices',
+      modules: ['billing'],
+    });
+    expect(result.overlaps).toHaveLength(1);
+    expect(result.overlaps[0]?.taskId).toBe('TASK-12');
+    expect(formatClaimWorkText(result)).toContain('Potential overlaps (1)');
+  });
+
+  it('is idempotent: re-claiming returns the existing task without duplicating', () => {
+    handleClaimWork(repos, { task_id: 'TASK-12', title: 'Retry', modules: ['billing'] });
+    const again = handleClaimWork(repos, {
+      task_id: 'TASK-12',
+      title: 'Retry again',
+      modules: ['billing'],
+    });
+    expect(again.alreadyClaimed).toBe(true);
+    expect(again.task.title).toBe('Retry');
+    expect(repos.tasks.list()).toHaveLength(1);
+  });
+
+  it('ignores non-active tasks when detecting overlaps', () => {
+    handleClaimWork(repos, { task_id: 'TASK-12', title: 'Retry', modules: ['billing'] });
+    repos.tasks.updateStatus('TASK-12', 'review_ready');
+    const result = handleClaimWork(repos, {
+      task_id: 'TASK-14',
+      title: 'Invoices',
+      modules: ['billing'],
+    });
+    expect(result.overlaps).toEqual([]);
+  });
+
+  it('formats a no-overlap claim clearly', () => {
+    const result = handleClaimWork(repos, { task_id: 'TASK-1', title: 'Solo' });
+    expect(formatClaimWorkText(result)).toContain('No potential overlaps');
+  });
+});


### PR DESCRIPTION
## PR 3 of the initial buildout (MCP core + claim_work)

Stands up the actual MCP server and the first of the three v0 tools. This is the heart of the demo: two agents claim overlapping work and Concord flags it **before either PR exists**.

### What's here
- **`domain/schemas.ts`** — Zod raw-shape input schema for `claim_work` (snake_case public contract).
- **`domain/overlap.ts`** — pure, naive v0 overlap detection over declared files, directories, modules, domains, and risk tags. No semantic analysis (honest about limits, per the plan).
- **`tools/claim-work.ts`** — idempotent handler (create-or-return), overlap reporting, event logging for adoption tracking, and `registerTool` wiring returning both human text and `structuredContent`.
- **`server.ts`** — `createServer(repos)` building the `McpServer` and registering tools.
- **`src/index.ts`** — stdio transport entry point (`bin: concord-mcp`), resolving `.concord/concord.db` from the repo root.

### Tests
Overlap detection (plan demo case + each category, self-exclusion), and handler behaviour (create, overlap flag, idempotent re-claim, non-active filtering, formatting). 14 new tests (27 total).

### End-to-end verification
Drove the built server over stdio with a real MCP client in a temp repo:
```
[A] claude-code claims TASK-12 → No potential overlaps with active tasks.
[B] codex claims TASK-14      → Potential overlaps (1):
      - TASK-12 (Add Stripe retry handling): same directory: src/billing; shared module(s): billing
```
`pnpm lint && pnpm typecheck && pnpm test && pnpm build` green locally.