### PR TITLE
feat(mcp): add handoff tool

### DIFF
--- a/src/domain/schemas.ts
+++ b/src/domain/schemas.ts
@@ -22,3 +22,20 @@ export const claimWorkInputShape = {
 
 export const claimWorkInputSchema = z.object(claimWorkInputShape);
 export type ClaimWorkInput = z.infer<typeof claimWorkInputSchema>;
+
+export const handoffInputShape = {
+  task_id: z.string().min(1).describe('The task being handed off, e.g. TASK-12'),
+  status: z.string().min(1).describe('Handoff status, e.g. done, blocked, in_progress'),
+  what_changed: z.string().min(1).describe('Concise summary of what changed'),
+  changed_files: z.array(z.string()).optional().describe('Files that changed'),
+  tests_run: z.array(z.string()).optional().describe('Test commands run'),
+  known_risks: z.array(z.string()).optional().describe('Known risks introduced'),
+  assumptions: z.array(z.string()).optional().describe('Assumptions the agent made'),
+  decisions: z.array(z.string()).optional().describe('Notable decisions and why'),
+  guardrails_checked: z.array(z.string()).optional().describe('Guardrails manually checked'),
+  needs_review_from: z.array(z.string()).optional().describe('Who should review'),
+  next_steps: z.array(z.string()).optional().describe('Remaining work or follow-ups'),
+} as const;
+
+export const handoffInputSchema = z.object(handoffInputShape);
+export type HandoffInput = z.infer<typeof handoffInputSchema>;

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import type { Repositories } from './db/index.js';
 import { registerClaimWork } from './tools/claim-work.js';
+import { registerHandoff } from './tools/handoff.js';
 
 /** Concord's advertised MCP server version. */
 export const SERVER_VERSION = '0.1.0';
@@ -13,5 +14,6 @@ export const SERVER_VERSION = '0.1.0';
 export function createServer(repos: Repositories): McpServer {
   const server = new McpServer({ name: 'concord-mcp', version: SERVER_VERSION });
   registerClaimWork(server, repos);
+  registerHandoff(server, repos);
   return server;
 }

--- a/src/tools/handoff.ts
+++ b/src/tools/handoff.ts
@@ -1,0 +1,95 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import type { HandoffRecord, Repositories } from '../db/index.js';
+import { handoffInputShape, type HandoffInput } from '../domain/schemas.js';
+
+export interface HandoffResult {
+  handoff: HandoffRecord;
+  taskAutoCreated: boolean;
+}
+
+/**
+ * Record a handoff for a task and mark the task handed off. If the task was
+ * never claimed, a minimal stub task is created so the handoff is never lost
+ * (the adoption tracker will still show that claim_work was skipped).
+ */
+export function handleHandoff(repos: Repositories, input: HandoffInput): HandoffResult {
+  const existing = repos.tasks.get(input.task_id);
+  const taskAutoCreated = existing === undefined;
+  if (existing === undefined) {
+    repos.tasks.create({
+      taskId: input.task_id,
+      title: input.task_id,
+      owner: null,
+      agent: null,
+      branch: null,
+      worktree: null,
+      expectedFiles: input.changed_files ?? [],
+      modules: [],
+      domains: [],
+      riskTags: [],
+      notes: null,
+    });
+  }
+
+  const handoff = repos.handoffs.create({
+    taskId: input.task_id,
+    status: input.status,
+    changedFiles: input.changed_files ?? [],
+    whatChanged: input.what_changed,
+    testsRun: input.tests_run ?? [],
+    knownRisks: input.known_risks ?? [],
+    assumptions: input.assumptions ?? [],
+    decisions: input.decisions ?? [],
+    guardrailsChecked: input.guardrails_checked ?? [],
+    needsReviewFrom: input.needs_review_from ?? [],
+    nextSteps: input.next_steps ?? [],
+  });
+
+  repos.tasks.updateStatus(input.task_id, 'handed_off');
+  repos.events.record({
+    taskId: input.task_id,
+    tool: 'handoff',
+    status: 'success',
+    detail: input.status,
+  });
+
+  return { handoff, taskAutoCreated };
+}
+
+export function formatHandoffText(result: HandoffResult): string {
+  const { handoff } = result;
+  const lines = [`Recorded handoff for ${handoff.taskId} (status: ${handoff.status}).`];
+  if (result.taskAutoCreated) {
+    lines.push('Note: task was not claimed first; created a stub task.');
+  }
+  lines.push(`Changed files: ${String(handoff.changedFiles.length)}`);
+  if (handoff.needsReviewFrom.length > 0) {
+    lines.push(`Needs review from: ${handoff.needsReviewFrom.join(', ')}`);
+  }
+  return lines.join('\n');
+}
+
+export function registerHandoff(server: McpServer, repos: Repositories): void {
+  server.registerTool(
+    'handoff',
+    {
+      title: 'Hand off work',
+      description:
+        'Record a concise handoff when an agent finishes or is blocked: what changed, ' +
+        'tests run, assumptions, decisions, and guardrails checked. Call this before finishing.',
+      inputSchema: handoffInputShape,
+    },
+    (args) => {
+      const result = handleHandoff(repos, args);
+      return {
+        content: [{ type: 'text', text: formatHandoffText(result) }],
+        structuredContent: {
+          task_id: result.handoff.taskId,
+          handoff_id: result.handoff.id,
+          task_auto_created: result.taskAutoCreated,
+        },
+      };
+    },
+  );
+}

--- a/test/tools/handoff.test.ts
+++ b/test/tools/handoff.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { openDatabase } from '../../src/db/connection.js';
+import { createRepositories, type Repositories } from '../../src/db/index.js';
+import { handleClaimWork } from '../../src/tools/claim-work.js';
+import { formatHandoffText, handleHandoff } from '../../src/tools/handoff.js';
+
+describe('handleHandoff', () => {
+  let repos: Repositories;
+  beforeEach(() => {
+    repos = createRepositories(openDatabase(':memory:'));
+  });
+
+  it('records a handoff for a claimed task and marks it handed off', () => {
+    handleClaimWork(repos, { task_id: 'TASK-12', title: 'Retry', modules: ['billing'] });
+    const result = handleHandoff(repos, {
+      task_id: 'TASK-12',
+      status: 'done',
+      what_changed: 'Queued retries instead of synchronous',
+      changed_files: ['src/billing/retry.ts'],
+      tests_run: ['pnpm test billing'],
+      needs_review_from: ['payments-team'],
+    });
+
+    expect(result.taskAutoCreated).toBe(false);
+    expect(result.handoff.whatChanged).toBe('Queued retries instead of synchronous');
+    expect(repos.tasks.get('TASK-12')?.status).toBe('handed_off');
+    expect(repos.handoffs.latestForTask('TASK-12')?.status).toBe('done');
+    expect(repos.events.listByTask('TASK-12').map((e) => e.tool)).toEqual([
+      'claim_work',
+      'handoff',
+    ]);
+  });
+
+  it('auto-creates a stub task when handing off an unclaimed task', () => {
+    const result = handleHandoff(repos, {
+      task_id: 'TASK-99',
+      status: 'blocked',
+      what_changed: 'Started but blocked on API keys',
+    });
+    expect(result.taskAutoCreated).toBe(true);
+    expect(repos.tasks.get('TASK-99')?.status).toBe('handed_off');
+    expect(formatHandoffText(result)).toContain('created a stub task');
+  });
+
+  it('formats needs-review recipients', () => {
+    const result = handleHandoff(repos, {
+      task_id: 'TASK-1',
+      status: 'done',
+      what_changed: 'x',
+      needs_review_from: ['alex', 'sam'],
+    });
+    expect(formatHandoffText(result)).toContain('Needs review from: alex, sam');
+  });
+});


### PR DESCRIPTION
## PR 4a of the initial buildout (handoff tool)

The second v0 tool. Records a structured handoff when an agent finishes or is blocked, using the existing handoffs repository.

### What's here
- **`domain/schemas.ts`** — Zod raw-shape input schema for `handoff` (status, what_changed, changed_files, tests_run, assumptions, decisions, guardrails_checked, needs_review_from, next_steps).
- **`tools/handoff.ts`** — records the handoff, marks the task `handed_off`, and logs an adoption event. If the task was never claimed, it auto-creates a stub task so the handoff is never lost (adoption tracker still reflects that `claim_work` was skipped).
- Registered in `server.ts`.

### Tests
Claimed-task handoff flow (status transition, event ordering `claim_work`→`handoff`), stub auto-creation for unclaimed tasks, and formatting. 3 new tests (30 total).

### Verification
`pnpm lint && pnpm typecheck && pnpm test && pnpm build` green locally.