### PR TITLE
chore: publish-ready as get-concord-mcp + OSS wiring

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## What & why
+
+Briefly describe the change and the problem it solves.
+
+## Checklist
+
+- [ ] Follows the coding rules in [`CLAUDE.md`](../CLAUDE.md) (no `any`, no
+      typecasts, layered modules)
+- [ ] Diff is under 600 LOC (split it if not)
+- [ ] Added/updated tests for behaviour changes
+- [ ] `pnpm lint && pnpm typecheck && pnpm test && pnpm build` passes locally
+- [ ] Checked for existing utilities/types before adding new ones
+
+## Notes for reviewers
+
+Anything that needs context, follow-ups, or open questions.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      dev-dependencies:
+        dependency-type: development
+      production-dependencies:
+        dependency-type: production
+
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write # required to create the GitHub Release
+  id-token: write # required for npm provenance
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: pnpm
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify
+        run: |
+          pnpm lint
+          pnpm format:check
+          pnpm typecheck
+          pnpm test
+          pnpm build
+
+      - name: Publish
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
+adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- MCP server with the three v0 tools: `claim_work` (with overlap detection),
+  `handoff`, and `review_ready`.
+- SQLite storage (source of truth) with migrations and typed repositories.
+- Rendered artifacts: `HANDOFF.md`, `REVIEW_PACKET.md`, `WORK_STATE.json`, and
+  `events.jsonl`, regenerated on every tool write.
+- `concord` CLI: `init`, `status`, `tasks`, `handoff`, `review-packet`,
+  `export`, `doctor`, and `install`.
+- `concord install` writes usage instructions for Claude Code, Codex, and Cursor.
+- Two-agent overlap demo (`pnpm demo`).
+
+[Unreleased]: https://github.com/Get-Concord-AI/concord-mcp/commits/main

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Concord MCP
 
+[![npm version](https://img.shields.io/npm/v/get-concord-mcp.svg)](https://www.npmjs.com/package/get-concord-mcp)
+[![npm downloads](https://img.shields.io/npm/dm/get-concord-mcp.svg)](https://www.npmjs.com/package/get-concord-mcp)
 [![CI](https://github.com/Get-Concord-AI/concord-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/Get-Concord-AI/concord-mcp/actions/workflows/ci.yml)
+[![Node.js](https://img.shields.io/node/v/get-concord-mcp.svg)](https://www.npmjs.com/package/get-concord-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
 
 **Shared work-state for coding agents.** Concord MCP gives Claude Code, Codex,
@@ -20,7 +23,7 @@ of that: a local place for agents to record what they are doing while they do it
 ## Install
 
 ```bash
-npm install -g concord-mcp
+npm install -g get-concord-mcp
 concord install
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Supported versions
+
+Concord is pre-1.0 and under active development. Security fixes are applied to the
+latest published version.
+
+## Reporting a vulnerability
+
+Please **do not** open a public issue for security vulnerabilities.
+
+Instead, report privately via GitHub's
+[private vulnerability reporting](https://github.com/Get-Concord-AI/concord-mcp/security/advisories/new)
+(Security → Report a vulnerability).
+
+Include steps to reproduce, affected versions, and impact. We aim to acknowledge
+reports within a few business days and will keep you updated on remediation.
+
+## Scope
+
+Concord is local-first: the open-source server stores data in a local SQLite
+database and does not transmit code, file paths, or task content anywhere. Please
+report anything that contradicts that behavior.

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -3,7 +3,7 @@
 ## 1. Install
 
 ```bash
-npm install -g concord-mcp
+npm install -g get-concord-mcp
 ```
 
 ## 2. Register the MCP server
@@ -14,7 +14,7 @@ Add Concord to your project's `.mcp.json`:
 {
   "mcpServers": {
     "concord": {
-      "command": "concord-mcp"
+      "command": "get-concord-mcp"
     }
   }
 }
@@ -23,7 +23,7 @@ Add Concord to your project's `.mcp.json`:
 Or use the Claude Code CLI:
 
 ```bash
-claude mcp add concord -- concord-mcp
+claude mcp add concord -- get-concord-mcp
 ```
 
 ## 3. Install the agent instructions

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -3,7 +3,7 @@
 ## 1. Install
 
 ```bash
-npm install -g concord-mcp
+npm install -g get-concord-mcp
 ```
 
 ## 2. Register the MCP server
@@ -12,7 +12,7 @@ Add Concord to your Codex config (`~/.codex/config.toml`):
 
 ```toml
 [mcp_servers.concord]
-command = "concord-mcp"
+command = "get-concord-mcp"
 ```
 
 Refer to the current Codex MCP documentation if the config format has changed.

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -3,7 +3,7 @@
 ## 1. Install
 
 ```bash
-npm install -g concord-mcp
+npm install -g get-concord-mcp
 ```
 
 ## 2. Register the MCP server
@@ -14,7 +14,7 @@ Add Concord to `.cursor/mcp.json`:
 {
   "mcpServers": {
     "concord": {
-      "command": "concord-mcp"
+      "command": "get-concord-mcp"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "concord-mcp",
+  "name": "get-concord-mcp",
   "version": "0.1.0",
   "description": "Shared work-state for coding agents: claim work, leave handoffs, and generate review packets before PRs, over MCP.",
   "keywords": [
@@ -14,13 +14,22 @@
     "agentic-coding"
   ],
   "license": "MIT",
+  "author": "Concord AI",
+  "homepage": "https://github.com/Get-Concord-AI/concord-mcp#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Get-Concord-AI/concord-mcp.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Get-Concord-AI/concord-mcp/issues"
+  },
   "type": "module",
   "engines": {
     "node": ">=20"
   },
   "packageManager": "pnpm@10.33.0",
   "bin": {
-    "concord-mcp": "dist/index.js",
+    "get-concord-mcp": "dist/index.js",
     "concord": "dist/cli/index.js"
   },
   "files": [
@@ -35,7 +44,8 @@
     "format:check": "prettier --check .",
     "test": "vitest run",
     "test:watch": "vitest",
-    "demo": "pnpm build && node examples/two-agent-overlap/demo.mjs"
+    "demo": "pnpm build && node examples/two-agent-overlap/demo.mjs",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@commander-js/extra-typings": "^14.0.0",


### PR DESCRIPTION
## Publish setup + OSS polish

`concord-mcp` is taken on npm (unrelated project), so this ships the package as **`get-concord-mcp`** (matches the `Get-Concord-AI` org) and wires the repo up as a proper OSS project.

### Package
- Rename to `get-concord-mcp`; bins: `concord` (human CLI) + `get-concord-mcp` (MCP server).
- Add `repository`, `homepage`, `bugs`, `author`, and a `prepublishOnly` build.
- Update install commands and MCP config snippets across README + `docs/`.

### Release automation
- `.github/workflows/release.yml` — on a `v*` tag: run the full gate, `npm publish --provenance --access public`, then create a GitHub Release with generated notes. Requires an `NPM_TOKEN` repo secret.

### OSS wiring
- README: npm version / downloads / Node badges (alongside CI + license).
- `CHANGELOG.md` (Keep a Changelog), `SECURITY.md` (private vuln reporting), PR template, and Dependabot (npm + actions, weekly).

### Verified
`npm pack --dry-run` → `get-concord-mcp@0.1.0`, 114 files, dist + README + LICENSE only. `pnpm lint && pnpm format:check && pnpm typecheck && pnpm test && pnpm build` green.

### Not done here (needs your action)
- Add the `NPM_TOKEN` secret before the first release.
- Publishing happens on tag push (`npm version 0.1.0 && git push --tags`) — no publish in this PR.