### PR TITLE
chore(ci): remove temporary OIDC debug logging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,16 +53,10 @@ jobs:
           pnpm test
           pnpm build
 
-      - name: OIDC diagnostics
-        run: |
-          echo "id-token request URL present: ${ACTIONS_ID_TOKEN_REQUEST_URL:+yes}"
-          echo "id-token request token present: ${ACTIONS_ID_TOKEN_REQUEST_TOKEN:+yes}"
-          echo "npm: $(npm --version)"
-
       # Provenance is generated automatically under OIDC; no --provenance flag,
       # no NODE_AUTH_TOKEN.
       - name: Publish
-        run: npm publish --access public --loglevel verbose
+        run: npm publish --access public
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
OIDC trusted publishing is confirmed working — v0.1.1 published with provenance and a GitHub Release was created. This removes the temporary diagnostics step and `--loglevel verbose` added while debugging.