### PR TITLE
feat: push work-state changes — MCP resources/updated + concord watch (#39)

### DIFF
--- a/src/cli/commands/watch.ts
+++ b/src/cli/commands/watch.ts
@@ -1,0 +1,42 @@
+import { watch } from 'node:fs';
+
+import type { Command } from '@commander-js/extra-typings';
+
+import { buildStatus, renderStatusText } from '../../artifacts/work-state-view.js';
+import type { Repositories } from '../../db/index.js';
+import { openContext } from '../context.js';
+
+/** Current work-state as text — what `concord watch` prints on each change. */
+export function watchSnapshot(repos: Repositories): string {
+  return renderStatusText(buildStatus(repos));
+}
+
+export function registerWatchCommand(program: Command): void {
+  program
+    .command('watch')
+    .description('Print work-state whenever .concord changes (Ctrl-C to stop)')
+    .action(() => {
+      const ctx = openContext(process.cwd());
+      const print = (): void => {
+        process.stdout.write(`${watchSnapshot(ctx.repos)}\n\n`);
+      };
+      print();
+
+      // Debounce: SQLite writes touch several files (db, -wal, -shm) in quick
+      // succession, so coalesce bursts into a single reprint.
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const watcher = watch(ctx.concordPath, () => {
+        if (timer !== undefined) {
+          clearTimeout(timer);
+        }
+        timer = setTimeout(print, 150);
+      });
+
+      process.once('SIGINT', () => {
+        if (timer !== undefined) {
+          clearTimeout(timer);
+        }
+        watcher.close();
+      });
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -11,6 +11,7 @@ import { registerInstallCommand } from './commands/install.js';
 import { registerReviewPacketCommand } from './commands/review-packet.js';
 import { registerStatus } from './commands/status.js';
 import { registerTasks } from './commands/tasks.js';
+import { registerWatchCommand } from './commands/watch.js';
 
 const program = new Command();
 program.name('concord').description('Shared work-state for coding agents').version(VERSION);
@@ -20,6 +21,7 @@ registerInstallCommand(program);
 registerStatus(program);
 registerTasks(program);
 registerCheckCommand(program);
+registerWatchCommand(program);
 registerHandoffCommand(program);
 registerReviewPacketCommand(program);
 registerExportCommand(program);

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,9 +21,15 @@ export interface ServerOptions {
  */
 export function createServer(repos: Repositories, options: ServerOptions = {}): McpServer {
   const server = new McpServer({ name: 'concord-mcp', version: SERVER_VERSION });
-  registerClaimWork(server, repos, options.onToolWrite);
-  registerHandoff(server, repos, options.onToolWrite);
-  registerReviewReady(server, repos, options.onToolWrite);
-  registerWorkState(server, repos);
+  // Register the read surface first so we get the change-notifier, then run it
+  // (plus the caller's hook) after every write.
+  const notifyWorkStateChanged = registerWorkState(server, repos);
+  const onWrite = (): void => {
+    options.onToolWrite?.();
+    notifyWorkStateChanged();
+  };
+  registerClaimWork(server, repos, onWrite);
+  registerHandoff(server, repos, onWrite);
+  registerReviewReady(server, repos, onWrite);
   return server;
 }

--- a/src/tools/get-work-state.ts
+++ b/src/tools/get-work-state.ts
@@ -1,4 +1,8 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  SubscribeRequestSchema,
+  UnsubscribeRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
 
 import { buildStatus, renderStatusText, type StatusView } from '../artifacts/work-state-view.js';
 import type { Repositories } from '../db/index.js';
@@ -20,8 +24,12 @@ export function handleGetWorkState(repos: Repositories): StatusView {
  * (which agents can call directly) and the `concord://work-state` resource (the
  * MCP-native read). Both return the same snapshot. This is read-only and does
  * not change the three-tool *write* surface.
+ *
+ * Returns a `notifyChanged` callback: call it after any write so subscribed
+ * clients are pushed a `resources/updated` for `concord://work-state`. MCP
+ * cannot wake an idle client — this is push while a session is connected.
  */
-export function registerWorkState(server: McpServer, repos: Repositories): void {
+export function registerWorkState(server: McpServer, repos: Repositories): () => void {
   server.registerTool(
     'get_work_state',
     {
@@ -63,4 +71,23 @@ export function registerWorkState(server: McpServer, repos: Repositories): void 
       ],
     }),
   );
+
+  // Advertise resource subscriptions and track which URIs clients care about,
+  // so writes push a targeted `resources/updated` rather than a broadcast.
+  server.server.registerCapabilities({ resources: { subscribe: true } });
+  const subscribers = new Set<string>();
+  server.server.setRequestHandler(SubscribeRequestSchema, (request) => {
+    subscribers.add(request.params.uri);
+    return {};
+  });
+  server.server.setRequestHandler(UnsubscribeRequestSchema, (request) => {
+    subscribers.delete(request.params.uri);
+    return {};
+  });
+
+  return () => {
+    if (subscribers.has(WORK_STATE_URI)) {
+      void server.server.sendResourceUpdated({ uri: WORK_STATE_URI });
+    }
+  };
 }

--- a/test/cli/watch.test.ts
+++ b/test/cli/watch.test.ts
@@ -1,0 +1,24 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { watchSnapshot } from '../../src/cli/commands/watch.js';
+import { openDatabase } from '../../src/db/connection.js';
+import { createRepositories, type Repositories } from '../../src/db/index.js';
+import { handleClaimWork } from '../../src/tools/claim-work.js';
+
+describe('watchSnapshot', () => {
+  let repos: Repositories;
+  beforeEach(() => {
+    repos = createRepositories(openDatabase(':memory:'));
+  });
+
+  it('renders the current work-state (what concord watch prints on each change)', () => {
+    const empty = watchSnapshot(repos);
+    expect(empty).toContain('Active work');
+    expect(empty).toContain('none');
+
+    handleClaimWork(repos, { task_id: 'T1', title: 'Frontend', agent: 'codex' });
+    const withWork = watchSnapshot(repos);
+    expect(withWork).toContain('T1');
+    expect(withWork).toContain('codex');
+  });
+});

--- a/test/tools/get-work-state.test.ts
+++ b/test/tools/get-work-state.test.ts
@@ -1,5 +1,6 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { ResourceUpdatedNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { openDatabase } from '../../src/db/connection.js';
@@ -75,6 +76,34 @@ describe('work-state MCP surface (end-to-end via in-memory transport)', () => {
 
       const read = await client.readResource({ uri: WORK_STATE_URI });
       expect(JSON.stringify(read)).toContain('TASK-1');
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it('pushes a resources/updated notification to subscribers when work-state changes', async () => {
+    const repos = createRepositories(openDatabase(':memory:'));
+    const server = createServer(repos);
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: 'test-client', version: '0.0.0' });
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+    try {
+      const updated: string[] = [];
+      const received = new Promise<void>((resolve) => {
+        client.setNotificationHandler(ResourceUpdatedNotificationSchema, (notification) => {
+          updated.push(notification.params.uri);
+          resolve();
+        });
+      });
+
+      await client.subscribeResource({ uri: WORK_STATE_URI });
+      // A write via claim_work should push an update to the subscriber.
+      await client.callTool({ name: 'claim_work', arguments: { task_id: 'T1', title: 'X' } });
+      await received;
+
+      expect(updated).toContain(WORK_STATE_URI);
     } finally {
       await client.close();
       await server.close();


### PR DESCRIPTION
## What & why

Agents learned about new claims/handoffs only by re-running `concord status`. This adds two push mechanisms so work-state changes surface without polling.

Closes #39 (the push-notifications half of #32).

## Changes

**MCP `resources/updated` (builds on #27's resource)**
- The server now advertises `resources.subscribe`, tracks subscribed URIs, and pushes a `notifications/resources/updated` for `concord://work-state` after **every tool write**.
- Wired via a notifier returned by `registerWorkState` and composed into the tools' write callback in `createServer` (alongside the existing artifact-regeneration hook).
- A connected, subscribed client is notified the moment another agent claims work / hands off — turning the read surface into push while a session is active.

**`concord watch` CLI**
- Prints the current work-state and reprints (150ms-debounced) whenever `.concord` changes. Pairs with Codex's `notify` mechanism, a terminal, or a desktop-notification wrapper. `Ctrl-C` stops it cleanly.

MCP cannot wake a fully idle client — both mechanisms are push-while-connected / external watch, as noted on #32.

## Testing

- `pnpm format:check` (changed files) ✅ · `pnpm lint` ✅ · `pnpm typecheck` ✅ · `pnpm test` ✅ (74 passed) · `pnpm build` ✅
- **End-to-end MCP test**: a real `Client` over `InMemoryTransport` subscribes to `concord://work-state`, another `callTool('claim_work')` triggers a write, and the client receives a `resources/updated` for the URI.
- `watchSnapshot` unit test (empty → then reflects a claim).
- **Live daemon smoke test**: ran `concord watch` in one process; a *separate* process claimed a task; the watcher reprinted with the new task — confirming cross-process fs-watch + SQLite re-query.

## Scope

4 source files (1 new) + 2 test files. Under the 600-LOC limit. Read-only additions; the three-tool write surface is unchanged.
