### PR TITLE
feat(cli): concord check — overlap gate for edit-time enforcement (part of #32)

### DIFF
--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -1,0 +1,77 @@
+import type { Command } from '@commander-js/extra-typings';
+
+import type { Repositories } from '../../db/index.js';
+import { normalizePath, type OverlapWarning } from '../../domain/overlap.js';
+import { openContext } from '../context.js';
+
+/**
+ * Exact-file collisions between the given files and OTHER active tasks' declared
+ * files. This is the client-agnostic primitive behind edit-time enforcement: a
+ * PreToolUse hook (Claude Code), a git pre-commit hook, or CI can call it to
+ * find out whether the files about to change are already claimed by someone
+ * else. `selfTaskId` excludes your own claim so you are not flagged against
+ * yourself.
+ *
+ * Unlike claim-time overlap detection (which also warns on shared
+ * directories/modules/domains), this gate is intentionally precise: it fires
+ * only on the *same file*, since blocking an edit on a coarse signal like a
+ * shared top-level directory would be too noisy to be useful.
+ */
+export function checkFileOverlaps(
+  repos: Repositories,
+  files: readonly string[],
+  selfTaskId?: string,
+): OverlapWarning[] {
+  const wanted = new Set(files.map(normalizePath).filter((file) => file !== ''));
+  const warnings: OverlapWarning[] = [];
+  for (const task of repos.tasks.list()) {
+    if (task.status !== 'active' || task.taskId === selfTaskId) {
+      continue;
+    }
+    const shared = task.expectedFiles.map(normalizePath).filter((file) => wanted.has(file));
+    if (shared.length > 0) {
+      const unique = [...new Set(shared)].sort((a, b) => a.localeCompare(b));
+      warnings.push({
+        taskId: task.taskId,
+        title: task.title,
+        reasons: [`same file(s): ${unique.join(', ')}`],
+      });
+    }
+  }
+  return warnings;
+}
+
+/** Human-readable result for `concord check`. */
+export function renderCheck(files: readonly string[], overlaps: readonly OverlapWarning[]): string {
+  if (files.length === 0) {
+    return 'No files to check. Usage: concord check [--task <id>] <file>...';
+  }
+  if (overlaps.length === 0) {
+    return `OK: none of the ${String(files.length)} file(s) overlap another active task.`;
+  }
+  const lines = [
+    `Overlap: files you are about to edit collide with ${String(overlaps.length)} active task(s):`,
+  ];
+  for (const overlap of overlaps) {
+    lines.push(`  - ${overlap.taskId} (${overlap.title}): ${overlap.reasons.join('; ')}`);
+  }
+  return lines.join('\n');
+}
+
+export function registerCheckCommand(program: Command): void {
+  program
+    .command('check [files...]')
+    .description(
+      'Check whether files you are about to edit overlap another active task (for hooks/CI)',
+    )
+    .option('-t, --task <id>', "your own task id, so its own claim isn't flagged as an overlap")
+    .action((files, options) => {
+      const overlaps = checkFileOverlaps(openContext(process.cwd()).repos, files, options.task);
+      process.stdout.write(`${renderCheck(files, overlaps)}\n`);
+      if (overlaps.length > 0) {
+        // Non-zero so a hook/CI can block. Claude Code PreToolUse hooks treat
+        // exit code 2 as "deny"; wrap as `concord check ... || exit 2` there.
+        process.exitCode = 1;
+      }
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,6 +2,7 @@
 import { Command } from '@commander-js/extra-typings';
 
 import { VERSION } from '../version.js';
+import { registerCheckCommand } from './commands/check.js';
 import { registerDoctorCommand } from './commands/doctor.js';
 import { registerExportCommand } from './commands/export.js';
 import { registerHandoffCommand } from './commands/handoff.js';
@@ -18,6 +19,7 @@ registerInit(program);
 registerInstallCommand(program);
 registerStatus(program);
 registerTasks(program);
+registerCheckCommand(program);
 registerHandoffCommand(program);
 registerReviewPacketCommand(program);
 registerExportCommand(program);

--- a/src/domain/overlap.ts
+++ b/src/domain/overlap.ts
@@ -52,7 +52,7 @@ function tokensOf(values: readonly string[]): string[] {
 /** Normalize a declared file path: drop a leading `./`, collapse `//`, resolve
  * `.`/`..` segments, and strip a trailing slash, so `./app/page.tsx` and
  * `app/page.tsx` compare equal. Paths stay case-sensitive. */
-function normalizePath(file: string): string {
+export function normalizePath(file: string): string {
   const trimmed = file.trim().replace(/^\.\//, '');
   const normalized = posix.normalize(trimmed).replace(/\/$/, '');
   return normalized === '.' ? '' : normalized;

--- a/src/install/instructions.ts
+++ b/src/install/instructions.ts
@@ -19,7 +19,9 @@ Concord regenerates human-readable \`HANDOFF.md\` and \`REVIEW_PACKET.md\` in
 
 Enforcement note: on clients with hooks/command registration this can be
 enforced; elsewhere it is instruction-based and may be skipped. \`concord doctor\`
-shows per-task adoption either way.`;
+shows per-task adoption either way. For edit-time enforcement, wire a PreToolUse
+(or git pre-commit) hook to \`concord check <files> --task <your-task-id>\`; it
+exits non-zero when your edits collide with another agent's active claim.`;
 
 /** MDC frontmatter used when creating a fresh Cursor rules file. */
 export const CURSOR_MDC_HEADER = `---

--- a/test/cli/check.test.ts
+++ b/test/cli/check.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { checkFileOverlaps, renderCheck } from '../../src/cli/commands/check.js';
+import { openDatabase } from '../../src/db/connection.js';
+import { createRepositories, type Repositories } from '../../src/db/index.js';
+import { handleClaimWork } from '../../src/tools/claim-work.js';
+
+describe('concord check', () => {
+  let repos: Repositories;
+  beforeEach(() => {
+    repos = createRepositories(openDatabase(':memory:'));
+  });
+
+  it('reports no overlap when the files are unclaimed', () => {
+    handleClaimWork(repos, { task_id: 'T1', title: 'Other', expected_files: ['src/a.ts'] });
+    const overlaps = checkFileOverlaps(repos, ['src/b.ts']);
+    expect(overlaps).toEqual([]);
+    expect(renderCheck(['src/b.ts'], overlaps)).toContain('OK');
+  });
+
+  it('flags a file already claimed by another active task (with path normalization)', () => {
+    handleClaimWork(repos, {
+      task_id: 'T1',
+      title: 'Owns retry',
+      expected_files: ['src/billing/retry.ts'],
+    });
+    // Leading ./ is normalized (see #30), so this still collides.
+    const overlaps = checkFileOverlaps(repos, ['./src/billing/retry.ts']);
+    expect(overlaps).toHaveLength(1);
+    expect(overlaps[0]?.taskId).toBe('T1');
+    expect(renderCheck(['src/billing/retry.ts'], overlaps)).toContain('Overlap');
+  });
+
+  it('excludes your own task via --task', () => {
+    handleClaimWork(repos, { task_id: 'MINE', title: 'Mine', expected_files: ['src/x.ts'] });
+    expect(checkFileOverlaps(repos, ['src/x.ts'], 'MINE')).toEqual([]);
+    // Without excluding self, the file matches its own claim.
+    expect(checkFileOverlaps(repos, ['src/x.ts'])).toHaveLength(1);
+  });
+
+  it('ignores non-active tasks', () => {
+    handleClaimWork(repos, { task_id: 'DONE', title: 'Done', expected_files: ['src/x.ts'] });
+    repos.tasks.updateStatus('DONE', 'review_ready');
+    expect(checkFileOverlaps(repos, ['src/x.ts'])).toEqual([]);
+  });
+
+  it('renders a usage hint when no files are given', () => {
+    expect(renderCheck([], [])).toContain('Usage: concord check');
+  });
+});


### PR DESCRIPTION
## What & why

Enforcement was instruction-based and skipped in dogfooding (agents claimed only when prodded). This adds the **client-agnostic enforcement primitive**: a command a PreToolUse hook, git pre-commit hook, or CI calls to block edits that collide with another agent's active claim.

**Part of #32** (the enforcement bullet). The umbrella's other two mechanisms are split into follow-ups: `concord watch` + MCP `resources/updated` → #39, and opt-in auto-install of the PreToolUse hook → #40.

## Changes

- **`concord check [files...] --task <id>`** — reports exact same-file collisions between the given files and *other* active tasks, and **exits non-zero (1)** on collision, `0` otherwise. `--task` excludes your own claim.
- **Precise by design.** Unlike claim-time overlap warnings (which also flag shared directories/modules/domains), the gate fires only on the *same file* — blocking an edit on a coarse signal like "both touch `src/`" would be unusable. Reuses #30's path normalization (`normalizePath` is now exported) so `./a.ts` and `a.ts` match.
- Install instructions now point agents to `concord check` for hook-based enforcement.

## Testing

- `pnpm format:check` (changed files) ✅ · `pnpm lint` ✅ · `pnpm typecheck` ✅ · `pnpm test` ✅ (72 passed) · `pnpm build` ✅
- New `test/cli/check.test.ts`: unclaimed files → clean; same file (incl. `./` normalization) → flagged; `--task` excludes self; non-active tasks ignored; usage hint for no args.
- **End-to-end CLI run** against a temp workspace: colliding edit → prints the conflict and `exit 1`; own file (`--task`) and unclaimed file → `exit 0`.

## Hook usage (documented; auto-install tracked in #40)

A Claude Code `PreToolUse` hook can gate `Edit`/`Write` by extracting the path from the hook's stdin JSON and running `concord check "$path" --task <id> || exit 2` (exit 2 = deny). Git pre-commit / CI use the default exit 1.

## Scope

4 source files (1 new) + 1 test file. Under the 600-LOC limit. No schema/DB change; no new MCP tool.
