### PR TITLE
feat(cli): handoff, review-packet, export, and doctor commands

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1,0 +1,61 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { Command } from '@commander-js/extra-typings';
+import { z } from 'zod';
+
+import { migrations } from '../../db/schema.js';
+import { buildAdoption } from '../../domain/adoption.js';
+import { openContext, type CliContext } from '../context.js';
+
+function yesNo(value: boolean): string {
+  return value ? 'yes' : 'no ';
+}
+
+/** Produce a human-readable diagnostics report for the workspace. */
+export function buildDoctorReport(ctx: CliContext): string {
+  const dbPath = join(ctx.concordPath, 'concord.db');
+  const schemaVersion = z.number().parse(ctx.repos.db.pragma('user_version', { simple: true }));
+  const tasks = ctx.repos.tasks.list();
+  const events = ctx.repos.events.list();
+  const adoption = buildAdoption(events);
+
+  const lines = [
+    'Concord doctor',
+    '',
+    'Workspace',
+    `  .concord/    ${existsSync(ctx.concordPath) ? 'ok' : 'missing'}`,
+    `  concord.db   ${existsSync(dbPath) ? 'ok' : 'missing'} (schema v${String(schemaVersion)}, expected v${String(migrations.length)})`,
+    '',
+    'Activity',
+    `  tasks: ${String(tasks.length)}`,
+    `  events: ${String(events.length)}`,
+    '',
+    'Adoption',
+  ];
+
+  if (adoption.length === 0) {
+    lines.push('  none');
+  } else {
+    for (const entry of adoption) {
+      lines.push(
+        `  ${entry.taskId.padEnd(10)} claim_work: ${yesNo(entry.claimWork)}  handoff: ${yesNo(entry.handoff)}  review_ready: ${yesNo(entry.reviewReady)}`,
+      );
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export function runDoctor(cwd: string): string {
+  return buildDoctorReport(openContext(cwd));
+}
+
+export function registerDoctorCommand(program: Command): void {
+  program
+    .command('doctor')
+    .description('Check the workspace and report tool adoption')
+    .action(() => {
+      process.stdout.write(`${runDoctor(process.cwd())}\n`);
+    });
+}

--- a/src/cli/commands/export.ts
+++ b/src/cli/commands/export.ts
@@ -1,0 +1,34 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { Command } from '@commander-js/extra-typings';
+
+import { writeArtifacts } from '../../artifacts/index.js';
+import { openContext } from '../context.js';
+
+const ARTIFACT_FILES = ['HANDOFF.md', 'REVIEW_PACKET.md', 'WORK_STATE.json', 'events.jsonl'];
+
+/** Regenerate the markdown/JSON artifacts and return the files that now exist. */
+export function runExportMarkdown(cwd: string): string[] {
+  const ctx = openContext(cwd);
+  writeArtifacts(ctx.concordPath, ctx.repos);
+  return ARTIFACT_FILES.filter((file) => existsSync(join(ctx.concordPath, file)));
+}
+
+export function registerExportCommand(program: Command): void {
+  program
+    .command('export')
+    .argument('[format]', 'export format', 'markdown')
+    .description('Regenerate .concord/ artifacts from the database')
+    .action((format) => {
+      if (format !== 'markdown') {
+        process.stderr.write(
+          `Unsupported export format: ${format}. Only "markdown" is supported.\n`,
+        );
+        process.exitCode = 1;
+        return;
+      }
+      const written = runExportMarkdown(process.cwd());
+      process.stdout.write(`Wrote ${String(written.length)} artifact(s): ${written.join(', ')}\n`);
+    });
+}

--- a/src/cli/commands/handoff.ts
+++ b/src/cli/commands/handoff.ts
@@ -1,0 +1,28 @@
+import type { Command } from '@commander-js/extra-typings';
+
+import { renderHandoffMarkdown } from '../../artifacts/index.js';
+import { openContext } from '../context.js';
+
+/** Render the latest handoff for a task as markdown, or an explanatory message. */
+export function runHandoffPacket(cwd: string, taskId: string): string {
+  const ctx = openContext(cwd);
+  const task = ctx.repos.tasks.get(taskId);
+  if (task === undefined) {
+    return `No task ${taskId}.`;
+  }
+  const handoff = ctx.repos.handoffs.latestForTask(taskId);
+  if (handoff === undefined) {
+    return `No handoff recorded for ${taskId}. Ask the agent to call the handoff tool.`;
+  }
+  return renderHandoffMarkdown(task, handoff);
+}
+
+export function registerHandoffCommand(program: Command): void {
+  program
+    .command('handoff')
+    .argument('<taskId>', 'the task to show a handoff for')
+    .description('Print the latest handoff for a task')
+    .action((taskId) => {
+      process.stdout.write(`${runHandoffPacket(process.cwd(), taskId)}\n`);
+    });
+}

--- a/src/cli/commands/review-packet.ts
+++ b/src/cli/commands/review-packet.ts
@@ -1,0 +1,28 @@
+import type { Command } from '@commander-js/extra-typings';
+
+import { renderReviewPacketMarkdown } from '../../artifacts/index.js';
+import { openContext } from '../context.js';
+
+/** Render the latest review packet for a task as markdown, or a message. */
+export function runReviewPacket(cwd: string, taskId: string): string {
+  const ctx = openContext(cwd);
+  const task = ctx.repos.tasks.get(taskId);
+  if (task === undefined) {
+    return `No task ${taskId}.`;
+  }
+  const review = ctx.repos.reviews.latestForTask(taskId);
+  if (review === undefined) {
+    return `No review packet for ${taskId}. Ask the agent to call the review_ready tool.`;
+  }
+  return renderReviewPacketMarkdown(task, review, ctx.repos.handoffs.latestForTask(taskId));
+}
+
+export function registerReviewPacketCommand(program: Command): void {
+  program
+    .command('review-packet')
+    .argument('<taskId>', 'the task to show a review packet for')
+    .description('Print the latest review packet for a task')
+    .action((taskId) => {
+      process.stdout.write(`${runReviewPacket(process.cwd(), taskId)}\n`);
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,7 +2,11 @@
 import { Command } from '@commander-js/extra-typings';
 
 import { VERSION } from '../version.js';
+import { registerDoctorCommand } from './commands/doctor.js';
+import { registerExportCommand } from './commands/export.js';
+import { registerHandoffCommand } from './commands/handoff.js';
 import { registerInit } from './commands/init.js';
+import { registerReviewPacketCommand } from './commands/review-packet.js';
 import { registerStatus } from './commands/status.js';
 import { registerTasks } from './commands/tasks.js';
 
@@ -12,5 +16,9 @@ program.name('concord').description('Shared work-state for coding agents').versi
 registerInit(program);
 registerStatus(program);
 registerTasks(program);
+registerHandoffCommand(program);
+registerReviewPacketCommand(program);
+registerExportCommand(program);
+registerDoctorCommand(program);
 
 program.parse();

--- a/src/domain/adoption.ts
+++ b/src/domain/adoption.ts
@@ -1,0 +1,32 @@
+import type { EventRecord, ToolName } from '../db/index.js';
+
+/** Which of the three v0 tools have been called for a task. */
+export interface TaskAdoption {
+  taskId: string;
+  claimWork: boolean;
+  handoff: boolean;
+  reviewReady: boolean;
+}
+
+/**
+ * Summarize tool adoption per task from the event log. This makes skipped tools
+ * visible even on clients where the workflow cannot be enforced.
+ */
+export function buildAdoption(events: readonly EventRecord[]): TaskAdoption[] {
+  const byTask = new Map<string, Set<ToolName>>();
+  for (const event of events) {
+    if (event.taskId === null) {
+      continue;
+    }
+    const tools = byTask.get(event.taskId) ?? new Set<ToolName>();
+    tools.add(event.tool);
+    byTask.set(event.taskId, tools);
+  }
+
+  return [...byTask.entries()].map(([taskId, tools]) => ({
+    taskId,
+    claimWork: tools.has('claim_work'),
+    handoff: tools.has('handoff'),
+    reviewReady: tools.has('review_ready'),
+  }));
+}

--- a/test/cli/cli-commands.test.ts
+++ b/test/cli/cli-commands.test.ts
@@ -1,0 +1,80 @@
+import { existsSync, mkdirSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { openDatabase } from '../../src/db/connection.js';
+import { createRepositories } from '../../src/db/index.js';
+import { runDoctor } from '../../src/cli/commands/doctor.js';
+import { runExportMarkdown } from '../../src/cli/commands/export.js';
+import { runHandoffPacket } from '../../src/cli/commands/handoff.js';
+import { runReviewPacket } from '../../src/cli/commands/review-packet.js';
+import { buildAdoption } from '../../src/domain/adoption.js';
+import { openRepositories } from '../../src/db/index.js';
+import { handleClaimWork } from '../../src/tools/claim-work.js';
+import { handleHandoff } from '../../src/tools/handoff.js';
+import { handleReviewReady } from '../../src/tools/review-ready.js';
+
+function seededRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'concord-cli2-'));
+  mkdirSync(join(dir, '.git'));
+  const repos = openRepositories(join(dir, '.concord', 'concord.db'));
+  handleClaimWork(repos, { task_id: 'TASK-12', title: 'Add retry', agent: 'claude-code' });
+  handleHandoff(repos, { task_id: 'TASK-12', status: 'done', what_changed: 'Queued retries' });
+  handleReviewReady(repos, {
+    task_id: 'TASK-12',
+    plan_summary: 'Queue retries',
+    open_questions: ['Sync or queued?'],
+  });
+  return dir;
+}
+
+describe('buildAdoption', () => {
+  it('reports which tools were called per task', () => {
+    const repos = createRepositories(openDatabase(':memory:'));
+    handleClaimWork(repos, { task_id: 'TASK-1', title: 'A' });
+    handleClaimWork(repos, { task_id: 'TASK-2', title: 'B' });
+    handleHandoff(repos, { task_id: 'TASK-1', status: 'done', what_changed: 'x' });
+
+    const adoption = buildAdoption(repos.events.list());
+    const one = adoption.find((a) => a.taskId === 'TASK-1');
+    const two = adoption.find((a) => a.taskId === 'TASK-2');
+    expect(one).toEqual({ taskId: 'TASK-1', claimWork: true, handoff: true, reviewReady: false });
+    expect(two).toEqual({ taskId: 'TASK-2', claimWork: true, handoff: false, reviewReady: false });
+  });
+});
+
+describe('CLI read/export commands', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = seededRepo();
+  });
+
+  it('prints a handoff packet for a task', () => {
+    expect(runHandoffPacket(dir, 'TASK-12')).toContain('# Handoff: TASK-12 — Add retry');
+  });
+
+  it('explains when a handoff is missing', () => {
+    expect(runHandoffPacket(dir, 'TASK-NONE')).toContain('No task TASK-NONE');
+  });
+
+  it('prints a review packet for a task', () => {
+    const out = runReviewPacket(dir, 'TASK-12');
+    expect(out).toContain('# Review Packet: TASK-12');
+    expect(out).toContain('Sync or queued?');
+  });
+
+  it('exports all artifacts to disk', () => {
+    const written = runExportMarkdown(dir);
+    expect(written).toContain('REVIEW_PACKET.md');
+    expect(existsSync(join(dir, '.concord', 'REVIEW_PACKET.md'))).toBe(true);
+  });
+
+  it('doctor reports schema version and adoption', () => {
+    const report = runDoctor(dir);
+    expect(report).toContain('schema v2, expected v2');
+    expect(report).toContain('TASK-12');
+    expect(report).toContain('claim_work: yes');
+  });
+});


### PR DESCRIPTION
## PR 8 of the initial buildout (CLI, continued)

Completes the human-facing CLI.

### Commands
- **`concord handoff <taskId>`** — print the latest handoff as markdown.
- **`concord review-packet <taskId>`** — print the latest review packet as markdown.
- **`concord export [markdown]`** — regenerate `.concord/` artifacts from the DB and report what was written.
- **`concord doctor`** — workspace + schema-version checks and a per-task **adoption table** (which of `claim_work` / `handoff` / `review_ready` were called).

### Shared logic
- **`domain/adoption.ts`** — `buildAdoption(events)` summarizes tool adoption per task from the event log. Reused by `doctor` now and by `concord install` in the next PR.

### Tests
Adoption summary, packet printing (found + missing task), export-to-disk, and doctor output. 6 new tests (48 total).

### Verification
Ran the binary against a seeded workspace:
```
Adoption
  TASK-12    claim_work: yes  handoff: yes  review_ready: yes
  TASK-14    claim_work: yes  handoff: no   review_ready: no
```
`concord export markdown` → `Wrote 4 artifact(s): HANDOFF.md, REVIEW_PACKET.md, WORK_STATE.json, events.jsonl`. `pnpm lint && pnpm typecheck && pnpm test && pnpm build` green.