### PR TITLE
feat(mcp): add review_ready tool and reviews storage

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,17 +1,21 @@
 import { openDatabase, type ConcordDatabase } from './connection.js';
 import { createEventRepository, type EventRepository } from './repositories/events.js';
 import { createHandoffRepository, type HandoffRepository } from './repositories/handoffs.js';
+import { createReviewRepository, type ReviewRepository } from './repositories/reviews.js';
 import { createTaskRepository, type TaskRepository } from './repositories/tasks.js';
 
 export type { ConcordDatabase } from './connection.js';
 export { openDatabase } from './connection.js';
 export type { NewTask, TaskRepository } from './repositories/tasks.js';
 export type { NewHandoff, HandoffRepository } from './repositories/handoffs.js';
+export type { NewReview, ReviewRepository } from './repositories/reviews.js';
 export type { NewEvent, EventRepository } from './repositories/events.js';
 export type {
   TaskRecord,
   TaskStatus,
   HandoffRecord,
+  ReviewRecord,
+  ProvenanceEntry,
   EventRecord,
   EventStatus,
   ToolName,
@@ -22,6 +26,7 @@ export interface Repositories {
   db: ConcordDatabase;
   tasks: TaskRepository;
   handoffs: HandoffRepository;
+  reviews: ReviewRepository;
   events: EventRepository;
 }
 
@@ -31,6 +36,7 @@ export function createRepositories(db: ConcordDatabase): Repositories {
     db,
     tasks: createTaskRepository(db),
     handoffs: createHandoffRepository(db),
+    reviews: createReviewRepository(db),
     events: createEventRepository(db),
   };
 }

--- a/src/db/repositories/reviews.ts
+++ b/src/db/repositories/reviews.ts
@@ -1,0 +1,81 @@
+import { z } from 'zod';
+
+import type { ConcordDatabase } from '../connection.js';
+import {
+  parseReviewRow,
+  serializeProvenance,
+  serializeStringArray,
+  type ProvenanceEntry,
+  type ReviewRecord,
+} from '../rows.js';
+
+/** Input for recording a review packet. Array fields default to `[]` at the caller. */
+export interface NewReview {
+  taskId: string;
+  planSummary: string;
+  testsRun: readonly string[];
+  diffSize: string | null;
+  guardrailsChecked: readonly string[];
+  assumptions: readonly string[];
+  openQuestions: readonly string[];
+  provenance: readonly ProvenanceEntry[];
+}
+
+export interface ReviewRepository {
+  create(review: NewReview): ReviewRecord;
+  listByTask(taskId: string): ReviewRecord[];
+  latestForTask(taskId: string): ReviewRecord | undefined;
+}
+
+const rawListSchema = z.array(z.unknown());
+
+export function createReviewRepository(db: ConcordDatabase): ReviewRepository {
+  const insertStmt = db.prepare(`
+    INSERT INTO reviews (
+      task_id, plan_summary, tests_run, diff_size, guardrails_checked,
+      assumptions, open_questions, provenance, created_at
+    ) VALUES (
+      @task_id, @plan_summary, @tests_run, @diff_size, @guardrails_checked,
+      @assumptions, @open_questions, @provenance, @created_at
+    )
+  `);
+  const getByIdStmt = db.prepare('SELECT * FROM reviews WHERE id = ?');
+  const listByTaskStmt = db.prepare(
+    'SELECT * FROM reviews WHERE task_id = ? ORDER BY created_at ASC, id ASC',
+  );
+  const latestStmt = db.prepare(
+    'SELECT * FROM reviews WHERE task_id = ? ORDER BY created_at DESC, id DESC LIMIT 1',
+  );
+
+  return {
+    create(review) {
+      const info = insertStmt.run({
+        task_id: review.taskId,
+        plan_summary: review.planSummary,
+        tests_run: serializeStringArray(review.testsRun),
+        diff_size: review.diffSize,
+        guardrails_checked: serializeStringArray(review.guardrailsChecked),
+        assumptions: serializeStringArray(review.assumptions),
+        open_questions: serializeStringArray(review.openQuestions),
+        provenance: serializeProvenance(review.provenance),
+        created_at: new Date().toISOString(),
+      });
+      const raw: unknown = getByIdStmt.get(info.lastInsertRowid);
+      if (raw === undefined) {
+        throw new Error(`Review ${String(info.lastInsertRowid)} could not be read back`);
+      }
+      return parseReviewRow(raw);
+    },
+    listByTask(taskId) {
+      const raw: unknown = listByTaskStmt.all(taskId);
+      return rawListSchema.parse(raw).map(parseReviewRow);
+    },
+    latestForTask(taskId) {
+      const raw: unknown = latestStmt.get(taskId);
+      if (raw === undefined) {
+        return undefined;
+      }
+      return parseReviewRow(raw);
+    },
+  };
+}

--- a/src/db/rows.ts
+++ b/src/db/rows.ts
@@ -32,6 +32,25 @@ export function serializeStringArray(values: readonly string[]): string {
   return JSON.stringify(values);
 }
 
+/** A single provenance entry: which field came from which source. */
+export interface ProvenanceEntry {
+  field: string;
+  source: string;
+}
+
+const provenanceSchema = z.array(z.object({ field: z.string(), source: z.string() }));
+
+/** Parse a JSON-encoded TEXT column into validated provenance entries. */
+export function parseProvenance(json: string): ProvenanceEntry[] {
+  const parsed: unknown = JSON.parse(json);
+  return provenanceSchema.parse(parsed);
+}
+
+/** Serialize provenance entries for storage in a TEXT column. */
+export function serializeProvenance(entries: readonly ProvenanceEntry[]): string {
+  return JSON.stringify(entries);
+}
+
 // --- tasks -----------------------------------------------------------------
 
 export interface TaskRecord {
@@ -137,6 +156,50 @@ export function parseHandoffRow(raw: unknown): HandoffRecord {
     guardrailsChecked: parseStringArray(row.guardrails_checked),
     needsReviewFrom: parseStringArray(row.needs_review_from),
     nextSteps: parseStringArray(row.next_steps),
+    createdAt: row.created_at,
+  };
+}
+
+// --- reviews ---------------------------------------------------------------
+
+export interface ReviewRecord {
+  id: number;
+  taskId: string;
+  planSummary: string;
+  testsRun: string[];
+  diffSize: string | null;
+  guardrailsChecked: string[];
+  assumptions: string[];
+  openQuestions: string[];
+  provenance: ProvenanceEntry[];
+  createdAt: string;
+}
+
+const reviewDbRowSchema = z.object({
+  id: z.number().int(),
+  task_id: z.string(),
+  plan_summary: z.string(),
+  tests_run: z.string(),
+  diff_size: z.string().nullable(),
+  guardrails_checked: z.string(),
+  assumptions: z.string(),
+  open_questions: z.string(),
+  provenance: z.string(),
+  created_at: z.string(),
+});
+
+export function parseReviewRow(raw: unknown): ReviewRecord {
+  const row = reviewDbRowSchema.parse(raw);
+  return {
+    id: row.id,
+    taskId: row.task_id,
+    planSummary: row.plan_summary,
+    testsRun: parseStringArray(row.tests_run),
+    diffSize: row.diff_size,
+    guardrailsChecked: parseStringArray(row.guardrails_checked),
+    assumptions: parseStringArray(row.assumptions),
+    openQuestions: parseStringArray(row.open_questions),
+    provenance: parseProvenance(row.provenance),
     createdAt: row.created_at,
   };
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -52,4 +52,21 @@ export const migrations: readonly string[] = [
 
   CREATE INDEX idx_events_task_id ON events(task_id);
   `,
+  // 002 — review packets produced by review_ready.
+  `
+  CREATE TABLE reviews (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id            TEXT NOT NULL REFERENCES tasks(task_id),
+    plan_summary       TEXT NOT NULL,
+    tests_run          TEXT NOT NULL DEFAULT '[]',
+    diff_size          TEXT,
+    guardrails_checked TEXT NOT NULL DEFAULT '[]',
+    assumptions        TEXT NOT NULL DEFAULT '[]',
+    open_questions     TEXT NOT NULL DEFAULT '[]',
+    provenance         TEXT NOT NULL DEFAULT '[]',
+    created_at         TEXT NOT NULL
+  );
+
+  CREATE INDEX idx_reviews_task_id ON reviews(task_id);
+  `,
 ];

--- a/src/domain/schemas.ts
+++ b/src/domain/schemas.ts
@@ -39,3 +39,20 @@ export const handoffInputShape = {
 
 export const handoffInputSchema = z.object(handoffInputShape);
 export type HandoffInput = z.infer<typeof handoffInputSchema>;
+
+export const reviewReadyInputShape = {
+  task_id: z.string().min(1).describe('The task being marked review-ready'),
+  plan_summary: z.string().min(1).describe('What the change intended to do'),
+  tests_run: z.array(z.string()).optional().describe('Test commands run'),
+  diff_size: z.string().optional().describe('Rough diff size, e.g. "+120 / -30"'),
+  guardrails_checked: z.array(z.string()).optional().describe('Guardrails checked'),
+  assumptions: z.array(z.string()).optional().describe('Assumptions made'),
+  open_questions: z.array(z.string()).optional().describe('Unresolved questions for review'),
+  provenance: z
+    .array(z.object({ field: z.string(), source: z.string() }))
+    .optional()
+    .describe('Where each claim came from, e.g. { field: "tests", source: "command output" }'),
+} as const;
+
+export const reviewReadyInputSchema = z.object(reviewReadyInputShape);
+export type ReviewReadyInput = z.infer<typeof reviewReadyInputSchema>;

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Repositories } from './db/index.js';
 import { registerClaimWork } from './tools/claim-work.js';
 import { registerHandoff } from './tools/handoff.js';
+import { registerReviewReady } from './tools/review-ready.js';
 
 /** Concord's advertised MCP server version. */
 export const SERVER_VERSION = '0.1.0';
@@ -15,5 +16,6 @@ export function createServer(repos: Repositories): McpServer {
   const server = new McpServer({ name: 'concord-mcp', version: SERVER_VERSION });
   registerClaimWork(server, repos);
   registerHandoff(server, repos);
+  registerReviewReady(server, repos);
   return server;
 }

--- a/src/tools/review-ready.ts
+++ b/src/tools/review-ready.ts
@@ -1,0 +1,95 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import type { ProvenanceEntry, Repositories, ReviewRecord } from '../db/index.js';
+import { reviewReadyInputShape, type ReviewReadyInput } from '../domain/schemas.js';
+
+export interface ReviewReadyResult {
+  review: ReviewRecord;
+  taskAutoCreated: boolean;
+}
+
+function toProvenance(entries: ReviewReadyInput['provenance']): ProvenanceEntry[] {
+  return (entries ?? []).map((entry) => ({ field: entry.field, source: entry.source }));
+}
+
+/**
+ * Record a review packet for a task and mark the task review-ready. Like
+ * handoff, this auto-creates a stub task if the work was never claimed.
+ */
+export function handleReviewReady(repos: Repositories, input: ReviewReadyInput): ReviewReadyResult {
+  const existing = repos.tasks.get(input.task_id);
+  const taskAutoCreated = existing === undefined;
+  if (existing === undefined) {
+    repos.tasks.create({
+      taskId: input.task_id,
+      title: input.task_id,
+      owner: null,
+      agent: null,
+      branch: null,
+      worktree: null,
+      expectedFiles: [],
+      modules: [],
+      domains: [],
+      riskTags: [],
+      notes: null,
+    });
+  }
+
+  const review = repos.reviews.create({
+    taskId: input.task_id,
+    planSummary: input.plan_summary,
+    testsRun: input.tests_run ?? [],
+    diffSize: input.diff_size ?? null,
+    guardrailsChecked: input.guardrails_checked ?? [],
+    assumptions: input.assumptions ?? [],
+    openQuestions: input.open_questions ?? [],
+    provenance: toProvenance(input.provenance),
+  });
+
+  repos.tasks.updateStatus(input.task_id, 'review_ready');
+  repos.events.record({
+    taskId: input.task_id,
+    tool: 'review_ready',
+    status: 'success',
+    detail: `${String(review.openQuestions.length)} open question(s)`,
+  });
+
+  return { review, taskAutoCreated };
+}
+
+export function formatReviewReadyText(result: ReviewReadyResult): string {
+  const { review } = result;
+  const lines = [`${review.taskId} is review-ready.`];
+  if (result.taskAutoCreated) {
+    lines.push('Note: task was not claimed first; created a stub task.');
+  }
+  lines.push(`Tests run: ${String(review.testsRun.length)}`);
+  lines.push(`Guardrails checked: ${String(review.guardrailsChecked.length)}`);
+  lines.push(`Open questions: ${String(review.openQuestions.length)}`);
+  return lines.join('\n');
+}
+
+export function registerReviewReady(server: McpServer, repos: Repositories): void {
+  server.registerTool(
+    'review_ready',
+    {
+      title: 'Mark review-ready',
+      description:
+        'Record review evidence before a PR: plan summary, tests run, diff size, guardrails ' +
+        'checked, assumptions, open questions, and provenance. Call this before opening a PR.',
+      inputSchema: reviewReadyInputShape,
+    },
+    (args) => {
+      const result = handleReviewReady(repos, args);
+      return {
+        content: [{ type: 'text', text: formatReviewReadyText(result) }],
+        structuredContent: {
+          task_id: result.review.taskId,
+          review_id: result.review.id,
+          open_questions: result.review.openQuestions.length,
+          task_auto_created: result.taskAutoCreated,
+        },
+      };
+    },
+  );
+}

--- a/test/db/connection.test.ts
+++ b/test/db/connection.test.ts
@@ -8,7 +8,7 @@ describe('openDatabase', () => {
   it('applies all migrations (user_version at head) and creates tables', () => {
     const db = openDatabase(':memory:');
     const version: unknown = db.pragma('user_version', { simple: true });
-    expect(version).toBe(1);
+    expect(version).toBe(2);
 
     const raw: unknown = db.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all();
     const names = new Set(
@@ -20,6 +20,7 @@ describe('openDatabase', () => {
     expect(names.has('tasks')).toBe(true);
     expect(names.has('handoffs')).toBe(true);
     expect(names.has('events')).toBe(true);
+    expect(names.has('reviews')).toBe(true);
   });
 });
 

--- a/test/db/storage.test.ts
+++ b/test/db/storage.test.ts
@@ -38,7 +38,7 @@ describe('migrations', () => {
   it('is idempotent when reopening (user_version already at head)', () => {
     const { db } = newRepos();
     const version: unknown = db.pragma('user_version', { simple: true });
-    expect(version).toBe(1);
+    expect(version).toBe(2);
   });
 });
 

--- a/test/tools/review-ready.test.ts
+++ b/test/tools/review-ready.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { openDatabase } from '../../src/db/connection.js';
+import { createRepositories, type Repositories } from '../../src/db/index.js';
+import { handleClaimWork } from '../../src/tools/claim-work.js';
+import { formatReviewReadyText, handleReviewReady } from '../../src/tools/review-ready.js';
+
+describe('handleReviewReady', () => {
+  let repos: Repositories;
+  beforeEach(() => {
+    repos = createRepositories(openDatabase(':memory:'));
+  });
+
+  it('records a review packet and marks the task review-ready', () => {
+    handleClaimWork(repos, { task_id: 'TASK-12', title: 'Retry', modules: ['billing'] });
+    const result = handleReviewReady(repos, {
+      task_id: 'TASK-12',
+      plan_summary: 'Queue retries instead of blocking checkout',
+      tests_run: ['pnpm test billing', 'pnpm test stripe'],
+      diff_size: '+120 / -30',
+      guardrails_checked: ['stripe payment test'],
+      open_questions: ['notify owner immediately or after final retry?'],
+      provenance: [
+        { field: 'tests', source: 'command output' },
+        { field: 'plan', source: 'agent reported' },
+      ],
+    });
+
+    expect(result.taskAutoCreated).toBe(false);
+    expect(result.review.testsRun).toHaveLength(2);
+    expect(result.review.provenance).toEqual([
+      { field: 'tests', source: 'command output' },
+      { field: 'plan', source: 'agent reported' },
+    ]);
+    expect(repos.tasks.get('TASK-12')?.status).toBe('review_ready');
+    expect(repos.reviews.latestForTask('TASK-12')?.diffSize).toBe('+120 / -30');
+    expect(repos.events.listByTask('TASK-12').map((e) => e.tool)).toEqual([
+      'claim_work',
+      'review_ready',
+    ]);
+  });
+
+  it('auto-creates a stub task when marking an unclaimed task review-ready', () => {
+    const result = handleReviewReady(repos, { task_id: 'TASK-77', plan_summary: 'Small fix' });
+    expect(result.taskAutoCreated).toBe(true);
+    expect(repos.tasks.get('TASK-77')?.status).toBe('review_ready');
+    expect(formatReviewReadyText(result)).toContain('review-ready');
+  });
+
+  it('defaults array and diff fields when omitted', () => {
+    const result = handleReviewReady(repos, { task_id: 'TASK-1', plan_summary: 'x' });
+    expect(result.review.testsRun).toEqual([]);
+    expect(result.review.provenance).toEqual([]);
+    expect(result.review.diffSize).toBeNull();
+  });
+});


### PR DESCRIPTION
## PR 4b of the initial buildout (review_ready tool)

The third and final v0 tool. Records review evidence before a PR and persists it as a review packet.

### What's here
- **`db/schema.ts`** — migration 002 creates the `reviews` table.
- **`db/rows.ts`** — `ReviewRecord` parser + structured provenance helpers (`{ field, source }`).
- **`db/repositories/reviews.ts`** — `create` / `listByTask` / `latestForTask`, wired into `Repositories`.
- **`domain/schemas.ts`** — `review_ready` input schema (plan_summary, tests_run, diff_size, guardrails_checked, assumptions, open_questions, provenance).
- **`tools/review-ready.ts`** — records the packet, marks the task `review_ready`, logs an adoption event (auto-creates a stub task if unclaimed).
- Registered in `server.ts`.

### Tests
Review flow (status transition, event ordering `claim_work`→`review_ready`), provenance round-trip, defaults for omitted fields, stub auto-create; migration-count assertions bumped to 2. 3 new tests (33 total).

### End-to-end verification
Drove all three tools over stdio in a temp repo — `listTools` returns `claim_work, handoff, review_ready`; claim→overlap→handoff→review_ready all produce correct output and persist. `pnpm lint && pnpm typecheck && pnpm test && pnpm build` green.