### PR TITLE
feat(cli): concord CLI with init, status, and tasks

### DIFF
--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -1,0 +1,21 @@
+import type { Command } from '@commander-js/extra-typings';
+
+import { writeArtifacts } from '../../artifacts/index.js';
+import { openContext } from '../context.js';
+
+/** Create the local `.concord/` workspace and return its path. */
+export function runInit(cwd: string): string {
+  const ctx = openContext(cwd);
+  writeArtifacts(ctx.concordPath, ctx.repos);
+  return ctx.concordPath;
+}
+
+export function registerInit(program: Command): void {
+  program
+    .command('init')
+    .description('Create the local .concord/ workspace')
+    .action(() => {
+      const path = runInit(process.cwd());
+      process.stdout.write(`Initialized Concord workspace at ${path}\n`);
+    });
+}

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -1,0 +1,158 @@
+import { dirname } from 'node:path';
+
+import type { Command } from '@commander-js/extra-typings';
+
+import type { Repositories, TaskRecord } from '../../db/index.js';
+import { detectOverlaps } from '../../domain/overlap.js';
+import { openContext } from '../context.js';
+
+interface ActiveEntry {
+  taskId: string;
+  agent: string;
+  branch: string;
+  touches: string;
+}
+
+interface OverlapPair {
+  a: string;
+  b: string;
+  reasons: string[];
+}
+
+interface ReviewEntry {
+  taskId: string;
+  testsCount: number;
+  guardrailsCount: number;
+  openQuestionCount: number;
+}
+
+interface OpenQuestionEntry {
+  taskId: string;
+  question: string;
+}
+
+export interface StatusView {
+  active: ActiveEntry[];
+  overlaps: OverlapPair[];
+  reviewReady: ReviewEntry[];
+  openQuestions: OpenQuestionEntry[];
+}
+
+function touchesOf(task: TaskRecord): string {
+  const values = task.modules.length > 0 ? task.modules : task.expectedFiles.map((f) => dirname(f));
+  const unique = [...new Set(values.filter((v) => v !== '.' && v !== ''))];
+  return unique.length > 0 ? unique.join(', ') : '-';
+}
+
+export function buildStatus(repos: Repositories): StatusView {
+  const tasks = repos.tasks.list();
+  const active = tasks.filter((task) => task.status === 'active');
+
+  const overlaps: OverlapPair[] = [];
+  const seenPairs = new Set<string>();
+  for (const task of active) {
+    for (const warning of detectOverlaps(
+      {
+        taskId: task.taskId,
+        expectedFiles: task.expectedFiles,
+        modules: task.modules,
+        domains: task.domains,
+        riskTags: task.riskTags,
+      },
+      active,
+    )) {
+      const key = [task.taskId, warning.taskId].sort((x, y) => x.localeCompare(y)).join('::');
+      if (!seenPairs.has(key)) {
+        seenPairs.add(key);
+        overlaps.push({ a: task.taskId, b: warning.taskId, reasons: warning.reasons });
+      }
+    }
+  }
+
+  const reviewReady: ReviewEntry[] = [];
+  const openQuestions: OpenQuestionEntry[] = [];
+  for (const task of tasks.filter((t) => t.status === 'review_ready')) {
+    const review = repos.reviews.latestForTask(task.taskId);
+    if (review === undefined) {
+      continue;
+    }
+    reviewReady.push({
+      taskId: task.taskId,
+      testsCount: review.testsRun.length,
+      guardrailsCount: review.guardrailsChecked.length,
+      openQuestionCount: review.openQuestions.length,
+    });
+    for (const question of review.openQuestions) {
+      openQuestions.push({ taskId: task.taskId, question });
+    }
+  }
+
+  return {
+    active: active.map((task) => ({
+      taskId: task.taskId,
+      agent: task.agent ?? '-',
+      branch: task.branch ?? '-',
+      touches: touchesOf(task),
+    })),
+    overlaps,
+    reviewReady,
+    openQuestions,
+  };
+}
+
+export function renderStatusText(view: StatusView): string {
+  const lines = ['Concord workspace', '', 'Active work'];
+  if (view.active.length === 0) {
+    lines.push('  none');
+  } else {
+    for (const entry of view.active) {
+      lines.push(
+        `  ${entry.taskId.padEnd(10)} ${entry.agent.padEnd(12)} ${entry.branch.padEnd(20)} touches: ${entry.touches}`,
+      );
+    }
+  }
+
+  lines.push('', 'Potential overlaps');
+  if (view.overlaps.length === 0) {
+    lines.push('  none');
+  } else {
+    for (const overlap of view.overlaps) {
+      lines.push(`  ${overlap.a} <-> ${overlap.b}: ${overlap.reasons.join('; ')}`);
+    }
+  }
+
+  lines.push('', 'Review ready');
+  if (view.reviewReady.length === 0) {
+    lines.push('  none');
+  } else {
+    for (const entry of view.reviewReady) {
+      lines.push(
+        `  ${entry.taskId.padEnd(10)} tests: ${String(entry.testsCount)}  guardrails: ${String(entry.guardrailsCount)}  open questions: ${String(entry.openQuestionCount)}`,
+      );
+    }
+  }
+
+  lines.push('', 'Open questions');
+  if (view.openQuestions.length === 0) {
+    lines.push('  none');
+  } else {
+    for (const entry of view.openQuestions) {
+      lines.push(`  ${entry.taskId}  "${entry.question}"`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export function runStatus(cwd: string): string {
+  return renderStatusText(buildStatus(openContext(cwd).repos));
+}
+
+export function registerStatus(program: Command): void {
+  program
+    .command('status')
+    .description('Show active work, overlaps, and review-ready tasks')
+    .action(() => {
+      process.stdout.write(`${runStatus(process.cwd())}\n`);
+    });
+}

--- a/src/cli/commands/tasks.ts
+++ b/src/cli/commands/tasks.ts
@@ -1,0 +1,32 @@
+import type { Command } from '@commander-js/extra-typings';
+
+import type { TaskRecord } from '../../db/index.js';
+import { openContext } from '../context.js';
+
+/** Render the full task list as a padded table (or a placeholder when empty). */
+export function renderTasks(tasks: readonly TaskRecord[]): string {
+  if (tasks.length === 0) {
+    return 'No tasks yet. Agents create tasks by calling claim_work.';
+  }
+  return tasks
+    .map((task) => {
+      const id = task.taskId.padEnd(10);
+      const status = task.status.padEnd(13);
+      const agent = (task.agent ?? '-').padEnd(12);
+      return `${id} ${status} ${agent} ${task.title}`;
+    })
+    .join('\n');
+}
+
+export function runTasks(cwd: string): string {
+  return renderTasks(openContext(cwd).repos.tasks.list());
+}
+
+export function registerTasks(program: Command): void {
+  program
+    .command('tasks')
+    .description('List all tasks Concord is tracking')
+    .action(() => {
+      process.stdout.write(`${runTasks(process.cwd())}\n`);
+    });
+}

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -1,0 +1,18 @@
+import { concordDir, databasePath, findRepoRoot } from '../config/paths.js';
+import { openRepositories, type Repositories } from '../db/index.js';
+
+export interface CliContext {
+  repoRoot: string;
+  concordPath: string;
+  repos: Repositories;
+}
+
+/** Resolve the repo root from `cwd` and open the Concord workspace there. */
+export function openContext(cwd: string): CliContext {
+  const repoRoot = findRepoRoot(cwd);
+  return {
+    repoRoot,
+    concordPath: concordDir(repoRoot),
+    repos: openRepositories(databasePath(repoRoot)),
+  };
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+import { Command } from '@commander-js/extra-typings';
+
+import { VERSION } from '../version.js';
+import { registerInit } from './commands/init.js';
+import { registerStatus } from './commands/status.js';
+import { registerTasks } from './commands/tasks.js';
+
+const program = new Command();
+program.name('concord').description('Shared work-state for coding agents').version(VERSION);
+
+registerInit(program);
+registerStatus(program);
+registerTasks(program);
+
+program.parse();

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,9 +4,10 @@ import type { Repositories } from './db/index.js';
 import { registerClaimWork } from './tools/claim-work.js';
 import { registerHandoff } from './tools/handoff.js';
 import { registerReviewReady } from './tools/review-ready.js';
+import { VERSION } from './version.js';
 
 /** Concord's advertised MCP server version. */
-export const SERVER_VERSION = '0.1.0';
+export const SERVER_VERSION = VERSION;
 
 export interface ServerOptions {
   /** Called after any tool writes to the database (used to regenerate artifacts). */

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,2 @@
+/** Single source of truth for the package version, shared by the CLI and server. */
+export const VERSION = '0.1.0';

--- a/test/cli/cli-core.test.ts
+++ b/test/cli/cli-core.test.ts
@@ -1,0 +1,97 @@
+import { existsSync, mkdirSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { openDatabase } from '../../src/db/connection.js';
+import { createRepositories, type Repositories } from '../../src/db/index.js';
+import { buildStatus, renderStatusText } from '../../src/cli/commands/status.js';
+import { renderTasks } from '../../src/cli/commands/tasks.js';
+import { runInit } from '../../src/cli/commands/init.js';
+import { handleClaimWork } from '../../src/tools/claim-work.js';
+import { handleReviewReady } from '../../src/tools/review-ready.js';
+
+function repoDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'concord-cli-'));
+  mkdirSync(join(dir, '.git'));
+  return dir;
+}
+
+describe('runInit', () => {
+  it('creates the .concord workspace with a database', () => {
+    const dir = repoDir();
+    const concordPath = runInit(dir);
+    expect(concordPath).toBe(join(dir, '.concord'));
+    expect(existsSync(join(concordPath, 'concord.db'))).toBe(true);
+    expect(existsSync(join(concordPath, 'WORK_STATE.json'))).toBe(true);
+  });
+});
+
+describe('renderTasks', () => {
+  it('shows a placeholder when there are no tasks', () => {
+    expect(renderTasks([])).toContain('No tasks yet');
+  });
+
+  it('renders a row per task', () => {
+    const repos = createRepositories(openDatabase(':memory:'));
+    handleClaimWork(repos, { task_id: 'TASK-12', title: 'Retry', agent: 'claude-code' });
+    const output = renderTasks(repos.tasks.list());
+    expect(output).toContain('TASK-12');
+    expect(output).toContain('claude-code');
+    expect(output).toContain('Retry');
+  });
+});
+
+describe('buildStatus / renderStatusText', () => {
+  let repos: Repositories;
+  beforeEach(() => {
+    repos = createRepositories(openDatabase(':memory:'));
+  });
+
+  it('reports none across all sections when empty', () => {
+    const text = renderStatusText(buildStatus(repos));
+    expect(text).toContain('Active work\n  none');
+    expect(text).toContain('Potential overlaps\n  none');
+  });
+
+  it('lists active work and overlaps between active tasks', () => {
+    handleClaimWork(repos, {
+      task_id: 'TASK-12',
+      title: 'Retry',
+      agent: 'claude-code',
+      branch: 'feat/retry',
+      modules: ['billing'],
+    });
+    handleClaimWork(repos, {
+      task_id: 'TASK-14',
+      title: 'Invoices',
+      agent: 'codex',
+      modules: ['billing'],
+    });
+
+    const view = buildStatus(repos);
+    expect(view.active).toHaveLength(2);
+    expect(view.overlaps).toHaveLength(1);
+
+    const text = renderStatusText(view);
+    expect(text).toContain('TASK-12');
+    expect(text).toContain('touches: billing');
+    expect(text).toContain('TASK-12 <-> TASK-14');
+  });
+
+  it('lists review-ready tasks and their open questions', () => {
+    handleClaimWork(repos, { task_id: 'TASK-9', title: 'Retry', modules: ['billing'] });
+    handleReviewReady(repos, {
+      task_id: 'TASK-9',
+      plan_summary: 'x',
+      tests_run: ['pnpm test'],
+      open_questions: ['Sync or queued retries?'],
+    });
+
+    const view = buildStatus(repos);
+    expect(view.reviewReady[0]?.openQuestionCount).toBe(1);
+    expect(view.active).toHaveLength(0);
+    expect(renderStatusText(view)).toContain('Sync or queued retries?');
+  });
+});


### PR DESCRIPTION
## PR 7 of the initial buildout (CLI core)

The human-facing `concord` CLI (agents use MCP tools; humans use the CLI). Built on commander + `@commander-js/extra-typings` for fully-typed handlers.

### Commands
- **`concord init`** — create the local `.concord/` workspace (DB + initial artifacts).
- **`concord status`** — active work, potential overlaps between active tasks, review-ready tasks, and open questions — matching the planned terminal layout.
- **`concord tasks`** — padded table of every tracked task.

### Design
- `cli/context.ts` resolves the repo root and opens the workspace.
- Status logic is a pure `buildStatus(repos)` → `StatusView`, rendered by a pure `renderStatusText` — both unit-tested independent of argv.
- `version.ts` is the single source of the version for CLI and server.

### Tests
`runInit` workspace creation, task table rendering, and status view/formatting (empty, active+overlap, review-ready+open-questions). 6 new tests (42 total).

### Verification
Built and ran the binary against a seeded DB:
```
Active work
  TASK-12    claude-code  feat/billing-retry   touches: billing, stripe
Potential overlaps
  TASK-12 <-> TASK-14: shared module(s): billing
Review ready
  TASK-09    tests: 1  guardrails: 1  open questions: 1
```
`pnpm lint && pnpm typecheck && pnpm test && pnpm build` green.