### PR TITLE
feat: add task-scoped memory tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-23
+
+### Added
+
+- Task-scoped memory with typed `update_task` entries for intent, progress,
+  assumptions, decisions, questions, answers, blockers, and findings.
+- `get_task_context` for reading a task's ordered updates, latest handoff and
+  review evidence, and current overlap warnings.
+
+## [0.2.0] - 2026-07-22
+
+### Added
+
+- Read-only work-state tool and resource, change notifications, overlap
+  enforcement commands, task decomposition, and normalized overlap matching.
+
+### Changed
+
+- Review readiness is now part of `handoff` via `ready_for_review`.
+
 ## [0.1.1]
 
 ### Changed
@@ -27,6 +47,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `concord install` writes usage instructions for Claude Code, Codex, and Cursor.
 - Two-agent overlap demo (`pnpm demo`).
 
-[Unreleased]: https://github.com/Get-Concord-AI/concord-mcp/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/Get-Concord-AI/concord-mcp/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/Get-Concord-AI/concord-mcp/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/Get-Concord-AI/concord-mcp/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/Get-Concord-AI/concord-mcp/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/Get-Concord-AI/concord-mcp/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,14 +7,15 @@ before making changes.
 ## What this project is
 
 `concord-mcp` is a local MCP server plus a `concord` CLI that gives coding agents
-shared work-state: agents **claim work**, leave **handoffs**, and generate
-**review packets** before opening PRs. SQLite is the source of truth; human-
-readable markdown artifacts are rendered from it for PR visibility.
+shared work-state: agents **claim work**, share typed **task context**, leave
+**handoffs**, and generate **review packets** before opening PRs. SQLite is the
+source of truth; human-readable markdown artifacts are rendered from it for PR
+visibility.
 
-The surface is intentionally two MCP tools: `claim_work` and `handoff` (plus the
-read-only `get_work_state`). Review packets are produced by `handoff` with
-`ready_for_review` set, not a separate tool. Do not add more tools without
-explicit product pull.
+The surface is intentionally five MCP tools: `get_work_state`, `claim_work`,
+`update_task`, `get_task_context`, and `handoff`. Review packets are produced by
+`handoff` with `ready_for_review` set, not a separate tool. Do not add more tools
+without explicit product pull.
 
 ## Coding rules (non-negotiable)
 
@@ -67,8 +68,8 @@ src/
   config/paths.ts     .concord/ resolution, repo-root discovery
   db/                 SQLite: connection, schema, row parsers, repositories
   domain/             types, Zod input schemas, overlap detection (pure logic)
-  tools/              MCP tools: claim_work, handoff (+ get_work_state read);
-                      review-ready.ts is a handoff-invoked helper, not a tool
+  tools/              five-tool MCP surface; review-ready.ts is a
+                      handoff-invoked helper, not a registered tool
   artifacts/          render HANDOFF.md / REVIEW_PACKET.md / WORK_STATE.json
   install/            per-client instruction writers
   cli/                commander CLI                     [bin: concord]

--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@
 
 **Shared work-state for coding agents.** Concord MCP gives Claude Code, Codex,
 Cursor, and other MCP-capable coding assistants a shared work log. Agents can
-claim work, leave handoffs, and generate review-ready packets before opening PRs.
+claim work, share task context, leave handoffs, and generate review-ready
+packets before opening PRs.
 
-> ⚠️ Early and under active development. The v0 surface is three MCP tools:
-> `claim_work`, `handoff`, and `review_ready`.
+> ⚠️ Early and under active development. The surface is five focused MCP tools:
+> `get_work_state`, `claim_work`, `update_task`, `get_task_context`, and
+> `handoff`.
 
 ## Why
 
@@ -40,13 +42,15 @@ setup:
 > Concord works through MCP tools plus the installed instructions on any
 > MCP-capable client.
 
-## The three tools
+## The five tools
 
-| Tool           | When                 | What it does                                                                     |
-| -------------- | -------------------- | -------------------------------------------------------------------------------- |
-| `claim_work`   | before editing       | records the task + expected files/modules; flags overlaps with other active work |
-| `handoff`      | when done or blocked | captures what changed, tests run, assumptions, decisions, guardrails             |
-| `review_ready` | before a PR          | records plan, tests, open questions, and provenance                              |
+| Tool               | When                     | What it does                                                                     |
+| ------------------ | ------------------------ | -------------------------------------------------------------------------------- |
+| `get_work_state`   | before choosing work     | shows active tasks, overlaps, review-ready work, and open questions              |
+| `claim_work`       | before editing           | records the task + expected files/modules; flags overlaps with other active work |
+| `update_task`      | while working            | appends typed intent, progress, decisions, questions, blockers, and findings     |
+| `get_task_context` | resuming or coordinating | returns the task, ordered updates, handoff, review evidence, and live overlaps   |
+| `handoff`          | done, blocked, or pre-PR | captures evidence; `ready_for_review` also produces the review packet            |
 
 ## What you get
 
@@ -83,14 +87,15 @@ concord doctor               # workspace checks + per-task tool adoption
 pnpm demo
 ```
 
-Runs the [two-agent overlap demo](./examples/two-agent-overlap/): two agents claim
-overlapping work (Concord flags it), then one hands off and marks the task
-review-ready — printing the generated artifacts.
+Runs the [two-agent overlap demo](./examples/two-agent-overlap/): two agents
+claim overlapping work, share and read task context, then one hands off and
+marks the task review-ready.
 
 ## What this is / is not
 
-Shared work-state and guardrails for the coding agents you already use. **Not** an
-orchestrator, code reviewer, memory vector DB, or autonomous coding agent.
+Shared work-state and task memory for coding agents using the same local
+checkout. **Not** an orchestrator, code reviewer, hosted sync service, memory
+vector DB, or autonomous coding agent.
 
 See also: [Why not just use markdown?](./docs/why-not-markdown.md)
 

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -32,14 +32,16 @@ claude mcp add concord -- concord-mcp
 concord install
 ```
 
-This writes a Concord block into `CLAUDE.md` telling the agent when to call
-`claim_work`, `handoff`, and `review_ready`. It preserves any existing content
-and is safe to re-run.
+This writes a Concord block into `CLAUDE.md` telling the agent when to claim
+work, share task context, and hand off. It preserves any existing content and is
+safe to re-run.
 
 ## 4. Use it
 
-Ask Claude to start a task. It should call `claim_work` before editing, then
-`handoff` and `review_ready` before opening a PR. Check progress with:
+Ask Claude to start a task. It should call `claim_work` before editing,
+`update_task` while working, and `get_task_context` when resuming or
+coordinating. Before a PR it calls `handoff` with `ready_for_review`. Check
+progress with:
 
 ```bash
 concord status

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -24,12 +24,13 @@ concord install
 ```
 
 This writes a Concord block into `AGENTS.md` (and `.codex/concord.md`) describing
-when to call `claim_work`, `handoff`, and `review_ready`. It is idempotent.
+when to claim work, share task context, and hand off. It is idempotent.
 
 ## 4. Use it
 
-Codex should call `claim_work` before editing and `handoff` / `review_ready`
-before a PR. Track it from your terminal:
+Codex should call `claim_work` before editing, `update_task` while working, and
+`get_task_context` when resuming or coordinating. Before a PR it calls `handoff`
+with `ready_for_review`. Track it from your terminal:
 
 ```bash
 concord status

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -27,7 +27,7 @@ concord install
 ```
 
 This writes `.cursor/rules/concord.mdc` (with `alwaysApply: true`) so the agent
-knows when to call `claim_work`, `handoff`, and `review_ready`. It is idempotent.
+knows when to claim work, share task context, and hand off. It is idempotent.
 
 ## 4. Use it
 

--- a/docs/why-not-markdown.md
+++ b/docs/why-not-markdown.md
@@ -15,8 +15,9 @@ Markdown handoff files are:
 
 Concord keeps the good parts and fixes those gaps:
 
-- **Structured** — agents record work through `claim_work`, `handoff`, and
-  `review_ready`, so the data is consistent and queryable.
+- **Structured** — agents record work through validated lifecycle tools,
+  including `claim_work`, `update_task`, and `handoff`, so the data is
+  consistent and queryable.
 - **Shared early** — `claim_work` flags overlaps between active tasks before
   either PR exists.
 - **Visible to humans** — Concord still produces `HANDOFF.md` and

--- a/examples/two-agent-overlap/demo.mjs
+++ b/examples/two-agent-overlap/demo.mjs
@@ -49,6 +49,23 @@ console.log(
   '\n',
 );
 
+console.log('$ claude-code records task context as it works');
+console.log(
+  await call('update_task', {
+    task_id: 'TASK-12',
+    kind: 'intent',
+    content: 'Keep checkout responsive when Stripe retries are needed',
+  }),
+);
+console.log(
+  await call('update_task', {
+    task_id: 'TASK-12',
+    kind: 'decision',
+    content: 'Use a queued retry so user-path calls never block checkout',
+  }),
+  '\n',
+);
+
 console.log('$ codex claims TASK-14 (also touches billing)');
 console.log(
   await call('claim_work', {
@@ -61,7 +78,10 @@ console.log(
   '\n',
 );
 
-console.log('$ claude-code hands off TASK-12');
+console.log('$ codex reads TASK-12 context before coordinating');
+console.log(await call('get_task_context', { task_id: 'TASK-12' }), '\n');
+
+console.log('$ claude-code hands off TASK-12 and marks it review-ready');
 console.log(
   await call('handoff', {
     task_id: 'TASK-12',
@@ -71,16 +91,7 @@ console.log(
     tests_run: ['pnpm test billing'],
     decisions: ['Use a queued retry so user-path calls never block checkout'],
     needs_review_from: ['payments-team'],
-  }),
-  '\n',
-);
-
-console.log('$ claude-code marks TASK-12 review-ready');
-console.log(
-  await call('review_ready', {
-    task_id: 'TASK-12',
-    plan_summary: 'Queue Stripe retries instead of blocking checkout',
-    tests_run: ['pnpm test billing'],
+    ready_for_review: true,
     diff_size: '+120 / -30',
     guardrails_checked: ['Stripe changes covered by an artificial payment test'],
     open_questions: ['Notify the account owner immediately or only after the final retry?'],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@concord-ai/concord-mcp",
   "version": "0.2.0",
-  "description": "Shared work-state for coding agents: claim work, leave handoffs, and generate review packets before PRs, over MCP.",
+  "description": "Shared work-state and task memory for coding agents: coordinate work, preserve decisions, and hand off through MCP.",
   "keywords": [
     "mcp",
     "model-context-protocol",

--- a/src/cli/commands/review-packet.ts
+++ b/src/cli/commands/review-packet.ts
@@ -12,7 +12,7 @@ export function runReviewPacket(cwd: string, taskId: string): string {
   }
   const review = ctx.repos.reviews.latestForTask(taskId);
   if (review === undefined) {
-    return `No review packet for ${taskId}. Ask the agent to call the review_ready tool.`;
+    return `No review packet for ${taskId}. Ask the agent to call handoff with ready_for_review.`;
   }
   return renderReviewPacketMarkdown(task, review, ctx.repos.handoffs.latestForTask(taskId));
 }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -2,6 +2,10 @@ import { openDatabase, type ConcordDatabase } from './connection.js';
 import { createEventRepository, type EventRepository } from './repositories/events.js';
 import { createHandoffRepository, type HandoffRepository } from './repositories/handoffs.js';
 import { createReviewRepository, type ReviewRepository } from './repositories/reviews.js';
+import {
+  createTaskUpdateRepository,
+  type TaskUpdateRepository,
+} from './repositories/task-updates.js';
 import { createTaskRepository, type TaskRepository } from './repositories/tasks.js';
 
 export type { ConcordDatabase } from './connection.js';
@@ -9,6 +13,7 @@ export { openDatabase } from './connection.js';
 export type { NewTask, TaskRepository } from './repositories/tasks.js';
 export type { NewHandoff, HandoffRepository } from './repositories/handoffs.js';
 export type { NewReview, ReviewRepository } from './repositories/reviews.js';
+export type { NewTaskUpdate, TaskUpdateRepository } from './repositories/task-updates.js';
 export type { NewEvent, EventRepository } from './repositories/events.js';
 export type {
   TaskRecord,
@@ -19,6 +24,8 @@ export type {
   EventRecord,
   EventStatus,
   ToolName,
+  TaskUpdateKind,
+  TaskUpdateRecord,
 } from './rows.js';
 
 /** The full set of Concord repositories bound to one database. */
@@ -27,6 +34,7 @@ export interface Repositories {
   tasks: TaskRepository;
   handoffs: HandoffRepository;
   reviews: ReviewRepository;
+  taskUpdates: TaskUpdateRepository;
   events: EventRepository;
 }
 
@@ -37,6 +45,7 @@ export function createRepositories(db: ConcordDatabase): Repositories {
     tasks: createTaskRepository(db),
     handoffs: createHandoffRepository(db),
     reviews: createReviewRepository(db),
+    taskUpdates: createTaskUpdateRepository(db),
     events: createEventRepository(db),
   };
 }

--- a/src/db/repositories/task-updates.ts
+++ b/src/db/repositories/task-updates.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod';
+
+import type { ConcordDatabase } from '../connection.js';
+import { parseTaskUpdateRow, type TaskUpdateKind, type TaskUpdateRecord } from '../rows.js';
+
+export interface NewTaskUpdate {
+  taskId: string;
+  kind: TaskUpdateKind;
+  content: string;
+  agent: string | null;
+}
+
+export interface TaskUpdateRepository {
+  create(update: NewTaskUpdate): TaskUpdateRecord;
+  listByTask(taskId: string): TaskUpdateRecord[];
+}
+
+const rawListSchema = z.array(z.unknown());
+
+export function createTaskUpdateRepository(db: ConcordDatabase): TaskUpdateRepository {
+  const insertStmt = db.prepare(`
+    INSERT INTO task_updates (task_id, kind, content, agent, created_at)
+    VALUES (@task_id, @kind, @content, @agent, @created_at)
+  `);
+  const getByIdStmt = db.prepare('SELECT * FROM task_updates WHERE id = ?');
+  const listByTaskStmt = db.prepare(
+    'SELECT * FROM task_updates WHERE task_id = ? ORDER BY created_at ASC, id ASC',
+  );
+
+  return {
+    create(update) {
+      const info = insertStmt.run({
+        task_id: update.taskId,
+        kind: update.kind,
+        content: update.content,
+        agent: update.agent,
+        created_at: new Date().toISOString(),
+      });
+      const raw: unknown = getByIdStmt.get(info.lastInsertRowid);
+      if (raw === undefined) {
+        throw new Error(`Task update ${String(info.lastInsertRowid)} could not be read back`);
+      }
+      return parseTaskUpdateRow(raw);
+    },
+    listByTask(taskId) {
+      const raw: unknown = listByTaskStmt.all(taskId);
+      return rawListSchema.parse(raw).map(parseTaskUpdateRow);
+    },
+  };
+}

--- a/src/db/rows.ts
+++ b/src/db/rows.ts
@@ -12,7 +12,7 @@ export type TaskStatus = (typeof taskStatusValues)[number];
 const taskStatusSchema = z.enum(taskStatusValues);
 
 /** Tools that can be recorded as events (used for adoption tracking). */
-export const toolNameValues = ['claim_work', 'handoff', 'review_ready'] as const;
+export const toolNameValues = ['claim_work', 'update_task', 'handoff', 'review_ready'] as const;
 export type ToolName = (typeof toolNameValues)[number];
 const toolNameSchema = z.enum(toolNameValues);
 
@@ -108,6 +108,51 @@ export function parseTaskRow(raw: unknown): TaskRecord {
     parentTaskId: row.parent_task_id,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
+  };
+}
+
+// --- task updates -----------------------------------------------------------
+
+export const taskUpdateKindValues = [
+  'intent',
+  'progress',
+  'assumption',
+  'decision',
+  'question',
+  'answer',
+  'blocker',
+  'finding',
+] as const;
+export type TaskUpdateKind = (typeof taskUpdateKindValues)[number];
+const taskUpdateKindSchema = z.enum(taskUpdateKindValues);
+
+export interface TaskUpdateRecord {
+  id: number;
+  taskId: string;
+  kind: TaskUpdateKind;
+  content: string;
+  agent: string | null;
+  createdAt: string;
+}
+
+const taskUpdateDbRowSchema = z.object({
+  id: z.number().int(),
+  task_id: z.string(),
+  kind: taskUpdateKindSchema,
+  content: z.string(),
+  agent: z.string().nullable(),
+  created_at: z.string(),
+});
+
+export function parseTaskUpdateRow(raw: unknown): TaskUpdateRecord {
+  const row = taskUpdateDbRowSchema.parse(raw);
+  return {
+    id: row.id,
+    taskId: row.task_id,
+    kind: row.kind,
+    content: row.content,
+    agent: row.agent,
+    createdAt: row.created_at,
   };
 }
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -74,4 +74,17 @@ export const migrations: readonly string[] = [
   `
   ALTER TABLE tasks ADD COLUMN parent_task_id TEXT;
   `,
+  // 004 — append-only, task-scoped memory shared between agent sessions.
+  `
+  CREATE TABLE task_updates (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id    TEXT NOT NULL REFERENCES tasks(task_id),
+    kind       TEXT NOT NULL,
+    content    TEXT NOT NULL,
+    agent      TEXT,
+    created_at TEXT NOT NULL
+  );
+
+  CREATE INDEX idx_task_updates_task_id ON task_updates(task_id);
+  `,
 ];

--- a/src/domain/schemas.ts
+++ b/src/domain/schemas.ts
@@ -37,6 +37,34 @@ export const claimWorkInputShape = {
 export const claimWorkInputSchema = z.object(claimWorkInputShape);
 export type ClaimWorkInput = z.infer<typeof claimWorkInputSchema>;
 
+export const updateTaskInputShape = {
+  task_id: z.string().min(1).describe('Claimed task receiving this memory entry'),
+  kind: z
+    .enum([
+      'intent',
+      'progress',
+      'assumption',
+      'decision',
+      'question',
+      'answer',
+      'blocker',
+      'finding',
+    ])
+    .describe('The kind of task-scoped update'),
+  content: z.string().min(1).describe('Concise context another agent needs'),
+  agent: z.string().optional().describe('Agent recording the update; defaults to the claimant'),
+} as const;
+
+export const updateTaskInputSchema = z.object(updateTaskInputShape);
+export type UpdateTaskInput = z.infer<typeof updateTaskInputSchema>;
+
+export const getTaskContextInputShape = {
+  task_id: z.string().min(1).describe('Task whose shared context should be read'),
+} as const;
+
+export const getTaskContextInputSchema = z.object(getTaskContextInputShape);
+export type GetTaskContextInput = z.infer<typeof getTaskContextInputSchema>;
+
 export const handoffInputShape = {
   task_id: z.string().min(1).describe('The task being handed off, e.g. TASK-12'),
   status: z.string().min(1).describe('Handoff status, e.g. done, blocked, in_progress'),

--- a/src/install/instructions.ts
+++ b/src/install/instructions.ts
@@ -9,6 +9,9 @@ This project uses Concord MCP. Use its tools so your work is visible before PRs:
 - **Before editing code**, call \`claim_work\` with the task id, title, and the
   files/modules you expect to touch. Concord warns about overlaps with other
   active work.
+- **While working**, call \`update_task\` for durable intent, progress,
+  assumptions, decisions, questions, answers, blockers, and findings. When
+  resuming or coordinating on a task, call \`get_task_context\` first.
 - **Before finishing or when blocked**, call \`handoff\` with what changed, tests
   run, assumptions, decisions, and guardrails you checked. **Before a PR**, set
   \`ready_for_review\` (with open questions and provenance) to also produce a

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,8 +2,10 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import type { Repositories } from './db/index.js';
 import { registerClaimWork } from './tools/claim-work.js';
+import { registerGetTaskContext } from './tools/get-task-context.js';
 import { registerWorkState } from './tools/get-work-state.js';
 import { registerHandoff } from './tools/handoff.js';
+import { registerUpdateTask } from './tools/update-task.js';
 import { VERSION } from './version.js';
 
 /** Concord's advertised MCP server version. */
@@ -27,7 +29,9 @@ export function createServer(repos: Repositories, options: ServerOptions = {}): 
     options.onToolWrite?.();
     notifyWorkStateChanged();
   };
+  registerGetTaskContext(server, repos);
   registerClaimWork(server, repos, onWrite);
+  registerUpdateTask(server, repos, onWrite);
   registerHandoff(server, repos, onWrite);
   return server;
 }

--- a/src/tools/get-task-context.ts
+++ b/src/tools/get-task-context.ts
@@ -1,0 +1,117 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import type {
+  HandoffRecord,
+  Repositories,
+  ReviewRecord,
+  TaskRecord,
+  TaskUpdateRecord,
+} from '../db/index.js';
+import { detectOverlaps, type OverlapWarning } from '../domain/overlap.js';
+import { getTaskContextInputShape, type GetTaskContextInput } from '../domain/schemas.js';
+
+export interface TaskContextResult {
+  task: TaskRecord;
+  updates: TaskUpdateRecord[];
+  latestHandoff: HandoffRecord | undefined;
+  latestReview: ReviewRecord | undefined;
+  overlaps: OverlapWarning[];
+}
+
+export function handleGetTaskContext(
+  repos: Repositories,
+  input: GetTaskContextInput,
+): TaskContextResult {
+  const task = repos.tasks.get(input.task_id);
+  if (!task) {
+    throw new Error(`Task "${input.task_id}" is not claimed. Call claim_work first.`);
+  }
+
+  const overlaps =
+    task.status === 'active'
+      ? detectOverlaps(
+          {
+            taskId: task.taskId,
+            parentTaskId: task.parentTaskId,
+            expectedFiles: task.expectedFiles,
+            modules: task.modules,
+            domains: task.domains,
+            riskTags: task.riskTags,
+          },
+          repos.tasks
+            .list()
+            .filter(
+              (candidate) => candidate.taskId !== task.taskId && candidate.status === 'active',
+            ),
+        )
+      : [];
+
+  return {
+    task,
+    updates: repos.taskUpdates.listByTask(task.taskId),
+    latestHandoff: repos.handoffs.latestForTask(task.taskId),
+    latestReview: repos.reviews.latestForTask(task.taskId),
+    overlaps,
+  };
+}
+
+function formatContext(result: TaskContextResult): string {
+  const updates =
+    result.updates.length === 0
+      ? '  None'
+      : result.updates
+          .map(
+            (update) => `  [${update.kind}] ${update.content} — ${update.agent ?? 'unknown agent'}`,
+          )
+          .join('\n');
+  const overlaps =
+    result.overlaps.length === 0
+      ? '  None'
+      : result.overlaps
+          .map((overlap) => `  ${overlap.taskId}: ${overlap.reasons.join('; ')}`)
+          .join('\n');
+
+  return [
+    `${result.task.taskId} — ${result.task.title}`,
+    `Status: ${result.task.status}`,
+    `Agent: ${result.task.agent ?? 'unassigned'}`,
+    `Notes: ${result.task.notes ?? 'not recorded'}`,
+    'Updates:',
+    updates,
+    'Live overlaps:',
+    overlaps,
+    `Latest handoff: ${result.latestHandoff?.whatChanged ?? 'none'}`,
+    `Review plan: ${result.latestReview?.planSummary ?? 'not submitted'}`,
+  ].join('\n');
+}
+
+export function registerGetTaskContext(server: McpServer, repos: Repositories): void {
+  server.registerTool(
+    'get_task_context',
+    {
+      title: 'Get task context',
+      description:
+        "Read a claimed task's scope, ordered updates, latest handoff and review, and current overlaps.",
+      inputSchema: getTaskContextInputShape,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    (input) => {
+      const result = handleGetTaskContext(repos, input);
+      return {
+        content: [{ type: 'text', text: formatContext(result) }],
+        structuredContent: {
+          task: result.task,
+          updates: result.updates,
+          latest_handoff: result.latestHandoff ?? null,
+          latest_review: result.latestReview ?? null,
+          overlaps: result.overlaps,
+        },
+      };
+    },
+  );
+}

--- a/src/tools/update-task.ts
+++ b/src/tools/update-task.ts
@@ -1,0 +1,67 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import type { Repositories, TaskUpdateRecord } from '../db/index.js';
+import { updateTaskInputShape, type UpdateTaskInput } from '../domain/schemas.js';
+
+export interface UpdateTaskResult {
+  update: TaskUpdateRecord;
+}
+
+/** Append one durable, task-scoped memory entry for other agents and sessions. */
+export function handleUpdateTask(repos: Repositories, input: UpdateTaskInput): UpdateTaskResult {
+  const task = repos.tasks.get(input.task_id);
+  if (task === undefined) {
+    throw new Error(`Task ${input.task_id} is not claimed. Call claim_work first.`);
+  }
+
+  const update = repos.taskUpdates.create({
+    taskId: input.task_id,
+    kind: input.kind,
+    content: input.content,
+    agent: input.agent ?? task.agent,
+  });
+  repos.events.record({
+    taskId: input.task_id,
+    tool: 'update_task',
+    status: 'success',
+    detail: input.kind,
+  });
+  return { update };
+}
+
+export function formatUpdateTaskText(result: UpdateTaskResult): string {
+  const author = result.update.agent === null ? '' : ` by ${result.update.agent}`;
+  return `Recorded ${result.update.kind} for ${result.update.taskId}${author}: ${result.update.content}`;
+}
+
+export function registerUpdateTask(
+  server: McpServer,
+  repos: Repositories,
+  onWrite?: () => void,
+): void {
+  server.registerTool(
+    'update_task',
+    {
+      title: 'Update task',
+      description:
+        'Append durable task-scoped context such as an intent, decision, assumption, question, ' +
+        'answer, blocker, finding, or progress update. The task must be claimed first.',
+      inputSchema: updateTaskInputShape,
+    },
+    (args) => {
+      const result = handleUpdateTask(repos, args);
+      onWrite?.();
+      return {
+        content: [{ type: 'text', text: formatUpdateTaskText(result) }],
+        structuredContent: {
+          update_id: result.update.id,
+          task_id: result.update.taskId,
+          kind: result.update.kind,
+          content: result.update.content,
+          agent: result.update.agent,
+          created_at: result.update.createdAt,
+        },
+      };
+    },
+  );
+}

--- a/test/cli/cli-commands.test.ts
+++ b/test/cli/cli-commands.test.ts
@@ -73,7 +73,7 @@ describe('CLI read/export commands', () => {
 
   it('doctor reports schema version and adoption', () => {
     const report = runDoctor(dir);
-    expect(report).toContain('schema v3, expected v3');
+    expect(report).toContain('schema v4, expected v4');
     expect(report).toContain('TASK-12');
     expect(report).toContain('claim_work: yes');
     // The resolved workspace path is surfaced so agents don't have to hunt for it.

--- a/test/db/connection.test.ts
+++ b/test/db/connection.test.ts
@@ -8,7 +8,7 @@ describe('openDatabase', () => {
   it('applies all migrations (user_version at head) and creates tables', () => {
     const db = openDatabase(':memory:');
     const version: unknown = db.pragma('user_version', { simple: true });
-    expect(version).toBe(3);
+    expect(version).toBe(4);
 
     const raw: unknown = db.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all();
     const names = new Set(
@@ -21,6 +21,7 @@ describe('openDatabase', () => {
     expect(names.has('handoffs')).toBe(true);
     expect(names.has('events')).toBe(true);
     expect(names.has('reviews')).toBe(true);
+    expect(names.has('task_updates')).toBe(true);
   });
 });
 

--- a/test/db/storage.test.ts
+++ b/test/db/storage.test.ts
@@ -34,12 +34,13 @@ describe('migrations', () => {
     expect(names.has('tasks')).toBe(true);
     expect(names.has('handoffs')).toBe(true);
     expect(names.has('events')).toBe(true);
+    expect(names.has('task_updates')).toBe(true);
   });
 
   it('is idempotent when reopening (user_version already at head)', () => {
     const { db } = newRepos();
     const version: unknown = db.pragma('user_version', { simple: true });
-    expect(version).toBe(3);
+    expect(version).toBe(4);
   });
 });
 

--- a/test/tools/get-work-state.test.ts
+++ b/test/tools/get-work-state.test.ts
@@ -67,6 +67,8 @@ describe('work-state MCP surface (end-to-end via in-memory transport)', () => {
     try {
       const tools = await client.listTools();
       expect(tools.tools.map((t) => t.name)).toContain('get_work_state');
+      expect(tools.tools.map((t) => t.name)).toContain('update_task');
+      expect(tools.tools.map((t) => t.name)).toContain('get_task_context');
 
       const resources = await client.listResources();
       expect(resources.resources.map((r) => r.uri)).toContain(WORK_STATE_URI);

--- a/test/tools/task-context.test.ts
+++ b/test/tools/task-context.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { openDatabase } from '../../src/db/connection.js';
+import { createRepositories, type Repositories } from '../../src/db/index.js';
+import { handleClaimWork } from '../../src/tools/claim-work.js';
+import { handleGetTaskContext } from '../../src/tools/get-task-context.js';
+import { handleHandoff } from '../../src/tools/handoff.js';
+import { handleUpdateTask } from '../../src/tools/update-task.js';
+
+describe('task-scoped memory', () => {
+  let repos: Repositories;
+
+  beforeEach(() => {
+    repos = createRepositories(openDatabase(':memory:'));
+    handleClaimWork(repos, {
+      task_id: 'TASK-12',
+      title: 'Retry payments',
+      agent: 'claude-code',
+      modules: ['billing'],
+      expected_files: ['src/billing/retry.ts'],
+    });
+  });
+
+  it('appends ordered typed updates and defaults to the claiming agent', () => {
+    handleUpdateTask(repos, {
+      task_id: 'TASK-12',
+      kind: 'intent',
+      content: 'Do not block checkout',
+    });
+    handleUpdateTask(repos, {
+      task_id: 'TASK-12',
+      kind: 'decision',
+      content: 'Use a queued retry',
+      agent: 'codex',
+    });
+
+    const context = handleGetTaskContext(repos, { task_id: 'TASK-12' });
+    expect(context.updates.map((update) => update.kind)).toEqual(['intent', 'decision']);
+    expect(context.updates.map((update) => update.agent)).toEqual(['claude-code', 'codex']);
+    expect(repos.events.listByTask('TASK-12').map((event) => event.tool)).toEqual([
+      'claim_work',
+      'update_task',
+      'update_task',
+    ]);
+  });
+
+  it('returns live overlaps and the latest handoff and review evidence', () => {
+    handleClaimWork(repos, {
+      task_id: 'TASK-14',
+      title: 'Invoice totals',
+      modules: ['billing'],
+    });
+    expect(handleGetTaskContext(repos, { task_id: 'TASK-12' }).overlaps[0]?.taskId).toBe('TASK-14');
+
+    handleHandoff(repos, {
+      task_id: 'TASK-12',
+      status: 'done',
+      what_changed: 'Queued retries',
+      tests_run: ['pnpm test'],
+      ready_for_review: true,
+    });
+    const context = handleGetTaskContext(repos, { task_id: 'TASK-12' });
+    expect(context.latestHandoff?.whatChanged).toBe('Queued retries');
+    expect(context.latestReview?.planSummary).toBe('Queued retries');
+    expect(context.task.status).toBe('review_ready');
+    expect(context.overlaps).toEqual([]);
+  });
+
+  it('requires an existing claimed task', () => {
+    expect(() =>
+      handleUpdateTask(repos, {
+        task_id: 'MISSING',
+        kind: 'progress',
+        content: 'Started',
+      }),
+    ).toThrow(/claim_work/);
+    expect(() => handleGetTaskContext(repos, { task_id: 'MISSING' })).toThrow(/claim_work/);
+  });
+});


### PR DESCRIPTION
## Summary
- add typed, append-only task updates for intent, progress, assumptions, decisions, questions, answers, blockers, and findings
- add get_task_context to recover scope, ordered updates, handoff/review evidence, and live overlaps
- align the five-tool public surface, install instructions, docs, changelog, and two-agent YC demo

## Verification
- pnpm typecheck
- pnpm lint
- pnpm test (100 tests)
- pnpm build
- pnpm demo
- focused Prettier check

## Scope
Local shared-checkout coordination only. No hosted sync, integrations, orchestration, or vector memory.