### PR TITLE
docs: launch assets, client setup docs, and README polish

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Report something that isn't working
+title: 'bug: '
+labels: bug
+---
+
+## What happened
+
+A clear description of the bug.
+
+## Steps to reproduce
+
+1. ...
+2. ...
+
+## Expected behavior
+
+What you expected to happen.
+
+## Environment
+
+- Concord version: (`concord --version`)
+- Client: (Claude Code / Codex / Cursor / other)
+- OS + Node version:
+
+## Additional context
+
+`concord doctor` output, logs, or anything else that helps.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea or improvement
+title: 'feat: '
+labels: enhancement
+---
+
+## The problem
+
+What workflow is painful today? What are you doing manually?
+
+## Proposed solution
+
+What you'd like Concord to do.
+
+## Alternatives considered
+
+Other approaches you thought about.
+
+## Scope check
+
+Does this fit Concord's v0 wedge (shared work-state for coding agents), or is it
+better suited to the future hosted product? See the README.

--- a/.github/ISSUE_TEMPLATE/workflow_example.md
+++ b/.github/ISSUE_TEMPLATE/workflow_example.md
@@ -1,0 +1,23 @@
+---
+name: Workflow example
+about: Share how you use Concord with your agents
+title: 'example: '
+labels: workflow-example
+---
+
+## Your setup
+
+Which client(s) and agents? What kind of project?
+
+## How you use Concord
+
+What does your claim_work / handoff / review_ready flow look like?
+
+## What worked / what broke
+
+Where did the workflow help, and where did it get in the way?
+
+## Artifacts (optional)
+
+Paste a `REVIEW_PACKET.md` or `HANDOFF.md` Concord generated (redact anything
+sensitive).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,32 @@
+# Contributor Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and maintainers pledge to make participation in the
+Concord project a harassment-free experience for everyone, regardless of age,
+body size, disability, ethnicity, gender identity and expression, level of
+experience, nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Being respectful of differing viewpoints and experiences
+- Giving and gracefully accepting constructive feedback
+- Focusing on what is best for the community
+
+Examples of unacceptable behavior:
+
+- Harassment, insulting or derogatory comments, and personal attacks
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainers. All complaints will be reviewed and investigated
+promptly and fairly.
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Concord MCP
 
+[![CI](https://github.com/Get-Concord-AI/concord-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/Get-Concord-AI/concord-mcp/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+
 **Shared work-state for coding agents.** Concord MCP gives Claude Code, Codex,
 Cursor, and other MCP-capable coding assistants a shared work log. Agents can
 claim work, leave handoffs, and generate review-ready packets before opening PRs.
@@ -21,16 +24,26 @@ npm install -g concord-mcp
 concord install
 ```
 
-Then, in a supported assistant:
+`concord install` writes Concord's tool instructions into your client configs
+(`CLAUDE.md`, `AGENTS.md`, `.codex/`, `.cursor/rules/`). Then register the MCP
+server with your client and let your agent use the tools through MCP. Per-client
+setup:
 
-```text
-/concord start TASK-12
-```
+- [Claude Code](./docs/claude-code.md)
+- [Codex](./docs/codex.md)
+- [Cursor](./docs/cursor.md)
 
-> **Client note:** `/concord` is available only where `concord install` can
-> register a slash command or equivalent. On other MCP-capable clients, agents use
-> the same Concord tools through MCP plus the installed assistant instructions.
-> There is no universal slash command across every client.
+> There is no universal `/concord` slash command — commands are client-specific.
+> Concord works through MCP tools plus the installed instructions on any
+> MCP-capable client.
+
+## The three tools
+
+| Tool           | When                 | What it does                                                                     |
+| -------------- | -------------------- | -------------------------------------------------------------------------------- |
+| `claim_work`   | before editing       | records the task + expected files/modules; flags overlaps with other active work |
+| `handoff`      | when done or blocked | captures what changed, tests run, assumptions, decisions, guardrails             |
+| `review_ready` | before a PR          | records plan, tests, open questions, and provenance                              |
 
 ## What you get
 
@@ -45,24 +58,42 @@ artifacts you can commit so they show up in PRs:
 └── WORK_STATE.json     generated export (optional)
 ```
 
-## What this is
+## CLI
 
-Shared work-state and guardrails for the coding agents you already use.
+Agents use the MCP tools; humans use the CLI.
 
-## What this is not
+```bash
+concord init                 # create the .concord/ workspace
+concord status               # active work, overlaps, review-ready, open questions
+concord tasks                # list all tracked tasks
+concord handoff <task-id>    # print the latest handoff
+concord review-packet <id>   # print the latest review packet
+concord export markdown      # regenerate .concord/ artifacts
+concord doctor               # workspace checks + per-task tool adoption
+```
 
-Not an orchestrator, code reviewer, memory vector DB, or autonomous coding agent.
+## Try the demo
 
-## Why not just use markdown?
+```bash
+pnpm demo
+```
 
-Markdown handoff files are a good start. Concord makes them structured, queryable
-by agents, visible to humans, and harder to skip.
+Runs the [two-agent overlap demo](./examples/two-agent-overlap/): two agents claim
+overlapping work (Concord flags it), then one hands off and marks the task
+review-ready — printing the generated artifacts.
 
-## Development
+## What this is / is not
+
+Shared work-state and guardrails for the coding agents you already use. **Not** an
+orchestrator, code reviewer, memory vector DB, or autonomous coding agent.
+
+See also: [Why not just use markdown?](./docs/why-not-markdown.md)
+
+## Contributing
 
 See [`CONTRIBUTING.md`](./CONTRIBUTING.md) and [`CLAUDE.md`](./CLAUDE.md). This
 repo is strictly typed (no `any`, no typecasts), modular, and every PR stays under
-600 LOC.
+600 LOC. Good first issues are labelled [`good first issue`](https://github.com/Get-Concord-AI/concord-mcp/labels/good%20first%20issue).
 
 ## License
 

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -1,0 +1,49 @@
+# Using Concord with Claude Code
+
+## 1. Install
+
+```bash
+npm install -g concord-mcp
+```
+
+## 2. Register the MCP server
+
+Add Concord to your project's `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "concord": {
+      "command": "concord-mcp"
+    }
+  }
+}
+```
+
+Or use the Claude Code CLI:
+
+```bash
+claude mcp add concord -- concord-mcp
+```
+
+## 3. Install the agent instructions
+
+```bash
+concord install
+```
+
+This writes a Concord block into `CLAUDE.md` telling the agent when to call
+`claim_work`, `handoff`, and `review_ready`. It preserves any existing content
+and is safe to re-run.
+
+## 4. Use it
+
+Ask Claude to start a task. It should call `claim_work` before editing, then
+`handoff` and `review_ready` before opening a PR. Check progress with:
+
+```bash
+concord status
+concord doctor   # shows per-task tool adoption
+```
+
+Generated `HANDOFF.md` and `REVIEW_PACKET.md` land in `.concord/`.

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -1,0 +1,40 @@
+# Using Concord with Codex
+
+## 1. Install
+
+```bash
+npm install -g concord-mcp
+```
+
+## 2. Register the MCP server
+
+Add Concord to your Codex config (`~/.codex/config.toml`):
+
+```toml
+[mcp_servers.concord]
+command = "concord-mcp"
+```
+
+Refer to the current Codex MCP documentation if the config format has changed.
+
+## 3. Install the agent instructions
+
+```bash
+concord install
+```
+
+This writes a Concord block into `AGENTS.md` (and `.codex/concord.md`) describing
+when to call `claim_work`, `handoff`, and `review_ready`. It is idempotent.
+
+## 4. Use it
+
+Codex should call `claim_work` before editing and `handoff` / `review_ready`
+before a PR. Track it from your terminal:
+
+```bash
+concord status
+concord doctor
+```
+
+> Enforcement is instruction-based on clients without hooks — `concord doctor`
+> makes skipped tools visible regardless.

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -1,0 +1,40 @@
+# Using Concord with Cursor
+
+## 1. Install
+
+```bash
+npm install -g concord-mcp
+```
+
+## 2. Register the MCP server
+
+Add Concord to `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "concord": {
+      "command": "concord-mcp"
+    }
+  }
+}
+```
+
+## 3. Install the agent instructions
+
+```bash
+concord install
+```
+
+This writes `.cursor/rules/concord.mdc` (with `alwaysApply: true`) so the agent
+knows when to call `claim_work`, `handoff`, and `review_ready`. It is idempotent.
+
+## 4. Use it
+
+Track progress and artifacts from the terminal:
+
+```bash
+concord status
+concord doctor
+cat .concord/REVIEW_PACKET.md
+```

--- a/docs/why-not-markdown.md
+++ b/docs/why-not-markdown.md
@@ -1,0 +1,28 @@
+# Why not just use markdown?
+
+Lots of teams already hand-write `AGENTS.md`, handoff notes, and review checklists
+for their coding agents. That's a great instinct — Concord is what those files
+grow into.
+
+Markdown handoff files are:
+
+- **Unstructured** — every agent and person writes them differently, so nothing
+  can query or check them.
+- **Invisible until PR time** — a file in one agent's branch doesn't warn another
+  agent that they're about to touch the same module.
+- **Easy to skip** — with no record of whether they were written, there's no way
+  to tell adoption from good intentions.
+
+Concord keeps the good parts and fixes those gaps:
+
+- **Structured** — agents record work through `claim_work`, `handoff`, and
+  `review_ready`, so the data is consistent and queryable.
+- **Shared early** — `claim_work` flags overlaps between active tasks before
+  either PR exists.
+- **Visible to humans** — Concord still produces `HANDOFF.md` and
+  `REVIEW_PACKET.md` you can commit and read in a PR.
+- **Measurable** — `concord doctor` shows which tools each task actually used, so
+  skipping is visible.
+
+You keep writing markdown — Concord just makes it structured, queryable, and hard
+to skip.


### PR DESCRIPTION
## PR 10 of the initial buildout (launch assets)

Community health files, per-client setup docs, and a launch-ready README.

### What's here
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1.
- **Issue templates** — bug report, feature request, and workflow-example.
- **`docs/`** — setup guides for Claude Code, Codex, and Cursor, plus `why-not-markdown.md`.
- **README** — CI + license badges, a three-tools table, full CLI reference, `pnpm demo` pointer, per-client setup links, and a contributing section. Corrected the earlier `/concord` slash-command wording to the honest MCP-tools framing.

### Verification
`pnpm lint && pnpm typecheck && pnpm test && pnpm build` green; all markdown is prettier-clean.

---

This completes the initial 7-day buildout: the three MCP tools, SQLite storage, artifact rendering, the full CLI, `concord install`, the dogfood demo, and launch docs — shipped as 11 small PRs, each under 600 LOC with green CI.