### PR TITLE
chore: scope package to @concord-ai org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ jobs:
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
+    # Scopes the OIDC token to this environment; add protection rules (required
+    # reviewers, tag restrictions) on the `release` environment to gate publishes.
+    environment: release
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Concord MCP
 
-[![npm version](https://img.shields.io/npm/v/get-concord-mcp.svg)](https://www.npmjs.com/package/get-concord-mcp)
-[![npm downloads](https://img.shields.io/npm/dm/get-concord-mcp.svg)](https://www.npmjs.com/package/get-concord-mcp)
+[![npm version](https://img.shields.io/npm/v/@concord-ai/concord-mcp.svg)](https://www.npmjs.com/package/@concord-ai/concord-mcp)
+[![npm downloads](https://img.shields.io/npm/dm/@concord-ai/concord-mcp.svg)](https://www.npmjs.com/package/@concord-ai/concord-mcp)
 [![CI](https://github.com/Get-Concord-AI/concord-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/Get-Concord-AI/concord-mcp/actions/workflows/ci.yml)
-[![Node.js](https://img.shields.io/node/v/get-concord-mcp.svg)](https://www.npmjs.com/package/get-concord-mcp)
+[![Node.js](https://img.shields.io/node/v/@concord-ai/concord-mcp.svg)](https://www.npmjs.com/package/@concord-ai/concord-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
 
 **Shared work-state for coding agents.** Concord MCP gives Claude Code, Codex,
@@ -23,7 +23,7 @@ of that: a local place for agents to record what they are doing while they do it
 ## Install
 
 ```bash
-npm install -g get-concord-mcp
+npm install -g @concord-ai/concord-mcp
 concord install
 ```
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,28 +1,38 @@
 # Releasing
 
-`get-concord-mcp` is published to npm with **trusted publishing (OIDC)** — no
-long-lived `NPM_TOKEN` secret, and no 2FA one-time code in CI. Provenance is
+`@concord-ai/concord-mcp` is published to npm with **trusted publishing (OIDC)** —
+no long-lived `NPM_TOKEN` secret, and no 2FA one-time code in CI. Provenance is
 generated automatically.
+
+Publishing runs inside the `release` GitHub Actions environment, so npm only
+accepts the publish from an approved, environment-scoped workflow run.
 
 ## One-time setup
 
 Trusted publishing can only be configured after a package exists, so the very
-first publish is done manually.
+first publish of the scoped package is done manually by an org member with publish
+rights.
 
-1. **First publish (local, once):**
+1. **First publish (local, once)** — from an account in the `concord-ai` npm org:
 
    ```bash
    pnpm lint && pnpm typecheck && pnpm test && pnpm build
    npm publish --access public
    ```
 
-   You'll be prompted for your npm 2FA code. This creates the package.
+   You'll be prompted for your npm 2FA code. This creates
+   `@concord-ai/concord-mcp` under the org.
 
-2. **Configure the trusted publisher** on npmjs.com:
+2. **Create the `release` GitHub environment** (repo → Settings → Environments):
+   optionally add protection rules (required reviewers, restrict to `v*` tags) so
+   a publish must be approved.
+
+3. **Configure the trusted publisher** on npmjs.com:
    package → **Settings → Trusted Publisher → GitHub Actions** with:
    - Organization/user: `Get-Concord-AI`
    - Repository: `concord-mcp`
    - Workflow filename: `release.yml`
+   - Environment name: `release`
 
 ## Every release after that
 
@@ -36,7 +46,8 @@ git push --follow-tags
 
 Pushing the `v*` tag triggers [`.github/workflows/release.yml`](./.github/workflows/release.yml),
 which runs the full verification gate, publishes to npm via OIDC (with automatic
-provenance), and creates a GitHub Release with generated notes.
+provenance), and creates a GitHub Release with generated notes. If the `release`
+environment has required reviewers, the run pauses for approval first.
 
 ## Notes
 

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -3,7 +3,7 @@
 ## 1. Install
 
 ```bash
-npm install -g get-concord-mcp
+npm install -g @concord-ai/concord-mcp
 ```
 
 ## 2. Register the MCP server
@@ -14,7 +14,7 @@ Add Concord to your project's `.mcp.json`:
 {
   "mcpServers": {
     "concord": {
-      "command": "get-concord-mcp"
+      "command": "concord-mcp"
     }
   }
 }
@@ -23,7 +23,7 @@ Add Concord to your project's `.mcp.json`:
 Or use the Claude Code CLI:
 
 ```bash
-claude mcp add concord -- get-concord-mcp
+claude mcp add concord -- concord-mcp
 ```
 
 ## 3. Install the agent instructions

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -3,7 +3,7 @@
 ## 1. Install
 
 ```bash
-npm install -g get-concord-mcp
+npm install -g @concord-ai/concord-mcp
 ```
 
 ## 2. Register the MCP server
@@ -12,7 +12,7 @@ Add Concord to your Codex config (`~/.codex/config.toml`):
 
 ```toml
 [mcp_servers.concord]
-command = "get-concord-mcp"
+command = "concord-mcp"
 ```
 
 Refer to the current Codex MCP documentation if the config format has changed.

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -3,7 +3,7 @@
 ## 1. Install
 
 ```bash
-npm install -g get-concord-mcp
+npm install -g @concord-ai/concord-mcp
 ```
 
 ## 2. Register the MCP server
@@ -14,7 +14,7 @@ Add Concord to `.cursor/mcp.json`:
 {
   "mcpServers": {
     "concord": {
-      "command": "get-concord-mcp"
+      "command": "concord-mcp"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "get-concord-mcp",
+  "name": "@concord-ai/concord-mcp",
   "version": "0.1.0",
   "description": "Shared work-state for coding agents: claim work, leave handoffs, and generate review packets before PRs, over MCP.",
   "keywords": [
@@ -29,8 +29,11 @@
   },
   "packageManager": "pnpm@10.33.0",
   "bin": {
-    "get-concord-mcp": "dist/index.js",
+    "concord-mcp": "dist/index.js",
     "concord": "dist/cli/index.js"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Publish under the org, not a personal account

`get-concord-mcp@0.1.0` ended up under the personal `alexechoi` account. This scopes the package to the **`concord-ai` npm org**.

### Changes
- Package renamed `get-concord-mcp` → **`@concord-ai/concord-mcp`**. Scoping removes the `concord-mcp` name collision, so the `get-` prefix is dropped and the server bin is `concord-mcp` again (`concord` stays the CLI bin).
- `publishConfig.access: public` (scoped packages default to private).
- Install commands, MCP config snippets, and npm badges updated to the scoped name.
- Release workflow now runs in the `release` GitHub environment; `RELEASING.md` documents the environment + trusted-publisher setup under the org.

### Verified
`npm pack --dry-run` → `@concord-ai/concord-mcp@0.1.0`, bins `concord-mcp` + `concord`. `pnpm lint && pnpm format:check && pnpm typecheck && pnpm test && pnpm build` green.

### Your follow-up (npm-side, needs org publish rights)
1. First scoped publish from an org member: `npm publish --access public`.
2. Create the `release` GitHub environment (Settings → Environments).
3. Configure the trusted publisher on the new package (org `Get-Concord-AI`, repo `concord-mcp`, workflow `release.yml`, environment `release`).
4. Deprecate the old personal package: `npm deprecate get-concord-mcp "moved to @concord-ai/concord-mcp"`.