### PR TITLE
feat(examples): two-agent overlap demo (dogfood)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,6 @@
 // @ts-check
 import eslint from '@eslint/js';
+import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
@@ -45,8 +46,11 @@ export default tseslint.config(
     },
   },
   {
-    // Config files: no type-aware linting required.
+    // Config files and example scripts: no type-aware linting; Node globals.
     files: ['**/*.js', '**/*.mjs'],
     extends: [tseslint.configs.disableTypeChecked],
+    languageOptions: {
+      globals: globals.node,
+    },
   },
 );

--- a/examples/two-agent-overlap/README.md
+++ b/examples/two-agent-overlap/README.md
@@ -1,0 +1,38 @@
+# Two-agent overlap demo
+
+This is the canonical Concord demo. It shows two coding agents working in
+parallel: Concord flags that they touch the same module **before either PR
+exists**, then captures a structured handoff and a review packet.
+
+## Run it
+
+From the repository root:
+
+```bash
+pnpm demo
+```
+
+This builds the server and runs [`demo.mjs`](./demo.mjs), which drives the real
+Concord MCP server over stdio inside a throwaway repo (so it never touches this
+project's own `.concord/`).
+
+## What happens
+
+1. **claude-code** claims `TASK-12` (Stripe retry handling, module `billing`).
+2. **codex** claims `TASK-14` (invoice totals, module `billing`) — Concord flags
+   the overlap on `billing`.
+3. **claude-code** hands off `TASK-12` with what changed, tests run, and
+   decisions.
+4. **claude-code** marks `TASK-12` review-ready with plan, guardrails, open
+   questions, and provenance.
+
+The script then prints the generated `.concord/` artifacts, including the full
+`REVIEW_PACKET.md`.
+
+## Expected overlap output
+
+```text
+Claimed TASK-14 (Fix invoice totals).
+Potential overlaps (1):
+  - TASK-12 (Add Stripe retry handling): same directory: src/billing; shared module(s): billing
+```

--- a/examples/two-agent-overlap/demo.mjs
+++ b/examples/two-agent-overlap/demo.mjs
@@ -1,0 +1,101 @@
+// End-to-end demo: two agents claim overlapping work, then one hands off and
+// marks the task review-ready. Drives the real Concord MCP server over stdio
+// and prints the artifacts it produces. Run with `pnpm demo` (builds first).
+
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const serverEntry = join(here, '..', '..', 'dist', 'index.js');
+
+// Run in a throwaway repo so the demo never touches this project's own .concord/.
+const workdir = mkdtempSync(join(tmpdir(), 'concord-demo-'));
+mkdirSync(join(workdir, '.git'));
+
+const transport = new StdioClientTransport({
+  command: process.execPath,
+  args: [serverEntry],
+  cwd: workdir,
+});
+const client = new Client({ name: 'concord-demo', version: '0.0.0' });
+await client.connect(transport);
+
+function text(result) {
+  const first = result.content[0];
+  return first && first.type === 'text' ? first.text : '';
+}
+
+async function call(name, args) {
+  return text(await client.callTool({ name, arguments: args }));
+}
+
+console.log('# Concord — two-agent overlap demo\n');
+
+console.log('$ claude-code claims TASK-12');
+console.log(
+  await call('claim_work', {
+    task_id: 'TASK-12',
+    title: 'Add Stripe retry handling',
+    agent: 'claude-code',
+    branch: 'feat/billing-retry',
+    modules: ['billing', 'stripe'],
+    expected_files: ['src/billing/retry.ts'],
+  }),
+  '\n',
+);
+
+console.log('$ codex claims TASK-14 (also touches billing)');
+console.log(
+  await call('claim_work', {
+    task_id: 'TASK-14',
+    title: 'Fix invoice totals',
+    agent: 'codex',
+    modules: ['billing'],
+    expected_files: ['src/billing/invoices.ts'],
+  }),
+  '\n',
+);
+
+console.log('$ claude-code hands off TASK-12');
+console.log(
+  await call('handoff', {
+    task_id: 'TASK-12',
+    status: 'done',
+    what_changed: 'Queued retries instead of blocking checkout',
+    changed_files: ['src/billing/retry.ts'],
+    tests_run: ['pnpm test billing'],
+    decisions: ['Use a queued retry so user-path calls never block checkout'],
+    needs_review_from: ['payments-team'],
+  }),
+  '\n',
+);
+
+console.log('$ claude-code marks TASK-12 review-ready');
+console.log(
+  await call('review_ready', {
+    task_id: 'TASK-12',
+    plan_summary: 'Queue Stripe retries instead of blocking checkout',
+    tests_run: ['pnpm test billing'],
+    diff_size: '+120 / -30',
+    guardrails_checked: ['Stripe changes covered by an artificial payment test'],
+    open_questions: ['Notify the account owner immediately or only after the final retry?'],
+    provenance: [
+      { field: 'plan', source: 'agent reported' },
+      { field: 'tests', source: 'command output' },
+    ],
+  }),
+  '\n',
+);
+
+await client.close();
+
+const concord = join(workdir, '.concord');
+console.log(`Artifacts written to ${concord}:`);
+console.log('  ' + readdirSync(concord).join(', ') + '\n');
+console.log('----- REVIEW_PACKET.md -----');
+console.log(readFileSync(join(concord, 'REVIEW_PACKET.md'), 'utf8'));

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "demo": "pnpm build && node examples/two-agent-overlap/demo.mjs"
   },
   "dependencies": {
     "@commander-js/extra-typings": "^14.0.0",
@@ -49,6 +50,7 @@
     "@types/node": "^24.0.0",
     "@vitest/coverage-v8": "^4.1.0",
     "eslint": "^9.19.0",
+    "globals": "^17.7.0",
     "prettier": "^3.4.0",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.64.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       eslint:
         specifier: ^9.19.0
         version: 9.39.5
+      globals:
+        specifier: ^17.7.0
+        version: 17.7.0
       prettier:
         specifier: ^3.4.0
         version: 3.9.5
@@ -771,6 +774,10 @@ packages:
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  globals@17.7.0:
+    resolution: {integrity: sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==}
     engines: {node: '>=18'}
 
   gopd@1.2.0:
@@ -2208,6 +2215,8 @@ snapshots:
       is-glob: 4.0.3
 
   globals@14.0.0: {}
+
+  globals@17.7.0: {}
 
   gopd@1.2.0: {}
 


### PR DESCRIPTION
## PR 6 of the initial buildout (example repo + dogfood)

The canonical <60s demo, runnable with one command and used to dogfood the tools end-to-end.

### What's here
- **`examples/two-agent-overlap/demo.mjs`** — drives the real Concord MCP server over stdio inside a throwaway repo (never touches this project's `.concord/`): claude-code claims `TASK-12` → codex claims overlapping `TASK-14` (overlap flagged) → handoff → review_ready. Prints each tool's output and the generated `.concord/` artifacts including the full `REVIEW_PACKET.md`.
- **`pnpm demo`** builds then runs it.
- **`examples/two-agent-overlap/README.md`** documents the flow and expected overlap output.
- **ESLint**: `.js`/`.mjs` now get Node globals (adds `globals` dev dependency) so example/config scripts lint cleanly.

### Verification
`pnpm demo` produces:
```
$ codex claims TASK-14 (also touches billing)
Potential overlaps (1):
  - TASK-12 (Add Stripe retry handling): same directory: src/billing; shared module(s): billing
```
and writes `HANDOFF.md, REVIEW_PACKET.md, WORK_STATE.json, events.jsonl` + the DB. `pnpm lint && pnpm typecheck && pnpm test && pnpm build` green.