### PR TITLE
fix(ci): drop GitHub environment from release workflow (OIDC 404)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ on:
 # used; npm authenticates the workflow through GitHub's OIDC provider. Requires a
 # trusted publisher to be configured for the package on npmjs.com first (which in
 # turn requires one manual first publish — see RELEASING.md).
+#
+# No `environment:` is set: the trusted-publisher config on npm must then leave
+# its Environment field blank. To gate publishing behind maintainer approval,
+# add `environment: <name>` here AND set the same name (exact case) on npm.
 permissions:
   contents: write # create the GitHub Release
   id-token: write # OIDC token for npm trusted publishing + provenance
@@ -17,9 +21,6 @@ jobs:
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
-    # Scopes the OIDC token to this environment; add protection rules (required
-    # reviewers, tag restrictions) on the `release` environment to gate publishes.
-    environment: release
     steps:
       - uses: actions/checkout@v4
 
@@ -29,13 +30,15 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '24.x'
+          node-version: '24'
           cache: pnpm
           registry-url: 'https://registry.npmjs.org'
 
       # Trusted publishing needs npm >= 11.5.1.
       - name: Update npm
-        run: npm install -g npm@latest
+        run: |
+          npm install -g npm@latest
+          npm --version
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,8 +4,8 @@
 no long-lived `NPM_TOKEN` secret, and no 2FA one-time code in CI. Provenance is
 generated automatically.
 
-Publishing runs inside the `release` GitHub Actions environment, so npm only
-accepts the publish from an approved, environment-scoped workflow run.
+By default the release workflow uses no GitHub environment (see the optional
+gating section below to add maintainer approval).
 
 ## One-time setup
 
@@ -23,16 +23,26 @@ rights.
    You'll be prompted for your npm 2FA code. This creates
    `@concord-ai/concord-mcp` under the org.
 
-2. **Create the `release` GitHub environment** (repo → Settings → Environments):
-   optionally add protection rules (required reviewers, restrict to `v*` tags) so
-   a publish must be approved.
-
-3. **Configure the trusted publisher** on npmjs.com:
+2. **Configure the trusted publisher** on npmjs.com:
    package → **Settings → Trusted Publisher → GitHub Actions** with:
    - Organization/user: `Get-Concord-AI`
    - Repository: `concord-mcp`
    - Workflow filename: `release.yml`
-   - Environment name: `release`
+   - Environment: **leave blank** (the workflow sets no environment)
+
+   The Environment field must match the workflow exactly. Since `release.yml`
+   sets no `environment:`, this field must be empty or npm will reject the OIDC
+   token and the publish falls back to (missing) token auth — a `404` on publish.
+
+### Optional: gate publishing behind approval
+
+To require a maintainer to approve each publish (so people with repo access still
+can't publish unilaterally), add it on **both** sides with the same name:
+
+1. Create the environment (repo → Settings → Environments, e.g. `Release`) with
+   required reviewers.
+2. Add `environment: Release` to the `publish` job in `release.yml`.
+3. Set the same **Environment** name on the npm trusted publisher.
 
 ## Every release after that
 


### PR DESCRIPTION
## Fix the failed release publish (E404)

The `v0.1.1` release run failed: `npm error 404 Not Found - PUT @concord-ai/concord-mcp`. npm attempted OIDC trusted publishing, the registry rejected the trust claim, and it fell back to an empty token → 404.

### Root cause
Environment mismatch. The workflow set `environment: release`, the GitHub environment is actually `Release` (0 protection rules), and the npm trusted-publisher Environment field is a third value. When any of these disagree, npm rejects the OIDC token.

### Fix
- Remove `environment:` from the publish job (matches npm's official OIDC example). With no environment claim, the npm trusted-publisher **Environment field must be left blank**.
- Pin `node-version: '24'` and echo `npm --version` for diagnostics.
- `RELEASING.md`: document exact-match requirement + an optional section for adding maintainer-approval gating on both sides later.

### After merge
Re-tag `v0.1.1` (it never published, so the version is free) to re-run the pipeline. Requires the npm trusted-publisher Environment field to be blank.