### PR TITLE
feat(claim-work): nudge agents to split oversized claims (#31)

### DIFF
--- a/src/domain/decomposition.ts
+++ b/src/domain/decomposition.ts
@@ -1,0 +1,48 @@
+/**
+ * Advisory checks that nudge agents to break work into the smallest
+ * independently-handoffable unit. A single claim that spans many files,
+ * modules, or domains tends to be too big to hand off or review cleanly, and it
+ * produces coarse overlap signals. These thresholds are soft: exceeding them is
+ * a suggestion, never an error.
+ */
+
+/** Soft upper bounds above which a claim looks too broad. */
+export const CLAIM_BREADTH_LIMITS = {
+  expectedFiles: 5,
+  modules: 3,
+  domains: 2,
+} as const;
+
+/** The parts of a claim used to judge whether it is too broad. */
+export interface ClaimBreadthInput {
+  expectedFiles: readonly string[];
+  modules: readonly string[];
+  domains: readonly string[];
+}
+
+/**
+ * Return human-readable reasons a claim looks too broad, or `[]` if it is
+ * appropriately scoped. Non-blocking: callers surface this as a suggestion to
+ * split the work, not as a rejection.
+ */
+export function assessClaimBreadth(input: ClaimBreadthInput): string[] {
+  const reasons: string[] = [];
+
+  if (input.expectedFiles.length > CLAIM_BREADTH_LIMITS.expectedFiles) {
+    reasons.push(
+      `${String(input.expectedFiles.length)} expected files (recommended <= ${String(CLAIM_BREADTH_LIMITS.expectedFiles)})`,
+    );
+  }
+  if (input.modules.length > CLAIM_BREADTH_LIMITS.modules) {
+    reasons.push(
+      `${String(input.modules.length)} modules (recommended <= ${String(CLAIM_BREADTH_LIMITS.modules)})`,
+    );
+  }
+  if (input.domains.length > CLAIM_BREADTH_LIMITS.domains) {
+    reasons.push(
+      `${String(input.domains.length)} domains (recommended <= ${String(CLAIM_BREADTH_LIMITS.domains)})`,
+    );
+  }
+
+  return reasons;
+}

--- a/src/install/instructions.ts
+++ b/src/install/instructions.ts
@@ -3,6 +3,9 @@ export const CONCORD_INSTRUCTIONS = `## Concord — shared work-state for coding
 
 This project uses Concord MCP. Use its tools so your work is visible before PRs:
 
+- **Keep each claim small.** Break work into the smallest independently
+  handoff-able unit and \`claim_work\` each piece separately, rather than
+  claiming one broad task. Concord flags claims that look too broad.
 - **Before editing code**, call \`claim_work\` with the task id, title, and the
   files/modules you expect to touch. Concord warns about overlaps with other
   active work.

--- a/src/tools/claim-work.ts
+++ b/src/tools/claim-work.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import type { Repositories, TaskRecord } from '../db/index.js';
+import { assessClaimBreadth } from '../domain/decomposition.js';
 import { detectOverlaps, type OverlapWarning } from '../domain/overlap.js';
 import { claimWorkInputShape, type ClaimWorkInput } from '../domain/schemas.js';
 
@@ -15,6 +16,12 @@ export interface ClaimWorkResult {
    * read (e.g. `concord status`), which recomputes overlaps live.
    */
   checkedAgainst: number;
+  /**
+   * Advisory reasons the claim looks too broad (empty when appropriately
+   * scoped). A non-empty list is a suggestion to split the work into smaller,
+   * independently-handoffable tasks — never a rejection.
+   */
+  breadthReasons: string[];
 }
 
 /**
@@ -66,6 +73,11 @@ export function handleClaimWork(repos: Repositories, input: ClaimWorkInput): Cla
     alreadyClaimed: existing !== undefined,
     overlaps,
     checkedAgainst: activeOthers.length,
+    breadthReasons: assessClaimBreadth({
+      expectedFiles: input.expected_files ?? [],
+      modules: input.modules ?? [],
+      domains: input.domains ?? [],
+    }),
   };
 }
 
@@ -86,15 +98,22 @@ export function formatClaimWorkText(result: ClaimWorkResult): string {
           'This is a point-in-time check — run `concord status` to re-check as new work is claimed.',
       );
     }
-    return lines.join('\n');
+  } else {
+    lines.push(
+      `Potential overlaps (${String(result.overlaps.length)} of ${String(result.checkedAgainst)} active task(s)):`,
+    );
+    for (const overlap of result.overlaps) {
+      lines.push(`  - ${overlap.taskId} (${overlap.title}): ${overlap.reasons.join('; ')}`);
+    }
   }
 
-  lines.push(
-    `Potential overlaps (${String(result.overlaps.length)} of ${String(result.checkedAgainst)} active task(s)):`,
-  );
-  for (const overlap of result.overlaps) {
-    lines.push(`  - ${overlap.taskId} (${overlap.title}): ${overlap.reasons.join('; ')}`);
+  if (result.breadthReasons.length > 0) {
+    lines.push(
+      `Heads-up: this claim looks broad (${result.breadthReasons.join('; ')}). ` +
+        'Consider splitting it into smaller, independently-handoffable tasks and claiming each separately.',
+    );
   }
+
   return lines.join('\n');
 }
 
@@ -126,6 +145,9 @@ export function registerClaimWork(
           // `overlaps`, this disambiguates "nobody else was active" (0) from
           // "compared against N, none conflict" — the check is point-in-time.
           checked_against: result.checkedAgainst,
+          // Advisory reasons the claim looks too broad; empty when well-scoped.
+          // A non-empty list suggests splitting into smaller tasks (non-blocking).
+          breadth_reasons: result.breadthReasons,
         },
       };
     },

--- a/test/domain/decomposition.test.ts
+++ b/test/domain/decomposition.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { assessClaimBreadth, CLAIM_BREADTH_LIMITS } from '../../src/domain/decomposition.js';
+
+describe('assessClaimBreadth', () => {
+  it('returns no reasons for a well-scoped claim', () => {
+    expect(
+      assessClaimBreadth({
+        expectedFiles: ['src/billing/retry.ts', 'src/billing/retry.test.ts'],
+        modules: ['billing'],
+        domains: ['payments'],
+      }),
+    ).toEqual([]);
+  });
+
+  it('treats the thresholds as inclusive (at the limit is fine)', () => {
+    expect(
+      assessClaimBreadth({
+        expectedFiles: Array.from(
+          { length: CLAIM_BREADTH_LIMITS.expectedFiles },
+          (_, i) => `f${String(i)}.ts`,
+        ),
+        modules: Array.from({ length: CLAIM_BREADTH_LIMITS.modules }, (_, i) => `m${String(i)}`),
+        domains: Array.from({ length: CLAIM_BREADTH_LIMITS.domains }, (_, i) => `d${String(i)}`),
+      }),
+    ).toEqual([]);
+  });
+
+  it('flags too many expected files', () => {
+    const reasons = assessClaimBreadth({
+      expectedFiles: ['a', 'b', 'c', 'd', 'e', 'f'],
+      modules: [],
+      domains: [],
+    });
+    expect(reasons).toHaveLength(1);
+    expect(reasons[0]).toContain('6 expected files');
+    expect(reasons[0]).toContain('<= 5');
+  });
+
+  it('flags every dimension that is over its limit', () => {
+    const reasons = assessClaimBreadth({
+      expectedFiles: ['a', 'b', 'c', 'd', 'e', 'f'],
+      modules: ['app', 'ui', 'state', 'api'],
+      domains: ['frontend', 'todo', 'auth'],
+    });
+    expect(reasons).toHaveLength(3);
+    expect(reasons.some((r) => r.includes('expected files'))).toBe(true);
+    expect(reasons.some((r) => r.includes('modules'))).toBe(true);
+    expect(reasons.some((r) => r.includes('domains'))).toBe(true);
+  });
+});

--- a/test/tools/claim-work.test.ts
+++ b/test/tools/claim-work.test.ts
@@ -83,4 +83,45 @@ describe('handleClaimWork', () => {
     expect(secondText).toContain('point-in-time');
     expect(secondText).toContain('concord status');
   });
+
+  it('does not nudge a well-scoped claim', () => {
+    const result = handleClaimWork(repos, {
+      task_id: 'TASK-1',
+      title: 'Small',
+      modules: ['billing'],
+      expected_files: ['src/billing/retry.ts'],
+    });
+    expect(result.breadthReasons).toEqual([]);
+    expect(formatClaimWorkText(result)).not.toContain('Heads-up');
+  });
+
+  it('nudges an oversized claim to split, without blocking it', () => {
+    const result = handleClaimWork(repos, {
+      task_id: 'TODO-FRONTEND-001',
+      title: 'Build the whole frontend',
+      modules: ['app-shell', 'todo-ui', 'client-state', 'api-client'],
+      domains: ['frontend', 'todo', 'auth'],
+      expected_files: ['a.tsx', 'b.tsx', 'c.tsx', 'd.tsx', 'e.tsx', 'f.tsx'],
+    });
+    // The claim still succeeds (non-blocking) ...
+    expect(result.alreadyClaimed).toBe(false);
+    expect(repos.tasks.get('TODO-FRONTEND-001')).toBeDefined();
+    // ... but it surfaces a decomposition suggestion.
+    expect(result.breadthReasons.length).toBeGreaterThan(0);
+    const text = formatClaimWorkText(result);
+    expect(text).toContain('Heads-up: this claim looks broad');
+    expect(text).toContain('independently-handoffable');
+  });
+
+  it('shows the breadth nudge alongside overlaps', () => {
+    handleClaimWork(repos, { task_id: 'OTHER', title: 'Other', modules: ['app-shell'] });
+    const result = handleClaimWork(repos, {
+      task_id: 'BIG',
+      title: 'Big overlapping claim',
+      modules: ['app-shell', 'todo-ui', 'client-state', 'api-client'],
+    });
+    const text = formatClaimWorkText(result);
+    expect(text).toContain('Potential overlaps');
+    expect(text).toContain('Heads-up: this claim looks broad');
+  });
 });


### PR DESCRIPTION
## What & why

Agents claim work at too coarse a granularity. In the dogfooding session the frontend task bundled `app-shell` + `todo-ui` + `client-state` (later `+api-client`) into one claim and never reached a handoff, while the smaller, well-scoped backend finished cleanly. Oversized claims are hard to hand off/review and produce coarse overlap signals. This adds a non-blocking nudge to split them.

Closes #31 (the nudge + instructions). Parent/child task ids — the third bullet of #31 — are split out to #36 as a separate data-model change.

## Changes

- **`src/domain/decomposition.ts`** (new, pure): `assessClaimBreadth` flags a claim as too broad against soft limits — **> 5 expected files, > 3 modules, > 2 domains** — and returns human-readable reasons. Thresholds are inclusive (at the limit is fine).
- **`claim_work`** surfaces the suggestion **without blocking**: a `Heads-up: this claim looks broad (…). Consider splitting…` line in the text, plus a `breadth_reasons` field in the structured output. The claim still succeeds and is recorded.
- **Install instructions** (`concord install`) gain a leading rule: *"Keep each claim small — break work into the smallest independently handoff-able unit and `claim_work` each piece separately."*

## Testing

- `pnpm format:check` (changed files) ✅ · `pnpm lint` ✅ · `pnpm typecheck` ✅ · `pnpm test` ✅ (64 passed) · `pnpm build` ✅
- New `test/domain/decomposition.test.ts` (well-scoped → no reasons; inclusive thresholds; per-dimension flags) and `claim-work` tests (small claim → no nudge; oversized claim → nudge but still claimed; nudge coexists with overlaps).
- Ran the built `dist/` on the exact oversized frontend claim → emits the nudge with specific reasons; a small claim stays quiet.

## Scope

3 source files + 2 test files, pure/advisory logic. No schema/DB change, no new tools, write surface unchanged.
