### PR TITLE
feat(overlap): match labels by normalized word tokens, not exact strings (#30)

### DIFF
--- a/src/domain/overlap.ts
+++ b/src/domain/overlap.ts
@@ -1,4 +1,4 @@
-import { dirname } from 'node:path';
+import { posix } from 'node:path';
 
 import type { TaskRecord } from '../db/index.js';
 
@@ -24,8 +24,46 @@ function sortedIntersection(a: readonly string[], b: readonly string[]): string[
   return [...shared].sort((x, y) => x.localeCompare(y));
 }
 
+/**
+ * Split a label (domain, module, risk tag) into normalized word tokens so that
+ * phrasing differences do not hide a real overlap: case, surrounding
+ * whitespace, and word separators (`-`, `_`, `/`, spaces) are all ignored.
+ * e.g. "Todo Frontend", "todo-frontend", and ["frontend", "todo"] all share the
+ * tokens {frontend, todo}.
+ */
+function tokenize(value: string): string[] {
+  return value
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((token) => token.length > 0);
+}
+
+/** The deduplicated set of word tokens across a list of labels. */
+function tokensOf(values: readonly string[]): string[] {
+  const tokens = new Set<string>();
+  for (const value of values) {
+    for (const token of tokenize(value)) {
+      tokens.add(token);
+    }
+  }
+  return [...tokens];
+}
+
+/** Normalize a declared file path: drop a leading `./`, collapse `//`, resolve
+ * `.`/`..` segments, and strip a trailing slash, so `./app/page.tsx` and
+ * `app/page.tsx` compare equal. Paths stay case-sensitive. */
+function normalizePath(file: string): string {
+  const trimmed = file.trim().replace(/^\.\//, '');
+  const normalized = posix.normalize(trimmed).replace(/\/$/, '');
+  return normalized === '.' ? '' : normalized;
+}
+
 function directories(files: readonly string[]): string[] {
-  return files.map((file) => dirname(file)).filter((dir) => dir !== '.' && dir !== '');
+  return files
+    .map((file) => normalizePath(file))
+    .filter((file) => file !== '')
+    .map((file) => posix.dirname(file))
+    .filter((dir) => dir !== '.' && dir !== '');
 }
 
 function surfaceOf(task: TaskRecord): OverlapSurface {
@@ -41,7 +79,10 @@ function surfaceOf(task: TaskRecord): OverlapSurface {
 function reasonsFor(candidate: OverlapSurface, existing: OverlapSurface): string[] {
   const reasons: string[] = [];
 
-  const sameFiles = sortedIntersection(candidate.expectedFiles, existing.expectedFiles);
+  const sameFiles = sortedIntersection(
+    candidate.expectedFiles.map(normalizePath).filter((file) => file !== ''),
+    existing.expectedFiles.map(normalizePath).filter((file) => file !== ''),
+  );
   if (sameFiles.length > 0) {
     reasons.push(`same file(s): ${sameFiles.join(', ')}`);
   }
@@ -54,17 +95,20 @@ function reasonsFor(candidate: OverlapSurface, existing: OverlapSurface): string
     reasons.push(`same directory: ${sameDirs.join(', ')}`);
   }
 
-  const sameModules = sortedIntersection(candidate.modules, existing.modules);
+  const sameModules = sortedIntersection(tokensOf(candidate.modules), tokensOf(existing.modules));
   if (sameModules.length > 0) {
     reasons.push(`shared module(s): ${sameModules.join(', ')}`);
   }
 
-  const sameDomains = sortedIntersection(candidate.domains, existing.domains);
+  const sameDomains = sortedIntersection(tokensOf(candidate.domains), tokensOf(existing.domains));
   if (sameDomains.length > 0) {
     reasons.push(`shared domain(s): ${sameDomains.join(', ')}`);
   }
 
-  const sameRiskTags = sortedIntersection(candidate.riskTags, existing.riskTags);
+  const sameRiskTags = sortedIntersection(
+    tokensOf(candidate.riskTags),
+    tokensOf(existing.riskTags),
+  );
   if (sameRiskTags.length > 0) {
     reasons.push(`shared risk tag(s): ${sameRiskTags.join(', ')}`);
   }
@@ -74,8 +118,10 @@ function reasonsFor(candidate: OverlapSurface, existing: OverlapSurface): string
 
 /**
  * Flag obvious overlaps between the candidate surface and existing tasks, based
- * on declared files, directories, modules, domains, and risk tags. This is a
- * deliberately naive v0: it does not perform semantic conflict detection.
+ * on declared files, directories, modules, domains, and risk tags. Labels are
+ * compared by normalized word tokens (case-, separator-, and order-insensitive)
+ * and files by normalized path, so phrasing differences do not hide an overlap.
+ * This remains deliberately naive: no stemming or semantic conflict detection.
  */
 export function detectOverlaps(
   candidate: OverlapSurface,

--- a/test/domain/overlap.test.ts
+++ b/test/domain/overlap.test.ts
@@ -55,12 +55,62 @@ describe('detectOverlaps', () => {
     expect(warnings[0]?.reasons.some((r) => r.startsWith('same directory'))).toBe(false);
   });
 
-  it('flags shared domains and risk tags', () => {
+  it('flags shared domains and risk tags (reported as normalized tokens)', () => {
     const warnings = detectOverlaps(candidate, [
       task({ taskId: 'TASK-D', domains: ['payments'], riskTags: ['payment-flow'] }),
     ]);
     expect(warnings[0]?.reasons).toContain('shared domain(s): payments');
-    expect(warnings[0]?.reasons).toContain('shared risk tag(s): payment-flow');
+    // 'payment-flow' tokenizes to {payment, flow}; reasons name the shared tokens.
+    expect(warnings[0]?.reasons).toContain('shared risk tag(s): flow, payment');
+  });
+
+  it('matches labels across case, whitespace, and word order (the dogfooding miss)', () => {
+    // A UX task declared domains as the single phrase "todo frontend"; the
+    // implementation task declared ["frontend", "todo"]. Exact matching missed
+    // this; token matching catches it.
+    const uxCandidate: OverlapSurface = {
+      taskId: 'TASK-UX',
+      expectedFiles: [],
+      modules: ['frontend UX'],
+      domains: ['todo frontend'],
+      riskTags: [],
+    };
+    const warnings = detectOverlaps(uxCandidate, [
+      task({ taskId: 'TASK-FE', title: 'Frontend', domains: ['Frontend', 'todo'] }),
+    ]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.reasons).toContain('shared domain(s): frontend, todo');
+  });
+
+  it('treats kebab, snake, and space separators as equivalent for modules', () => {
+    const kebab: OverlapSurface = {
+      taskId: 'TASK-K',
+      expectedFiles: [],
+      modules: ['app-shell'],
+      domains: [],
+      riskTags: [],
+    };
+    const warnings = detectOverlaps(kebab, [task({ taskId: 'TASK-S', modules: ['app_shell'] })]);
+    expect(warnings[0]?.reasons).toContain('shared module(s): app, shell');
+  });
+
+  it('normalizes file paths so ./app/page.tsx and app/page.tsx are the same file', () => {
+    const withDotSlash: OverlapSurface = {
+      taskId: 'TASK-P',
+      expectedFiles: ['./app/page.tsx'],
+      modules: [],
+      domains: [],
+      riskTags: [],
+    };
+    const sameFile = detectOverlaps(withDotSlash, [
+      task({ taskId: 'TASK-Q', expectedFiles: ['app/page.tsx'] }),
+    ]);
+    expect(sameFile[0]?.reasons).toContain('same file(s): app/page.tsx');
+
+    const sameDir = detectOverlaps(withDotSlash, [
+      task({ taskId: 'TASK-R', expectedFiles: ['app//layout.tsx'] }),
+    ]);
+    expect(sameDir[0]?.reasons).toContain('same directory: app');
   });
 
   it('returns nothing for disjoint tasks', () => {


### PR DESCRIPTION
## What & why

Overlap detection compared `domains` / `modules` / `risk_tags` by **exact string** and files by raw path, so phrasing differences hid real overlaps. In the dogfooding session the domain `"todo frontend"` never matched `["frontend", "todo"]`, so the UX task's overlap with the frontend task went unflagged.

Fixes #30.

## Changes (all in `src/domain/overlap.ts`)

- **Token matching for labels.** Domains/modules/risk tags are lowercased and split on whitespace and `-` / `_` / `/` separators, then matched on shared tokens. So `"Todo Frontend"`, `"todo-frontend"`, and `["frontend", "todo"]` all overlap. Reason strings now name the shared **tokens** (e.g. `shared domain(s): frontend, todo`).
- **Path normalization for files.** Strip a leading `./`, collapse `//`, resolve `.`/`..` segments, and drop trailing slashes, so `./app/page.tsx` and `app/page.tsx` are the same file (and share directory `app`). Paths stay case-sensitive.
- Deliberately **no stemming or semantic detection** — kept deterministic and dependency-free, per the domain-layer guidelines.

## Testing

- `pnpm format:check` (changed files) ✅ · `pnpm lint` ✅ · `pnpm typecheck` ✅ · `pnpm test` ✅ (57 passed) · `pnpm build` ✅
- New `test/domain/overlap.test.ts` cases: case/whitespace/word-order (the dogfooding miss), kebab/snake/space equivalence, and `./`-prefix / `//` path normalization.
- Ran the built `dist/` against the exact dogfooding scenario — `"todo frontend"` vs `["frontend","todo"]` now flags `shared domain(s): frontend, todo`.

## Scope

2 files, pure domain logic. No schema/DB change, no new tools. Sharper overlaps also make #31 (task-decomposition nudges) more meaningful.
