### PR TITLE
Ignore Concord workspace during init

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,14 @@ setup:
 
 ## What you get
 
-SQLite is the local source of truth (gitignored). Concord renders human-readable
-artifacts you can commit so they show up in PRs:
+SQLite is the local source of truth. `concord init` adds `.concord/` to the
+repository's `.gitignore`, so the generated workspace stays local by default.
+Teams that want selected artifacts in PRs can remove that rule or force-add the
+human-readable files:
 
 ```text
 .concord/
-├── concord.db          local source of truth (gitignored)
+├── concord.db          local source of truth
 ├── HANDOFF.md          human-readable handoff
 ├── REVIEW_PACKET.md    review-ready evidence
 └── WORK_STATE.json     generated export (optional)

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -1,11 +1,29 @@
 import type { Command } from '@commander-js/extra-typings';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 import { writeArtifacts } from '../../artifacts/index.js';
 import { openContext } from '../context.js';
 
+const CONCORD_GITIGNORE_ENTRY = '.concord/';
+
+/** Ensure Concord's generated workspace is ignored without changing other rules. */
+export function ensureConcordIgnored(repoRoot: string): void {
+  const gitignorePath = join(repoRoot, '.gitignore');
+  const current = existsSync(gitignorePath) ? readFileSync(gitignorePath, 'utf8') : '';
+  const entries = current.split(/\r?\n/u).map((line) => line.trim());
+  if (entries.includes(CONCORD_GITIGNORE_ENTRY)) {
+    return;
+  }
+
+  const separator = current.length > 0 && !current.endsWith('\n') ? '\n' : '';
+  writeFileSync(gitignorePath, `${current}${separator}${CONCORD_GITIGNORE_ENTRY}\n`);
+}
+
 /** Create the local `.concord/` workspace and return its path. */
 export function runInit(cwd: string): string {
   const ctx = openContext(cwd);
+  ensureConcordIgnored(ctx.repoRoot);
   writeArtifacts(ctx.concordPath, ctx.repos);
   return ctx.concordPath;
 }

--- a/test/cli/cli-core.test.ts
+++ b/test/cli/cli-core.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -25,6 +25,18 @@ describe('runInit', () => {
     expect(concordPath).toBe(join(dir, '.concord'));
     expect(existsSync(join(concordPath, 'concord.db'))).toBe(true);
     expect(existsSync(join(concordPath, 'WORK_STATE.json'))).toBe(true);
+    expect(readFileSync(join(dir, '.gitignore'), 'utf8')).toBe('.concord/\n');
+  });
+
+  it('preserves existing gitignore rules and adds the Concord entry once', () => {
+    const dir = repoDir();
+    const gitignorePath = join(dir, '.gitignore');
+    writeFileSync(gitignorePath, 'node_modules/');
+
+    runInit(dir);
+    runInit(dir);
+
+    expect(readFileSync(gitignorePath, 'utf8')).toBe('node_modules/\n.concord/\n');
   });
 });
 


### PR DESCRIPTION
## Summary
- add `.concord/` to the repository-root `.gitignore` during `concord init`
- preserve existing ignore rules and avoid duplicate entries
- document that generated artifacts stay local by default

## Tests
- `pnpm test` (96 passed)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec prettier --check README.md src/cli/commands/init.ts test/cli/cli-core.test.ts`
- `pnpm build`
- `git diff --check`