### PR TITLE
chore(release): 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-ai/concord-mcp",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Shared work-state for coding agents: claim work, leave handoffs, and generate review packets before PRs, over MCP.",
   "keywords": [
     "mcp",
@@ -45,6 +45,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "version": "node scripts/sync-version.mjs && git add src/version.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "demo": "pnpm build && node examples/two-agent-overlap/demo.mjs",

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -1,0 +1,12 @@
+// Regenerate src/version.ts from package.json so the CLI/server never report a
+// version that has drifted from the published package. Wired to the `version`
+// npm lifecycle script, so it runs automatically during `npm version <x>`.
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const root = new URL('../', import.meta.url);
+const pkg = JSON.parse(readFileSync(new URL('package.json', root), 'utf8'));
+
+writeFileSync(
+  new URL('src/version.ts', root),
+  `/** Single source of truth for the package version, shared by the CLI and server. */\nexport const VERSION = '${pkg.version}';\n`,
+);

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 /** Single source of truth for the package version, shared by the CLI and server. */
-export const VERSION = '0.1.0';
+export const VERSION = '0.2.0';


### PR DESCRIPTION
Prepares the first release since v0.1.1.

## Version
- **0.1.1 → 0.2.0** — minor bump: pre-1.0 with a breaking change (`review_ready` tool removed in #28).
- **Fixes the version drift**: `src/version.ts` was stuck at `0.1.0` while the package was `0.1.1` (why `concord --version` mis-reported). Now synced to 0.2.0; the built CLI reports `0.2.0`.
- **Adds a `version` npm script** (`node scripts/sync-version.mjs && git add src/version.ts`) that regenerates `src/version.ts` from `package.json`, so future `npm version <x>` bumps can't let the two drift again.

## What 0.2.0 ships (since v0.1.1)
#29 point-in-time overlaps · #30 token overlap matching · #31 decomposition nudge · #27 `get_work_state` tool + resource · #32 edit-time enforcement + live push (`concord check`/`watch`/hook, MCP `resources/updated`) · #33 re-claim scope feedback + polish · #36 parent/child tasks (schema v2→v3) · **#28 fold `review_ready` into `handoff` (breaking)**.

## After merge
Tag `v0.2.0` on main and push it — `release.yml` runs the gate and publishes to npm via OIDC, then cuts a GitHub Release.

Gate: format ✅ lint ✅ typecheck ✅ test ✅ (95) build ✅; built CLI reports `0.2.0`.