### PR TITLE
fix(claim-work): make overlap results explicitly point-in-time (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,16 @@ See [`CONTRIBUTING.md`](./CONTRIBUTING.md) and [`CLAUDE.md`](./CLAUDE.md). This
 repo is strictly typed (no `any`, no typecasts), modular, and every PR stays under
 600 LOC. Good first issues are labelled [`good first issue`](https://github.com/Get-Concord-AI/concord-mcp/labels/good%20first%20issue).
 
+## Star History
+
+<a href="https://www.star-history.com/?repos=Get-Concord-AI%2Fconcord-mcp&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=Get-Concord-AI/concord-mcp&type=date&theme=dark&legend=top-left&sealed_token=DbdI1sO4OagCGFjVA8u5Muv8TyjExR3cllFEq-O_HR3Lzj1jwj7p3N1KuL5fqohiyjzgevkwPQTT8oAw-rZfwTGNwRcTD9sb7aM0pDiJ6ZFGbGY2swwz0CNpbh3Usu4Dw6UIXBDuXacj3SBUTvdU7UYqEcAZtYdlTqUphLqPIrnMJa9WbAbg4ksGqaU2" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=Get-Concord-AI/concord-mcp&type=date&legend=top-left&sealed_token=DbdI1sO4OagCGFjVA8u5Muv8TyjExR3cllFEq-O_HR3Lzj1jwj7p3N1KuL5fqohiyjzgevkwPQTT8oAw-rZfwTGNwRcTD9sb7aM0pDiJ6ZFGbGY2swwz0CNpbh3Usu4Dw6UIXBDuXacj3SBUTvdU7UYqEcAZtYdlTqUphLqPIrnMJa9WbAbg4ksGqaU2" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=Get-Concord-AI/concord-mcp&type=date&legend=top-left&sealed_token=DbdI1sO4OagCGFjVA8u5Muv8TyjExR3cllFEq-O_HR3Lzj1jwj7p3N1KuL5fqohiyjzgevkwPQTT8oAw-rZfwTGNwRcTD9sb7aM0pDiJ6ZFGbGY2swwz0CNpbh3Usu4Dw6UIXBDuXacj3SBUTvdU7UYqEcAZtYdlTqUphLqPIrnMJa9WbAbg4ksGqaU2" />
+ </picture>
+</a>
+
 ## License
 
 [MIT](./LICENSE)

--- a/src/tools/claim-work.ts
+++ b/src/tools/claim-work.ts
@@ -8,6 +8,13 @@ export interface ClaimWorkResult {
   task: TaskRecord;
   alreadyClaimed: boolean;
   overlaps: OverlapWarning[];
+  /**
+   * How many other active tasks the overlap check compared against. Overlap
+   * detection is point-in-time: an empty `overlaps` only means nothing conflicts
+   * *right now*. A later overlapping claim will not appear here — it surfaces on
+   * read (e.g. `concord status`), which recomputes overlaps live.
+   */
+  checkedAgainst: number;
 }
 
 /**
@@ -54,7 +61,12 @@ export function handleClaimWork(repos: Repositories, input: ClaimWorkInput): Cla
     detail: overlaps.length > 0 ? `${String(overlaps.length)} overlap(s)` : null,
   });
 
-  return { task, alreadyClaimed: existing !== undefined, overlaps };
+  return {
+    task,
+    alreadyClaimed: existing !== undefined,
+    overlaps,
+    checkedAgainst: activeOthers.length,
+  };
 }
 
 export function formatClaimWorkText(result: ClaimWorkResult): string {
@@ -62,11 +74,24 @@ export function formatClaimWorkText(result: ClaimWorkResult): string {
   const lines = [`${verb} ${result.task.taskId} (${result.task.title}).`];
 
   if (result.overlaps.length === 0) {
-    lines.push('No potential overlaps with active tasks.');
+    if (result.checkedAgainst === 0) {
+      lines.push(
+        'No other active claims to check against yet. Overlaps are only checked at ' +
+          'claim time, so a later overlapping claim will not appear here — run ' +
+          '`concord status` to re-check as others claim work.',
+      );
+    } else {
+      lines.push(
+        `No overlaps with the ${String(result.checkedAgainst)} other active task(s) at claim time. ` +
+          'This is a point-in-time check — run `concord status` to re-check as new work is claimed.',
+      );
+    }
     return lines.join('\n');
   }
 
-  lines.push(`Potential overlaps (${String(result.overlaps.length)}):`);
+  lines.push(
+    `Potential overlaps (${String(result.overlaps.length)} of ${String(result.checkedAgainst)} active task(s)):`,
+  );
   for (const overlap of result.overlaps) {
     lines.push(`  - ${overlap.taskId} (${overlap.title}): ${overlap.reasons.join('; ')}`);
   }
@@ -84,7 +109,8 @@ export function registerClaimWork(
       title: 'Claim work',
       description:
         'Record that an agent is starting a task and flag overlaps with other active tasks. ' +
-        'Call this before editing code.',
+        'Call this before editing code. Overlap detection is point-in-time (only against tasks ' +
+        'already active at claim time); run `concord status` to re-check as others claim.',
       inputSchema: claimWorkInputShape,
     },
     (args) => {
@@ -96,6 +122,10 @@ export function registerClaimWork(
           task_id: result.task.taskId,
           already_claimed: result.alreadyClaimed,
           overlaps: result.overlaps,
+          // Number of other active tasks compared against. With an empty
+          // `overlaps`, this disambiguates "nobody else was active" (0) from
+          // "compared against N, none conflict" — the check is point-in-time.
+          checked_against: result.checkedAgainst,
         },
       };
     },

--- a/test/cli/cli-core.test.ts
+++ b/test/cli/cli-core.test.ts
@@ -80,6 +80,26 @@ describe('buildStatus / renderStatusText', () => {
     expect(text).toContain('TASK-12 <-> TASK-14');
   });
 
+  it('surfaces a later overlap to the earlier claimant on read (closes the point-in-time gap)', () => {
+    // The first claim sees no overlaps — nobody else was active yet (#29).
+    const first = handleClaimWork(repos, {
+      task_id: 'TASK-1',
+      title: 'Frontend',
+      domains: ['todo'],
+    });
+    expect(first.overlaps).toEqual([]);
+    expect(first.checkedAgainst).toBe(0);
+
+    // A second, overlapping claim lands after. The earlier claimant was never
+    // told at claim time — but status recomputes overlaps live, so the pair is
+    // now visible to both sides.
+    handleClaimWork(repos, { task_id: 'TASK-2', title: 'Backend', domains: ['todo'] });
+
+    const view = buildStatus(repos);
+    expect(view.overlaps).toHaveLength(1);
+    expect(renderStatusText(view)).toContain('TASK-1 <-> TASK-2');
+  });
+
   it('lists review-ready tasks and their open questions', () => {
     handleClaimWork(repos, { task_id: 'TASK-9', title: 'Retry', modules: ['billing'] });
     handleReviewReady(repos, {

--- a/test/tools/claim-work.test.ts
+++ b/test/tools/claim-work.test.ts
@@ -19,6 +19,7 @@ describe('handleClaimWork', () => {
     });
     expect(result.alreadyClaimed).toBe(false);
     expect(result.overlaps).toEqual([]);
+    expect(result.checkedAgainst).toBe(0);
     expect(repos.tasks.get('TASK-12')?.title).toBe('Add Stripe retry handling');
     expect(repos.events.listByTask('TASK-12').map((e) => e.tool)).toEqual(['claim_work']);
   });
@@ -32,7 +33,8 @@ describe('handleClaimWork', () => {
     });
     expect(result.overlaps).toHaveLength(1);
     expect(result.overlaps[0]?.taskId).toBe('TASK-12');
-    expect(formatClaimWorkText(result)).toContain('Potential overlaps (1)');
+    expect(result.checkedAgainst).toBe(1);
+    expect(formatClaimWorkText(result)).toContain('Potential overlaps (1 of 1 active task(s))');
   });
 
   it('is idempotent: re-claiming returns the existing task without duplicating', () => {
@@ -58,8 +60,27 @@ describe('handleClaimWork', () => {
     expect(result.overlaps).toEqual([]);
   });
 
-  it('formats a no-overlap claim clearly', () => {
-    const result = handleClaimWork(repos, { task_id: 'TASK-1', title: 'Solo' });
-    expect(formatClaimWorkText(result)).toContain('No potential overlaps');
+  it('makes an empty result explicitly point-in-time rather than definitive', () => {
+    // First claim: nobody else is active, so there is nothing to compare against.
+    const first = handleClaimWork(repos, { task_id: 'TASK-1', title: 'Solo' });
+    expect(first.checkedAgainst).toBe(0);
+    const firstText = formatClaimWorkText(first);
+    expect(firstText).not.toContain('No potential overlaps with active tasks.');
+    expect(firstText).toContain('No other active claims to check against yet');
+    expect(firstText).toContain('concord status');
+
+    // Second, non-overlapping claim: compared against 1 active task, still clean,
+    // but the wording stays point-in-time.
+    const second = handleClaimWork(repos, {
+      task_id: 'TASK-2',
+      title: 'Unrelated',
+      modules: ['signup'],
+    });
+    expect(second.overlaps).toEqual([]);
+    expect(second.checkedAgainst).toBe(1);
+    const secondText = formatClaimWorkText(second);
+    expect(secondText).toContain('No overlaps with the 1 other active task(s) at claim time');
+    expect(secondText).toContain('point-in-time');
+    expect(secondText).toContain('concord status');
   });
 });


### PR DESCRIPTION
## What & why

`claim_work` computes overlaps only against tasks **already active at claim time**, so the first of two concurrent overlapping claims got `"No potential overlaps with active tasks."` and (as seen in a dogfooding session) over-trusted it as definitive. This makes the response honest about its point-in-time nature.

Fixes #29.

## Changes

- **Point-in-time wording.** An empty result no longer reads as permanent:
  - 0 others active → *"No other active claims to check against yet … run `concord status` to re-check as others claim work."*
  - N others active, none conflicting → *"No overlaps with the N other active task(s) at claim time. This is a point-in-time check — run `concord status` to re-check…"*
- **`checked_against` count** added to the structured output and `ClaimWorkResult`, disambiguating "nobody else was active" (0) from "compared against N, none conflict."
- **Tool description** now states overlap detection is point-in-time.

Reads (`concord status` / `buildStatus`) already recompute overlaps live, so both parties eventually see the conflict — a regression test locks that in. Pushing a *proactive notification* to the earlier claimant is intentionally deferred to #32 (notifications infra).

## Testing

- `pnpm lint` ✅ · `pnpm typecheck` ✅ · `pnpm test` ✅ (54 passed) · `pnpm build` ✅
- New/updated tests: point-in-time wording for both empty cases, `checked_against` counts, and a `buildStatus` regression proving a later overlap surfaces to the earlier claimant on read.
- Ran the built `dist/` against the exact frontend/backend dogfooding scenario to confirm runtime output.

## Scope

3 files, +75/−8 LOC (under the 600-LOC rule). No schema/DB changes; write surface stays at 3 tools.
