### PR TITLE
ci: publish via npm trusted publishing (OIDC), no token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,13 @@ on:
     tags:
       - 'v*'
 
+# Tokenless publishing via npm Trusted Publishing (OIDC). No NPM_TOKEN secret is
+# used; npm authenticates the workflow through GitHub's OIDC provider. Requires a
+# trusted publisher to be configured for the package on npmjs.com first (which in
+# turn requires one manual first publish — see RELEASING.md).
 permissions:
-  contents: write # required to create the GitHub Release
-  id-token: write # required for npm provenance
+  contents: write # create the GitHub Release
+  id-token: write # OIDC token for npm trusted publishing + provenance
 
 jobs:
   publish:
@@ -22,9 +26,13 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: pnpm
           registry-url: 'https://registry.npmjs.org'
+
+      # Trusted publishing needs npm >= 11.5.1.
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -37,10 +45,10 @@ jobs:
           pnpm test
           pnpm build
 
+      # Provenance is generated automatically under OIDC; no --provenance flag,
+      # no NODE_AUTH_TOKEN.
       - name: Publish
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,46 @@
+# Releasing
+
+`get-concord-mcp` is published to npm with **trusted publishing (OIDC)** — no
+long-lived `NPM_TOKEN` secret, and no 2FA one-time code in CI. Provenance is
+generated automatically.
+
+## One-time setup
+
+Trusted publishing can only be configured after a package exists, so the very
+first publish is done manually.
+
+1. **First publish (local, once):**
+
+   ```bash
+   pnpm lint && pnpm typecheck && pnpm test && pnpm build
+   npm publish --access public
+   ```
+
+   You'll be prompted for your npm 2FA code. This creates the package.
+
+2. **Configure the trusted publisher** on npmjs.com:
+   package → **Settings → Trusted Publisher → GitHub Actions** with:
+   - Organization/user: `Get-Concord-AI`
+   - Repository: `concord-mcp`
+   - Workflow filename: `release.yml`
+
+## Every release after that
+
+No token, no manual publish:
+
+```bash
+# bump the version (updates package.json and creates a commit + tag)
+npm version patch   # or minor / major
+git push --follow-tags
+```
+
+Pushing the `v*` tag triggers [`.github/workflows/release.yml`](./.github/workflows/release.yml),
+which runs the full verification gate, publishes to npm via OIDC (with automatic
+provenance), and creates a GitHub Release with generated notes.
+
+## Notes
+
+- Keep [`CHANGELOG.md`](./CHANGELOG.md) up to date under `[Unreleased]`; move
+  entries under the new version when you release.
+- Requirements handled by the workflow: Node 24, npm >= 11.5.1, and
+  `id-token: write` permission.


### PR DESCRIPTION
## Tokenless publishing (OIDC)

Answers the "how does the npm token work with 2FA in CI?" question by removing the token entirely.

### Why
- Legacy npm automation tokens were removed (Nov 2025); only granular tokens remain, and they'd need "Bypass 2FA" enabled — a long-lived secret that defeats 2FA.
- **Trusted publishing (OIDC)** (GA July 2025) needs no `NPM_TOKEN`, is unaffected by account 2FA, and generates provenance automatically.

### Changes
- `release.yml`: OIDC trusted publishing — no `NODE_AUTH_TOKEN`/`NPM_TOKEN`, no `--provenance` flag (automatic). Node 24 + `npm@latest` (trusted publishing requires npm >= 11.5.1). Keeps `id-token: write` and the GitHub Release step.
- `RELEASING.md`: documents the one-time manual first publish (required before a trusted publisher can be configured), the npmjs.com trusted-publisher setup, and the tag-based release flow thereafter.

### Follow-up (your action)
1. First publish locally once: `npm publish --access public` (enter 2FA OTP) to create `get-concord-mcp`.
2. Configure the trusted publisher on npmjs.com (org `Get-Concord-AI`, repo `concord-mcp`, workflow `release.yml`).
3. Thereafter: `npm version <bump> && git push --follow-tags` → CI publishes tokenless.

`pnpm lint && pnpm format:check && pnpm test` green.

Sources: [npm trusted publishers docs](https://docs.npmjs.com/trusted-publishers/), [GitHub Changelog: OIDC GA](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/).