### PR TITLE
feat(cli): concord install for client instruction files

### DIFF
--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -1,0 +1,18 @@
+import type { Command } from '@commander-js/extra-typings';
+
+import { findRepoRoot } from '../../config/paths.js';
+import { installConcord } from '../../install/index.js';
+
+export function registerInstallCommand(program: Command): void {
+  program
+    .command('install')
+    .description('Write Concord usage instructions into supported client configs')
+    .action(() => {
+      const repoRoot = findRepoRoot(process.cwd());
+      const written = installConcord(repoRoot);
+      process.stdout.write(`Installed Concord instructions:\n`);
+      for (const relPath of written) {
+        process.stdout.write(`  ${relPath}\n`);
+      }
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,6 +6,7 @@ import { registerDoctorCommand } from './commands/doctor.js';
 import { registerExportCommand } from './commands/export.js';
 import { registerHandoffCommand } from './commands/handoff.js';
 import { registerInit } from './commands/init.js';
+import { registerInstallCommand } from './commands/install.js';
 import { registerReviewPacketCommand } from './commands/review-packet.js';
 import { registerStatus } from './commands/status.js';
 import { registerTasks } from './commands/tasks.js';
@@ -14,6 +15,7 @@ const program = new Command();
 program.name('concord').description('Shared work-state for coding agents').version(VERSION);
 
 registerInit(program);
+registerInstallCommand(program);
 registerStatus(program);
 registerTasks(program);
 registerHandoffCommand(program);

--- a/src/install/block.ts
+++ b/src/install/block.ts
@@ -1,0 +1,25 @@
+/** Markers delimiting Concord's managed block within a client instruction file. */
+export const BLOCK_START = '<!-- concord:start -->';
+export const BLOCK_END = '<!-- concord:end -->';
+
+/**
+ * Insert or replace Concord's managed block in `existing`, preserving all other
+ * content. Idempotent: running it again with the same block is a no-op.
+ */
+export function upsertBlock(existing: string, block: string): string {
+  const wrapped = `${BLOCK_START}\n${block}\n${BLOCK_END}`;
+
+  const startIdx = existing.indexOf(BLOCK_START);
+  const endIdx = existing.indexOf(BLOCK_END);
+  if (startIdx !== -1 && endIdx > startIdx) {
+    const before = existing.slice(0, startIdx);
+    const after = existing.slice(endIdx + BLOCK_END.length);
+    return `${before}${wrapped}${after}`;
+  }
+
+  if (existing.length === 0) {
+    return `${wrapped}\n`;
+  }
+  const separator = existing.endsWith('\n') ? '\n' : '\n\n';
+  return `${existing}${separator}${wrapped}\n`;
+}

--- a/src/install/index.ts
+++ b/src/install/index.ts
@@ -1,0 +1,37 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { upsertBlock } from './block.js';
+import { CONCORD_INSTRUCTIONS, CURSOR_MDC_HEADER } from './instructions.js';
+
+interface InstallTarget {
+  /** Path relative to the repo root. */
+  relPath: string;
+  /** Seed content used only when the file does not yet exist. */
+  header?: string;
+}
+
+const TARGETS: readonly InstallTarget[] = [
+  { relPath: 'CLAUDE.md' },
+  { relPath: 'AGENTS.md' },
+  { relPath: join('.codex', 'concord.md') },
+  { relPath: join('.cursor', 'rules', 'concord.mdc'), header: CURSOR_MDC_HEADER },
+];
+
+function writeTarget(repoRoot: string, target: InstallTarget): string {
+  const fullPath = join(repoRoot, target.relPath);
+  const existing = existsSync(fullPath) ? readFileSync(fullPath, 'utf8') : (target.header ?? '');
+  const updated = upsertBlock(existing, CONCORD_INSTRUCTIONS);
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, updated);
+  return target.relPath;
+}
+
+/**
+ * Write (or idempotently update) Concord's instructions into every supported
+ * client config, preserving any existing content. Returns the relative paths
+ * written.
+ */
+export function installConcord(repoRoot: string): string[] {
+  return TARGETS.map((target) => writeTarget(repoRoot, target));
+}

--- a/src/install/instructions.ts
+++ b/src/install/instructions.ts
@@ -1,0 +1,26 @@
+/** The canonical instruction block written into each client's config. */
+export const CONCORD_INSTRUCTIONS = `## Concord — shared work-state for coding agents
+
+This project uses Concord MCP. Use its tools so your work is visible before PRs:
+
+- **Before editing code**, call \`claim_work\` with the task id, title, and the
+  files/modules you expect to touch. Concord warns about overlaps with other
+  active work.
+- **Before finishing or when blocked**, call \`handoff\` with what changed, tests
+  run, assumptions, decisions, and guardrails you checked.
+- **Before opening a PR**, call \`review_ready\` with a plan summary, tests, open
+  questions, and provenance.
+
+Concord regenerates human-readable \`HANDOFF.md\` and \`REVIEW_PACKET.md\` in
+\`.concord/\` so humans can review your work.
+
+Enforcement note: on clients with hooks/command registration this can be
+enforced; elsewhere it is instruction-based and may be skipped. \`concord doctor\`
+shows per-task adoption either way.`;
+
+/** MDC frontmatter used when creating a fresh Cursor rules file. */
+export const CURSOR_MDC_HEADER = `---
+description: Concord shared work-state tools for coding agents
+alwaysApply: true
+---
+`;

--- a/test/install/install.test.ts
+++ b/test/install/install.test.ts
@@ -1,0 +1,64 @@
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { BLOCK_END, BLOCK_START, upsertBlock } from '../../src/install/block.js';
+import { installConcord } from '../../src/install/index.js';
+
+describe('upsertBlock', () => {
+  it('appends a wrapped block to existing content', () => {
+    const result = upsertBlock('# My rules\n', 'HELLO');
+    expect(result).toContain('# My rules');
+    expect(result).toContain(`${BLOCK_START}\nHELLO\n${BLOCK_END}`);
+  });
+
+  it('is idempotent: re-running replaces in place', () => {
+    const once = upsertBlock('# My rules\n', 'HELLO');
+    const twice = upsertBlock(once, 'HELLO');
+    expect(twice).toBe(once);
+  });
+
+  it('replaces block content without touching surrounding text', () => {
+    const withBlock = upsertBlock('top\n', 'OLD');
+    const updated = upsertBlock(`${withBlock}bottom\n`, 'NEW');
+    expect(updated).toContain('top');
+    expect(updated).toContain('bottom');
+    expect(updated).toContain('NEW');
+    expect(updated).not.toContain('OLD');
+  });
+});
+
+describe('installConcord', () => {
+  it('writes all four client targets', () => {
+    const root = mkdtempSync(join(tmpdir(), 'concord-install-'));
+    const written = installConcord(root);
+    expect(written).toEqual([
+      'CLAUDE.md',
+      'AGENTS.md',
+      join('.codex', 'concord.md'),
+      join('.cursor', 'rules', 'concord.mdc'),
+    ]);
+    for (const relPath of written) {
+      expect(existsSync(join(root, relPath))).toBe(true);
+    }
+    expect(readFileSync(join(root, 'CLAUDE.md'), 'utf8')).toContain('claim_work');
+    expect(readFileSync(join(root, '.cursor', 'rules', 'concord.mdc'), 'utf8')).toContain(
+      'alwaysApply: true',
+    );
+  });
+
+  it('preserves existing file content and is idempotent', () => {
+    const root = mkdtempSync(join(tmpdir(), 'concord-install-'));
+    writeFileSync(join(root, 'CLAUDE.md'), '# Existing project rules\n');
+    installConcord(root);
+    const first = readFileSync(join(root, 'CLAUDE.md'), 'utf8');
+    installConcord(root);
+    const second = readFileSync(join(root, 'CLAUDE.md'), 'utf8');
+
+    expect(first).toContain('# Existing project rules');
+    expect(first).toContain('claim_work');
+    expect(second).toBe(first);
+  });
+});


### PR DESCRIPTION
## PR 9 of the initial buildout (concord install)

`concord install` writes Concord's tool-usage instructions into supported client configs so agents know when to call the tools. (The adoption tracker that surfaces skipped tools already shipped in `concord doctor`.)

### What's here
- **`install/block.ts`** — idempotent, marker-delimited block upsert (`<!-- concord:start -->` … `<!-- concord:end -->`) that preserves any surrounding content.
- **`install/instructions.ts`** — the canonical block (when to call `claim_work` / `handoff` / `review_ready`) plus an honest enforcement note, and Cursor MDC frontmatter.
- **`install/index.ts`** — writes `CLAUDE.md`, `AGENTS.md`, `.codex/concord.md`, `.cursor/rules/concord.mdc`.
- **`concord install`** command.

### Honest enforcement
The block states plainly that enforcement is only guaranteed on clients with hooks/command registration; elsewhere it's instruction-based and `concord doctor` surfaces adoption regardless.

### Tests
Upsert append/replace/idempotency, all four targets written, existing content preserved, re-run is a no-op. 5 new tests (53 total).

### Verification
Ran `concord install` twice in a scratch dir — all four files written; CLAUDE.md contains exactly one Concord block after re-running (idempotent). `pnpm lint && pnpm typecheck && pnpm test && pnpm build` green.