### PR TITLE
feat: fold review_ready into handoff (#28)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,10 @@ shared work-state: agents **claim work**, leave **handoffs**, and generate
 **review packets** before opening PRs. SQLite is the source of truth; human-
 readable markdown artifacts are rendered from it for PR visibility.
 
-The v0 surface is intentionally three MCP tools: `claim_work`, `handoff`,
-`review_ready`. Do not add more tools without explicit product pull.
+The surface is intentionally two MCP tools: `claim_work` and `handoff` (plus the
+read-only `get_work_state`). Review packets are produced by `handoff` with
+`ready_for_review` set, not a separate tool. Do not add more tools without
+explicit product pull.
 
 ## Coding rules (non-negotiable)
 
@@ -65,7 +67,8 @@ src/
   config/paths.ts     .concord/ resolution, repo-root discovery
   db/                 SQLite: connection, schema, row parsers, repositories
   domain/             types, Zod input schemas, overlap detection (pure logic)
-  tools/              the 3 MCP tools (thin adapters over domain + db)
+  tools/              MCP tools: claim_work, handoff (+ get_work_state read);
+                      review-ready.ts is a handoff-invoked helper, not a tool
   artifacts/          render HANDOFF.md / REVIEW_PACKET.md / WORK_STATE.json
   install/            per-client instruction writers
   cli/                commander CLI                     [bin: concord]

--- a/src/domain/schemas.ts
+++ b/src/domain/schemas.ts
@@ -49,6 +49,22 @@ export const handoffInputShape = {
   guardrails_checked: z.array(z.string()).optional().describe('Guardrails manually checked'),
   needs_review_from: z.array(z.string()).optional().describe('Who should review'),
   next_steps: z.array(z.string()).optional().describe('Remaining work or follow-ups'),
+  ready_for_review: z
+    .boolean()
+    .optional()
+    .describe(
+      'Set true when this handoff also marks the task ready for review (before a PR). ' +
+        'This renders REVIEW_PACKET.md from the handoff.',
+    ),
+  diff_size: z
+    .string()
+    .optional()
+    .describe('Rough diff size for the review packet, e.g. "+120 / -30"'),
+  open_questions: z.array(z.string()).optional().describe('Unresolved questions for the reviewer'),
+  provenance: z
+    .array(z.object({ field: z.string(), source: z.string() }))
+    .optional()
+    .describe('Where each claim came from, e.g. { field: "tests", source: "command output" }'),
 } as const;
 
 export const handoffInputSchema = z.object(handoffInputShape);

--- a/src/install/instructions.ts
+++ b/src/install/instructions.ts
@@ -10,9 +10,9 @@ This project uses Concord MCP. Use its tools so your work is visible before PRs:
   files/modules you expect to touch. Concord warns about overlaps with other
   active work.
 - **Before finishing or when blocked**, call \`handoff\` with what changed, tests
-  run, assumptions, decisions, and guardrails you checked.
-- **Before opening a PR**, call \`review_ready\` with a plan summary, tests, open
-  questions, and provenance.
+  run, assumptions, decisions, and guardrails you checked. **Before a PR**, set
+  \`ready_for_review\` (with open questions and provenance) to also produce a
+  review packet.
 
 Concord regenerates human-readable \`HANDOFF.md\` and \`REVIEW_PACKET.md\` in
 \`.concord/\` so humans can review your work.

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,7 +4,6 @@ import type { Repositories } from './db/index.js';
 import { registerClaimWork } from './tools/claim-work.js';
 import { registerWorkState } from './tools/get-work-state.js';
 import { registerHandoff } from './tools/handoff.js';
-import { registerReviewReady } from './tools/review-ready.js';
 import { VERSION } from './version.js';
 
 /** Concord's advertised MCP server version. */
@@ -30,6 +29,5 @@ export function createServer(repos: Repositories, options: ServerOptions = {}): 
   };
   registerClaimWork(server, repos, onWrite);
   registerHandoff(server, repos, onWrite);
-  registerReviewReady(server, repos, onWrite);
   return server;
 }

--- a/src/tools/handoff.ts
+++ b/src/tools/handoff.ts
@@ -2,10 +2,13 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import type { HandoffRecord, Repositories } from '../db/index.js';
 import { handoffInputShape, type HandoffInput } from '../domain/schemas.js';
+import { handleReviewReady } from './review-ready.js';
 
 export interface HandoffResult {
   handoff: HandoffRecord;
   taskAutoCreated: boolean;
+  /** True when `ready_for_review` was set, so a review packet was also produced. */
+  reviewReady: boolean;
 }
 
 /**
@@ -47,7 +50,6 @@ export function handleHandoff(repos: Repositories, input: HandoffInput): Handoff
     nextSteps: input.next_steps ?? [],
   });
 
-  repos.tasks.updateStatus(input.task_id, 'handed_off');
   repos.events.record({
     taskId: input.task_id,
     tool: 'handoff',
@@ -55,7 +57,26 @@ export function handleHandoff(repos: Repositories, input: HandoffInput): Handoff
     detail: input.status,
   });
 
-  return { handoff, taskAutoCreated };
+  // Folding review_ready into handoff: when flagged, produce the review packet
+  // (and set status review_ready) via the shared review handler. Otherwise the
+  // task is simply handed off.
+  const reviewReady = input.ready_for_review === true;
+  if (reviewReady) {
+    handleReviewReady(repos, {
+      task_id: input.task_id,
+      plan_summary: input.what_changed,
+      tests_run: input.tests_run,
+      diff_size: input.diff_size,
+      guardrails_checked: input.guardrails_checked,
+      assumptions: input.assumptions,
+      open_questions: input.open_questions,
+      provenance: input.provenance,
+    });
+  } else {
+    repos.tasks.updateStatus(input.task_id, 'handed_off');
+  }
+
+  return { handoff, taskAutoCreated, reviewReady };
 }
 
 export function formatHandoffText(result: HandoffResult): string {
@@ -67,6 +88,9 @@ export function formatHandoffText(result: HandoffResult): string {
   lines.push(`Changed files: ${String(handoff.changedFiles.length)}`);
   if (handoff.needsReviewFrom.length > 0) {
     lines.push(`Needs review from: ${handoff.needsReviewFrom.join(', ')}`);
+  }
+  if (result.reviewReady) {
+    lines.push('Marked review-ready; REVIEW_PACKET.md regenerated.');
   }
   return lines.join('\n');
 }
@@ -82,7 +106,8 @@ export function registerHandoff(
       title: 'Hand off work',
       description:
         'Record a concise handoff when an agent finishes or is blocked: what changed, ' +
-        'tests run, assumptions, decisions, and guardrails checked. Call this before finishing.',
+        'tests run, assumptions, decisions, and guardrails checked. Call this before finishing. ' +
+        'Set ready_for_review before a PR to also produce a review packet.',
       inputSchema: handoffInputShape,
     },
     (args) => {
@@ -94,6 +119,7 @@ export function registerHandoff(
           task_id: result.handoff.taskId,
           handoff_id: result.handoff.id,
           task_auto_created: result.taskAutoCreated,
+          review_ready: result.reviewReady,
         },
       };
     },

--- a/src/tools/review-ready.ts
+++ b/src/tools/review-ready.ts
@@ -1,7 +1,5 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-
 import type { ProvenanceEntry, Repositories, ReviewRecord } from '../db/index.js';
-import { reviewReadyInputShape, type ReviewReadyInput } from '../domain/schemas.js';
+import { type ReviewReadyInput } from '../domain/schemas.js';
 
 export interface ReviewReadyResult {
   review: ReviewRecord;
@@ -13,8 +11,9 @@ function toProvenance(entries: ReviewReadyInput['provenance']): ProvenanceEntry[
 }
 
 /**
- * Record a review packet for a task and mark the task review-ready. Like
- * handoff, this auto-creates a stub task if the work was never claimed.
+ * Record a review packet for a task and mark the task review-ready. Invoked by
+ * `handoff` when `ready_for_review` is set (review_ready is no longer a separate
+ * tool). Auto-creates a stub task if the work was never claimed.
  */
 export function handleReviewReady(repos: Repositories, input: ReviewReadyInput): ReviewReadyResult {
   const existing = repos.tasks.get(input.task_id);
@@ -68,34 +67,4 @@ export function formatReviewReadyText(result: ReviewReadyResult): string {
   lines.push(`Guardrails checked: ${String(review.guardrailsChecked.length)}`);
   lines.push(`Open questions: ${String(review.openQuestions.length)}`);
   return lines.join('\n');
-}
-
-export function registerReviewReady(
-  server: McpServer,
-  repos: Repositories,
-  onWrite?: () => void,
-): void {
-  server.registerTool(
-    'review_ready',
-    {
-      title: 'Mark review-ready',
-      description:
-        'Record review evidence before a PR: plan summary, tests run, diff size, guardrails ' +
-        'checked, assumptions, open questions, and provenance. Call this before opening a PR.',
-      inputSchema: reviewReadyInputShape,
-    },
-    (args) => {
-      const result = handleReviewReady(repos, args);
-      onWrite?.();
-      return {
-        content: [{ type: 'text', text: formatReviewReadyText(result) }],
-        structuredContent: {
-          task_id: result.review.taskId,
-          review_id: result.review.id,
-          open_questions: result.review.openQuestions.length,
-          task_auto_created: result.taskAutoCreated,
-        },
-      };
-    },
-  );
 }

--- a/test/tools/handoff.test.ts
+++ b/test/tools/handoff.test.ts
@@ -52,4 +52,40 @@ describe('handleHandoff', () => {
     });
     expect(formatHandoffText(result)).toContain('Needs review from: alex, sam');
   });
+
+  it('produces a review packet when ready_for_review is set (folded review_ready)', () => {
+    handleClaimWork(repos, { task_id: 'TASK-12', title: 'Retry', modules: ['billing'] });
+    const result = handleHandoff(repos, {
+      task_id: 'TASK-12',
+      status: 'done',
+      what_changed: 'Queued retries',
+      ready_for_review: true,
+      tests_run: ['pnpm test'],
+      open_questions: ['Sync or queued?'],
+      diff_size: '+40 / -5',
+    });
+
+    expect(result.reviewReady).toBe(true);
+    // Task is review-ready, and a review record was written from the handoff.
+    expect(repos.tasks.get('TASK-12')?.status).toBe('review_ready');
+    const review = repos.reviews.latestForTask('TASK-12');
+    expect(review?.planSummary).toBe('Queued retries');
+    expect(review?.openQuestions).toEqual(['Sync or queued?']);
+    expect(review?.diffSize).toBe('+40 / -5');
+    // Both handoff and review_ready adoption are recorded.
+    expect(repos.events.listByTask('TASK-12').map((e) => e.tool)).toEqual([
+      'claim_work',
+      'handoff',
+      'review_ready',
+    ]);
+    expect(formatHandoffText(result)).toContain('Marked review-ready');
+  });
+
+  it('does not produce a review packet on a plain handoff', () => {
+    handleClaimWork(repos, { task_id: 'TASK-12', title: 'Retry' });
+    const result = handleHandoff(repos, { task_id: 'TASK-12', status: 'done', what_changed: 'x' });
+    expect(result.reviewReady).toBe(false);
+    expect(repos.tasks.get('TASK-12')?.status).toBe('handed_off');
+    expect(repos.reviews.latestForTask('TASK-12')).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## What & why

In the dogfooding session **no agent ever called `review_ready`** — across both clients, all work stopped at `handoff`. The separate pre-PR step didn't match how agents actually finish. Per the decision on #28, fold review readiness into `handoff` so it rides the step agents already take.

Closes #28.

## Changes

- **`handoff` gains `ready_for_review`** (plus `diff_size`, `open_questions`, `provenance`). When set, the handoff also produces the review packet and marks the task `review_ready`, delegating to the existing review handler. Otherwise the task is simply handed off. `handoff`'s structured output now includes `review_ready`.
- **The `review_ready` MCP tool is removed.** The surface is now two write tools — `claim_work` and `handoff` — plus the read-only `get_work_state`. The review handler stays as an internal helper invoked by `handoff`; the `reviews` table, `REVIEW_PACKET.md` rendering, `concord status`, and adoption tracking are all unchanged (a `ready_for_review` handoff still records a `review_ready` event, so adoption reflects it).
- Installed instructions and `CLAUDE.md` updated to describe the two-tool surface.

## ⚠️ Breaking change

The `review_ready` MCP tool no longer exists. Callers use `handoff({ status: 'done', ready_for_review: true, ... })` instead. (Pre-1.0; the CLI `concord review-packet` is unchanged.)

## Testing

- `pnpm format:check` (changed files + CLAUDE.md) ✅ · `pnpm lint` ✅ · `pnpm typecheck` ✅ · `pnpm test` ✅ (95 passed) · `pnpm build` ✅
- New handoff tests: `ready_for_review` produces a review record (plan/open-questions/diff-size), sets `review_ready`, records both `handoff` + `review_ready` adoption events; a plain handoff produces no review packet and stays `handed_off`.
- Existing review/artifact/status tests still pass (the review handler + reviews infra are unchanged).
- **End-to-end**: an in-memory MCP client's tool list is now `claim_work, get_work_state, handoff` (no `review_ready`); a `handoff({ ready_for_review: true })` renders `REVIEW_PACKET.md`.

## Scope

7 files. Reuses the existing review infrastructure — no schema change, no new dependencies.
