### PR TITLE
feat: parent/child task ids for decomposition tracking (#36)

### DIFF
--- a/src/artifacts/work-state-json.ts
+++ b/src/artifacts/work-state-json.ts
@@ -7,6 +7,7 @@ interface WorkStateTask {
   agent: string | null;
   owner: string | null;
   branch: string | null;
+  parent_task_id: string | null;
   modules: string[];
   domains: string[];
   expected_files: string[];
@@ -25,6 +26,7 @@ function toWorkStateTask(task: TaskRecord): WorkStateTask {
     agent: task.agent,
     owner: task.owner,
     branch: task.branch,
+    parent_task_id: task.parentTaskId,
     modules: task.modules,
     domains: task.domains,
     expected_files: task.expectedFiles,

--- a/src/artifacts/work-state-view.ts
+++ b/src/artifacts/work-state-view.ts
@@ -8,6 +8,7 @@ interface ActiveEntry {
   agent: string;
   branch: string;
   touches: string;
+  parentTaskId: string | null;
 }
 
 interface OverlapPair {
@@ -59,6 +60,7 @@ export function buildStatus(repos: Repositories): StatusView {
         modules: task.modules,
         domains: task.domains,
         riskTags: task.riskTags,
+        parentTaskId: task.parentTaskId,
       },
       active,
     )) {
@@ -94,6 +96,7 @@ export function buildStatus(repos: Repositories): StatusView {
       agent: task.agent ?? '-',
       branch: task.branch ?? '-',
       touches: touchesOf(task),
+      parentTaskId: task.parentTaskId,
     })),
     overlaps,
     reviewReady,
@@ -107,8 +110,9 @@ export function renderStatusText(view: StatusView): string {
     lines.push('  none');
   } else {
     for (const entry of view.active) {
+      const parent = entry.parentTaskId === null ? '' : `  (child of ${entry.parentTaskId})`;
       lines.push(
-        `  ${entry.taskId.padEnd(10)} ${entry.agent.padEnd(12)} ${entry.branch.padEnd(20)} touches: ${entry.touches}`,
+        `  ${entry.taskId.padEnd(10)} ${entry.agent.padEnd(12)} ${entry.branch.padEnd(20)} touches: ${entry.touches}${parent}`,
       );
     }
   }

--- a/src/db/repositories/tasks.ts
+++ b/src/db/repositories/tasks.ts
@@ -16,6 +16,7 @@ export interface NewTask {
   domains: readonly string[];
   riskTags: readonly string[];
   notes: string | null;
+  parentTaskId: string | null;
 }
 
 /** The declared surface of a claim, updated when an agent re-claims with an
@@ -42,11 +43,11 @@ export function createTaskRepository(db: ConcordDatabase): TaskRepository {
     INSERT INTO tasks (
       task_id, title, owner, agent, branch, worktree,
       expected_files, modules, domains, risk_tags, notes, status,
-      created_at, updated_at
+      parent_task_id, created_at, updated_at
     ) VALUES (
       @task_id, @title, @owner, @agent, @branch, @worktree,
       @expected_files, @modules, @domains, @risk_tags, @notes, @status,
-      @created_at, @updated_at
+      @parent_task_id, @created_at, @updated_at
     )
   `);
   const getStmt = db.prepare('SELECT * FROM tasks WHERE task_id = ?');
@@ -84,6 +85,7 @@ export function createTaskRepository(db: ConcordDatabase): TaskRepository {
         risk_tags: serializeStringArray(task.riskTags),
         notes: task.notes,
         status: 'active',
+        parent_task_id: task.parentTaskId,
         created_at: now,
         updated_at: now,
       });

--- a/src/db/rows.ts
+++ b/src/db/rows.ts
@@ -66,6 +66,8 @@ export interface TaskRecord {
   riskTags: string[];
   notes: string | null;
   status: TaskStatus;
+  /** The parent task this is a subtask of, or null for a top-level task. */
+  parentTaskId: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -83,6 +85,7 @@ const taskDbRowSchema = z.object({
   risk_tags: z.string(),
   notes: z.string().nullable(),
   status: taskStatusSchema,
+  parent_task_id: z.string().nullable(),
   created_at: z.string(),
   updated_at: z.string(),
 });
@@ -102,6 +105,7 @@ export function parseTaskRow(raw: unknown): TaskRecord {
     riskTags: parseStringArray(row.risk_tags),
     notes: row.notes,
     status: row.status,
+    parentTaskId: row.parent_task_id,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -69,4 +69,9 @@ export const migrations: readonly string[] = [
 
   CREATE INDEX idx_reviews_task_id ON reviews(task_id);
   `,
+  // 003 — parent/child task decomposition. A soft reference (no FK): a subtask
+  // may be claimed before or without its parent existing.
+  `
+  ALTER TABLE tasks ADD COLUMN parent_task_id TEXT;
+  `,
 ];

--- a/src/domain/overlap.ts
+++ b/src/domain/overlap.ts
@@ -9,6 +9,9 @@ export interface OverlapSurface {
   modules: readonly string[];
   domains: readonly string[];
   riskTags: readonly string[];
+  /** Parent task, if this is a subtask. A task never overlaps its own parent or
+   * child (their shared surface is expected). */
+  parentTaskId?: string | null;
 }
 
 /** A flagged overlap between a candidate task and one existing task. */
@@ -73,7 +76,13 @@ function surfaceOf(task: TaskRecord): OverlapSurface {
     modules: task.modules,
     domains: task.domains,
     riskTags: task.riskTags,
+    parentTaskId: task.parentTaskId,
   };
+}
+
+/** True when the two tasks are in a direct parent/child relationship. */
+function isParentChild(candidate: OverlapSurface, task: TaskRecord): boolean {
+  return candidate.parentTaskId === task.taskId || task.parentTaskId === candidate.taskId;
 }
 
 function reasonsFor(candidate: OverlapSurface, existing: OverlapSurface): string[] {
@@ -129,7 +138,7 @@ export function detectOverlaps(
 ): OverlapWarning[] {
   const warnings: OverlapWarning[] = [];
   for (const task of existing) {
-    if (task.taskId === candidate.taskId) {
+    if (task.taskId === candidate.taskId || isParentChild(candidate, task)) {
       continue;
     }
     const reasons = reasonsFor(candidate, surfaceOf(task));

--- a/src/domain/schemas.ts
+++ b/src/domain/schemas.ts
@@ -19,6 +19,14 @@ export const claimWorkInputShape = {
     ),
   branch: z.string().optional().describe('Git branch, if known'),
   worktree: z.string().optional().describe('Git worktree path, if used'),
+  parent_task_id: z
+    .string()
+    .optional()
+    .describe(
+      'Parent task id when this is a subtask of a larger effort, e.g. TODO-FRONTEND-001.1 ' +
+        'is a subtask of TODO-FRONTEND-001. Overlaps between a parent and its own child are ' +
+        'not flagged.',
+    ),
   expected_files: z.array(z.string()).optional().describe('Files the task expects to touch'),
   modules: z.array(z.string()).optional().describe('Logical modules touched, e.g. billing'),
   domains: z.array(z.string()).optional().describe('Product domains touched, e.g. payments'),

--- a/src/tools/claim-work.ts
+++ b/src/tools/claim-work.ts
@@ -56,6 +56,9 @@ export function handleClaimWork(repos: Repositories, input: ClaimWorkInput): Cla
 
   const existing = repos.tasks.get(input.task_id);
 
+  // Parent is set at first claim and preserved thereafter (identity is idempotent).
+  const parentTaskId = existing ? existing.parentTaskId : (input.parent_task_id ?? null);
+
   // Effective scope: the merged surface for an existing claim, else the input.
   const scope = {
     expectedFiles: existing ? mergeUnique(existing.expectedFiles, inputFiles) : inputFiles,
@@ -68,7 +71,7 @@ export function handleClaimWork(repos: Repositories, input: ClaimWorkInput): Cla
     .list()
     .filter((task) => task.taskId !== input.task_id && task.status === 'active');
 
-  const overlaps = detectOverlaps({ taskId: input.task_id, ...scope }, activeOthers);
+  const overlaps = detectOverlaps({ taskId: input.task_id, parentTaskId, ...scope }, activeOthers);
 
   const scopeAdded = existing
     ? [
@@ -90,6 +93,7 @@ export function handleClaimWork(repos: Repositories, input: ClaimWorkInput): Cla
       worktree: input.worktree ?? null,
       ...scope,
       notes: input.notes ?? null,
+      parentTaskId,
     });
   } else if (scopeAdded.length > 0) {
     task = repos.tasks.updateScope(input.task_id, scope) ?? existing;
@@ -158,6 +162,7 @@ export function formatClaimWorkText(result: ClaimWorkResult): string {
  * overlap entries, so the payload is internally consistent. */
 export function toClaimWorkStructured(result: ClaimWorkResult): {
   task_id: string;
+  parent_task_id: string | null;
   already_claimed: boolean;
   overlaps: { task_id: string; title: string; reasons: string[] }[];
   checked_against: number;
@@ -166,6 +171,7 @@ export function toClaimWorkStructured(result: ClaimWorkResult): {
 } {
   return {
     task_id: result.task.taskId,
+    parent_task_id: result.task.parentTaskId,
     already_claimed: result.alreadyClaimed,
     overlaps: result.overlaps.map((overlap) => ({
       task_id: overlap.taskId,

--- a/src/tools/handoff.ts
+++ b/src/tools/handoff.ts
@@ -29,6 +29,7 @@ export function handleHandoff(repos: Repositories, input: HandoffInput): Handoff
       domains: [],
       riskTags: [],
       notes: null,
+      parentTaskId: null,
     });
   }
 

--- a/src/tools/review-ready.ts
+++ b/src/tools/review-ready.ts
@@ -32,6 +32,7 @@ export function handleReviewReady(repos: Repositories, input: ReviewReadyInput):
       domains: [],
       riskTags: [],
       notes: null,
+      parentTaskId: null,
     });
   }
 

--- a/test/cli/cli-commands.test.ts
+++ b/test/cli/cli-commands.test.ts
@@ -73,7 +73,7 @@ describe('CLI read/export commands', () => {
 
   it('doctor reports schema version and adoption', () => {
     const report = runDoctor(dir);
-    expect(report).toContain('schema v2, expected v2');
+    expect(report).toContain('schema v3, expected v3');
     expect(report).toContain('TASK-12');
     expect(report).toContain('claim_work: yes');
     // The resolved workspace path is surfaced so agents don't have to hunt for it.

--- a/test/cli/cli-core.test.ts
+++ b/test/cli/cli-core.test.ts
@@ -80,6 +80,24 @@ describe('buildStatus / renderStatusText', () => {
     expect(text).toContain('TASK-12 <-> TASK-14');
   });
 
+  it('annotates a subtask with its parent in the active list', () => {
+    handleClaimWork(repos, {
+      task_id: 'FE-1',
+      title: 'Frontend',
+      modules: ['app-shell'],
+      agent: 'codex',
+    });
+    handleClaimWork(repos, {
+      task_id: 'FE-1.1',
+      title: 'Sub',
+      parent_task_id: 'FE-1',
+      modules: ['todo-ui'],
+      agent: 'codex',
+    });
+    const text = renderStatusText(buildStatus(repos));
+    expect(text).toContain('(child of FE-1)');
+  });
+
   it('surfaces a later overlap to the earlier claimant on read (closes the point-in-time gap)', () => {
     // The first claim sees no overlaps — nobody else was active yet (#29).
     const first = handleClaimWork(repos, {

--- a/test/db/connection.test.ts
+++ b/test/db/connection.test.ts
@@ -8,7 +8,7 @@ describe('openDatabase', () => {
   it('applies all migrations (user_version at head) and creates tables', () => {
     const db = openDatabase(':memory:');
     const version: unknown = db.pragma('user_version', { simple: true });
-    expect(version).toBe(2);
+    expect(version).toBe(3);
 
     const raw: unknown = db.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all();
     const names = new Set(
@@ -44,6 +44,7 @@ describe('row parsing', () => {
       risk_tags: '[]',
       notes: null,
       status: 'active',
+      parent_task_id: null,
       created_at: '2026-07-17T00:00:00.000Z',
       updated_at: '2026-07-17T00:00:00.000Z',
     });

--- a/test/db/storage.test.ts
+++ b/test/db/storage.test.ts
@@ -20,6 +20,7 @@ const baseTask = {
   domains: ['payments'],
   riskTags: ['payment-flow'],
   notes: null,
+  parentTaskId: null,
 } as const;
 
 describe('migrations', () => {
@@ -38,7 +39,7 @@ describe('migrations', () => {
   it('is idempotent when reopening (user_version already at head)', () => {
     const { db } = newRepos();
     const version: unknown = db.pragma('user_version', { simple: true });
-    expect(version).toBe(2);
+    expect(version).toBe(3);
   });
 });
 
@@ -87,6 +88,13 @@ describe('task repository', () => {
     expect(updated?.expectedFiles).toEqual(['src/a.ts', 'src/b.ts']);
     expect(updated?.modules).toEqual(['billing', 'stripe']);
     expect(repos.tasks.get('TASK-12')?.domains).toEqual(['payments']);
+  });
+
+  it('persists a parent task id (null for top-level tasks)', () => {
+    repos.tasks.create({ ...baseTask, taskId: 'PARENT' });
+    repos.tasks.create({ ...baseTask, taskId: 'CHILD', parentTaskId: 'PARENT' });
+    expect(repos.tasks.get('CHILD')?.parentTaskId).toBe('PARENT');
+    expect(repos.tasks.get('PARENT')?.parentTaskId).toBeNull();
   });
 });
 

--- a/test/domain/overlap.test.ts
+++ b/test/domain/overlap.test.ts
@@ -17,6 +17,7 @@ function task(partial: Partial<TaskRecord> & { taskId: string }): TaskRecord {
     riskTags: partial.riskTags ?? [],
     notes: null,
     status: partial.status ?? 'active',
+    parentTaskId: partial.parentTaskId ?? null,
     createdAt: '2026-07-17T00:00:00.000Z',
     updatedAt: '2026-07-17T00:00:00.000Z',
   };
@@ -124,6 +125,36 @@ describe('detectOverlaps', () => {
   it('never flags a task against itself', () => {
     expect(detectOverlaps(candidate, [task({ taskId: 'TASK-A', modules: ['billing'] })])).toEqual(
       [],
+    );
+  });
+
+  it('does not flag a task against its own parent or child (but still flags others)', () => {
+    const child: OverlapSurface = {
+      taskId: 'FE-1.1',
+      parentTaskId: 'FE-1',
+      expectedFiles: [],
+      modules: ['app-shell'],
+      domains: [],
+      riskTags: [],
+    };
+    // Shares a module with its parent — expected, so not flagged.
+    expect(detectOverlaps(child, [task({ taskId: 'FE-1', modules: ['app-shell'] })])).toEqual([]);
+    // The reverse direction (parent candidate vs child) is also excluded.
+    const parent: OverlapSurface = {
+      taskId: 'FE-1',
+      expectedFiles: [],
+      modules: ['app-shell'],
+      domains: [],
+      riskTags: [],
+    };
+    expect(
+      detectOverlaps(parent, [
+        task({ taskId: 'FE-1.1', modules: ['app-shell'], parentTaskId: 'FE-1' }),
+      ]),
+    ).toEqual([]);
+    // An unrelated task sharing the module is still flagged.
+    expect(detectOverlaps(child, [task({ taskId: 'OTHER', modules: ['app-shell'] })])).toHaveLength(
+      1,
     );
   });
 });

--- a/test/tools/claim-work.test.ts
+++ b/test/tools/claim-work.test.ts
@@ -180,4 +180,29 @@ describe('handleClaimWork', () => {
     // No camelCase leak inside the overlap entries.
     expect(JSON.stringify(structured)).not.toContain('taskId');
   });
+
+  it('records a parent task id and does not flag overlaps with its own parent', () => {
+    handleClaimWork(repos, { task_id: 'FE-1', title: 'Frontend', modules: ['app-shell'] });
+    const child = handleClaimWork(repos, {
+      task_id: 'FE-1.1',
+      title: 'App shell subtask',
+      parent_task_id: 'FE-1',
+      modules: ['app-shell'],
+    });
+    expect(child.task.parentTaskId).toBe('FE-1');
+    expect(toClaimWorkStructured(child).parent_task_id).toBe('FE-1');
+    // Shares a module with its parent, but that is expected — not flagged.
+    expect(child.overlaps).toEqual([]);
+  });
+
+  it('still flags overlaps between a subtask and unrelated (non-parent) tasks', () => {
+    handleClaimWork(repos, { task_id: 'OTHER', title: 'Other', modules: ['app-shell'] });
+    const child = handleClaimWork(repos, {
+      task_id: 'FE-1.1',
+      title: 'Sub',
+      parent_task_id: 'FE-1',
+      modules: ['app-shell'],
+    });
+    expect(child.overlaps.some((overlap) => overlap.taskId === 'OTHER')).toBe(true);
+  });
 });


### PR DESCRIPTION
## What & why

Lets a large effort decompose into trackable subtasks, each with its own claim and handoff — the data-model half of the decomposition work started in #31 (the nudge shipped in #31; this is the follow-up split out to #36).

Closes #36.

## Changes

- **Schema migration 003 (v2 → v3)**: adds a nullable `parent_task_id` column to `tasks`. It's a **soft reference** (no FK) — a subtask may be claimed before or without its parent existing.
- **Threads `parentTaskId`** through row parsing (Zod), `NewTask`, the task repository INSERT, the `claim_work` input schema (`parent_task_id`), the `claim_work` structured output, and the `WORK_STATE.json` artifact.
- **Overlap detection** no longer flags a task against its own **parent or child** (their shared surface is expected). Unrelated tasks — and siblings under the same parent — still flag.
- **`concord status`** annotates a subtask as `(child of <parent>)` in the active list.

## Testing

- `pnpm format:check` (changed files) ✅ · `pnpm lint` ✅ · `pnpm typecheck` ✅ · `pnpm test` ✅ (93 passed) · `pnpm build` ✅
- New tests: `tasks` persists `parent_task_id` (null for top-level); overlap excludes parent↔child both directions but still flags others; `claim_work` records the parent and skips parent overlaps but flags non-parents; `status` shows `(child of …)`; schema-version assertions bumped to v3.
- **Live migration test**: hand-built a v2 database with a legacy row, reopened it with the current code → `user_version` upgraded to 3, the legacy row read cleanly (`parentTaskId: null`, data preserved), and a new subtask of it worked with no false parent overlap.

## Scope

16 files, +133/−8 LOC — mostly one-line threads of the new field. Under the 600-LOC limit. First schema migration since v2; existing databases upgrade in place.
