### PR TITLE
feat: agent presence — register_agent, roster, stale claims, repo-root store

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,15 +7,18 @@ before making changes.
 ## What this project is
 
 `concord-mcp` is a local MCP server plus a `concord` CLI that gives coding agents
-shared work-state: agents **claim work**, share typed **task context**, leave
-**handoffs**, and generate **review packets** before opening PRs. SQLite is the
-source of truth; human-readable markdown artifacts are rendered from it for PR
-visibility.
+shared work-state: agents **register their presence**, **claim work**, share
+typed **task context**, leave **handoffs**, and generate **review packets**
+before opening PRs. SQLite is the source of truth; human-readable markdown
+artifacts are rendered from it for PR visibility.
 
-The surface is intentionally five MCP tools: `get_work_state`, `claim_work`,
-`update_task`, `get_task_context`, and `handoff`. Review packets are produced by
-`handoff` with `ready_for_review` set, not a separate tool. Do not add more tools
-without explicit product pull.
+The surface is intentionally six MCP tools: `register_agent`, `get_work_state`,
+`claim_work`, `update_task`, `get_task_context`, and `handoff`. Review packets
+are produced by `handoff` with `ready_for_review` set, not a separate tool.
+`register_agent` was added with explicit product pull for agent presence (who is
+here and what they are working on); liveness is derived from `last_seen` in
+`domain/presence.ts`, not stored. Do not add more tools without explicit product
+pull.
 
 ## Coding rules (non-negotiable)
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,14 @@ gone away without handing off.
 
 ## What you get
 
-SQLite is the local source of truth. `concord init` adds `.concord/` to the
+SQLite is the local source of truth, kept in the `.concord/` at the **root of
+the repo** the work is happening in. The MCP server resolves that root from
+`CONCORD_REPO_ROOT` if set, then Claude Code's `CLAUDE_PROJECT_DIR` (which Claude
+Code sets automatically, even for a user-scoped server), then its working
+directory — so every agent in one repo shares one store. Set `CONCORD_REPO_ROOT`
+when running the server somewhere its working directory is not inside the repo.
+
+`concord init` adds `.concord/` to the
 repository's `.gitignore`, so the generated workspace stays local by default.
 Teams that want selected artifacts in PRs can remove that rule or force-add the
 human-readable files:

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
 
 **Shared work-state for coding agents.** Concord MCP gives Claude Code, Codex,
 Cursor, and other MCP-capable coding assistants a shared work log. Agents can
-claim work, share task context, leave handoffs, and generate review-ready
-packets before opening PRs.
+register their presence, claim work, share task context, leave handoffs, and
+generate review-ready packets before opening PRs.
 
-> ⚠️ Early and under active development. The surface is five focused MCP tools:
-> `get_work_state`, `claim_work`, `update_task`, `get_task_context`, and
-> `handoff`.
+> ⚠️ Early and under active development. The surface is six focused MCP tools:
+> `register_agent`, `get_work_state`, `claim_work`, `update_task`,
+> `get_task_context`, and `handoff`.
 
 ## Why
 
@@ -42,15 +42,21 @@ setup:
 > Concord works through MCP tools plus the installed instructions on any
 > MCP-capable client.
 
-## The five tools
+## The six tools
 
-| Tool               | When                     | What it does                                                                     |
-| ------------------ | ------------------------ | -------------------------------------------------------------------------------- |
-| `get_work_state`   | before choosing work     | shows active tasks, overlaps, review-ready work, and open questions              |
-| `claim_work`       | before editing           | records the task + expected files/modules; flags overlaps with other active work |
-| `update_task`      | while working            | appends typed intent, progress, decisions, questions, blockers, and findings     |
-| `get_task_context` | resuming or coordinating | returns the task, ordered updates, handoff, review evidence, and live overlaps   |
-| `handoff`          | done, blocked, or pre-PR | captures evidence; `ready_for_review` also produces the review packet            |
+| Tool               | When                     | What it does                                                                      |
+| ------------------ | ------------------------ | --------------------------------------------------------------------------------- |
+| `register_agent`   | at session start         | registers this instance's identity + summary + status; returns the live roster    |
+| `get_work_state`   | before choosing work     | shows the agent roster, active tasks, overlaps, stale claims, and open questions   |
+| `claim_work`       | before editing           | records the task + expected files/modules; flags overlaps with other active work  |
+| `update_task`      | while working            | appends typed intent, progress, decisions, questions, blockers, and findings      |
+| `get_task_context` | resuming or coordinating | returns the task, ordered updates, handoff, review evidence, and live overlaps    |
+| `handoff`          | done, blocked, or pre-PR | captures evidence; `ready_for_review` also produces the review packet             |
+
+Every write tool accepts your `register_agent` `agent_id`, which keeps your
+presence live just by working. `get_work_state` shows **who is here** (with
+liveness), and flags **stale claims** — an active claim whose owning agent has
+gone away without handing off.
 
 ## What you get
 
@@ -73,7 +79,8 @@ Agents use the MCP tools; humans use the CLI.
 
 ```bash
 concord init                 # create the .concord/ workspace
-concord status               # active work, overlaps, review-ready, open questions
+concord status               # roster, active work, overlaps, stale claims, review-ready
+concord who                  # which agents are present and what they are working on
 concord tasks                # list all tracked tasks
 concord handoff <task-id>    # print the latest handoff
 concord review-packet <id>   # print the latest review packet

--- a/src/artifacts/index.ts
+++ b/src/artifacts/index.ts
@@ -2,6 +2,7 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import type { HandoffRecord, Repositories, ReviewRecord, TaskRecord } from '../db/index.js';
+import { buildRoster } from '../domain/presence.js';
 import { renderEventsJsonl } from './events-jsonl.js';
 import { renderHandoffMarkdown } from './handoff-md.js';
 import { renderReviewPacketMarkdown } from './review-packet-md.js';
@@ -65,8 +66,12 @@ export function writeArtifacts(
 ): void {
   mkdirSync(concordDirPath, { recursive: true });
   const tasks = repos.tasks.list();
+  const roster = buildRoster(repos.agents.list(), Date.parse(generatedAt));
 
-  writeFileSync(join(concordDirPath, 'WORK_STATE.json'), renderWorkStateJson(tasks, generatedAt));
+  writeFileSync(
+    join(concordDirPath, 'WORK_STATE.json'),
+    renderWorkStateJson(tasks, roster, generatedAt),
+  );
   writeFileSync(join(concordDirPath, 'events.jsonl'), renderEventsJsonl(repos.events.list()));
 
   const handoff = latestHandoff(repos, tasks);

--- a/src/artifacts/work-state-json.ts
+++ b/src/artifacts/work-state-json.ts
@@ -1,4 +1,5 @@
 import type { TaskRecord } from '../db/index.js';
+import type { PresenceEntry } from '../domain/presence.js';
 
 interface WorkStateTask {
   task_id: string;
@@ -13,8 +14,20 @@ interface WorkStateTask {
   expected_files: string[];
 }
 
+interface WorkStatePresence {
+  agent_id: string;
+  kind: string;
+  owner: string | null;
+  summary: string | null;
+  status: string;
+  liveness: string;
+  last_seen: string;
+  age_seconds: number;
+}
+
 interface WorkState {
   generated_at: string;
+  presence: WorkStatePresence[];
   tasks: WorkStateTask[];
 }
 
@@ -33,10 +46,28 @@ function toWorkStateTask(task: TaskRecord): WorkStateTask {
   };
 }
 
-/** Render WORK_STATE.json: a snapshot of all tasks and their current status. */
-export function renderWorkStateJson(tasks: readonly TaskRecord[], generatedAt: string): string {
+function toWorkStatePresence(entry: PresenceEntry): WorkStatePresence {
+  return {
+    agent_id: entry.agentId,
+    kind: entry.kind,
+    owner: entry.owner,
+    summary: entry.summary,
+    status: entry.status,
+    liveness: entry.liveness,
+    last_seen: entry.lastSeen,
+    age_seconds: entry.ageSeconds,
+  };
+}
+
+/** Render WORK_STATE.json: a snapshot of the agent roster and all tasks. */
+export function renderWorkStateJson(
+  tasks: readonly TaskRecord[],
+  roster: readonly PresenceEntry[],
+  generatedAt: string,
+): string {
   const state: WorkState = {
     generated_at: generatedAt,
+    presence: roster.map(toWorkStatePresence),
     tasks: tasks.map(toWorkStateTask),
   };
   return `${JSON.stringify(state, null, 2)}\n`;

--- a/src/artifacts/work-state-view.ts
+++ b/src/artifacts/work-state-view.ts
@@ -2,7 +2,12 @@ import { dirname } from 'node:path';
 
 import type { Repositories, TaskRecord } from '../db/index.js';
 import { detectOverlaps } from '../domain/overlap.js';
-import { buildRoster, type PresenceEntry } from '../domain/presence.js';
+import {
+  buildRoster,
+  detectStaleClaims,
+  type PresenceEntry,
+  type StaleClaim,
+} from '../domain/presence.js';
 
 interface ActiveEntry {
   taskId: string;
@@ -42,6 +47,8 @@ export interface StatusView {
   /** Registered agents with derived liveness — "who is here and what they are
    * doing", most-live first. */
   presence: PresenceEntry[];
+  /** Active claims whose owning agent has gone away or never registered. */
+  staleClaims: StaleClaim[];
 }
 
 function touchesOf(task: TaskRecord): string {
@@ -106,6 +113,7 @@ export function buildStatus(repos: Repositories, now: number = Date.now()): Stat
     reviewReady,
     openQuestions,
     presence: buildRoster(repos.agents.list(), now),
+    staleClaims: detectStaleClaims(tasks, repos.agents.list(), now),
   };
 }
 
@@ -143,6 +151,19 @@ export function renderStatusText(view: StatusView): string {
   } else {
     for (const overlap of view.overlaps) {
       lines.push(`  ${overlap.a} <-> ${overlap.b}: ${overlap.reasons.join('; ')}`);
+    }
+  }
+
+  lines.push('', 'Stale claims');
+  if (view.staleClaims.length === 0) {
+    lines.push('  none');
+  } else {
+    for (const claim of view.staleClaims) {
+      const detail =
+        claim.reason === 'agent-unregistered'
+          ? 'agent never registered'
+          : `agent away ${String(claim.ageSeconds ?? 0)}s`;
+      lines.push(`  ${claim.taskId.padEnd(10)} ${claim.agentId} (${detail})`);
     }
   }
 

--- a/src/artifacts/work-state-view.ts
+++ b/src/artifacts/work-state-view.ts
@@ -2,6 +2,7 @@ import { dirname } from 'node:path';
 
 import type { Repositories, TaskRecord } from '../db/index.js';
 import { detectOverlaps } from '../domain/overlap.js';
+import { buildRoster, type PresenceEntry } from '../domain/presence.js';
 
 interface ActiveEntry {
   taskId: string;
@@ -38,6 +39,9 @@ export interface StatusView {
   overlaps: OverlapPair[];
   reviewReady: ReviewEntry[];
   openQuestions: OpenQuestionEntry[];
+  /** Registered agents with derived liveness — "who is here and what they are
+   * doing", most-live first. */
+  presence: PresenceEntry[];
 }
 
 function touchesOf(task: TaskRecord): string {
@@ -46,7 +50,7 @@ function touchesOf(task: TaskRecord): string {
   return unique.length > 0 ? unique.join(', ') : '-';
 }
 
-export function buildStatus(repos: Repositories): StatusView {
+export function buildStatus(repos: Repositories, now: number = Date.now()): StatusView {
   const tasks = repos.tasks.list();
   const active = tasks.filter((task) => task.status === 'active');
 
@@ -101,11 +105,27 @@ export function buildStatus(repos: Repositories): StatusView {
     overlaps,
     reviewReady,
     openQuestions,
+    presence: buildRoster(repos.agents.list(), now),
   };
 }
 
+/** Render the presence roster as indented lines, or a placeholder when empty. */
+export function renderRosterLines(roster: readonly PresenceEntry[]): string[] {
+  if (roster.length === 0) {
+    return ['  none'];
+  }
+  return roster.map((entry) => {
+    const state = `${entry.liveness}/${entry.status}`;
+    const doing = entry.summary ?? '-';
+    return `  ${entry.agentId.padEnd(18)} ${state.padEnd(20)} ${doing}  (${String(entry.ageSeconds)}s ago)`;
+  });
+}
+
 export function renderStatusText(view: StatusView): string {
-  const lines = ['Concord workspace', '', 'Active work'];
+  const lines = ['Concord workspace', '', "Who's here"];
+  lines.push(...renderRosterLines(view.presence));
+
+  lines.push('', 'Active work');
   if (view.active.length === 0) {
     lines.push('  none');
   } else {

--- a/src/cli/commands/hook.ts
+++ b/src/cli/commands/hook.ts
@@ -1,9 +1,11 @@
+import { randomBytes } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 
 import type { Command } from '@commander-js/extra-typings';
 import { z } from 'zod';
 
 import type { Repositories } from '../../db/index.js';
+import { buildRoster } from '../../domain/presence.js';
 import { openContext } from '../context.js';
 import { checkFileOverlaps } from './check.js';
 
@@ -66,6 +68,77 @@ export function decidePreToolUse(
   };
 }
 
+/** The subset of Claude Code's SessionStart payload we use. */
+const sessionStartPayloadSchema = z
+  .object({
+    session_id: z.string().optional(),
+    cwd: z.string().optional(),
+  })
+  .passthrough();
+
+/**
+ * A stable per-session agent id for Claude Code. Derived from the session id so
+ * the same session always maps to the same identity (SessionStart is idempotent
+ * via upsert); falls back to a random suffix when no session id is provided.
+ */
+export function sessionStartAgentId(sessionId: string | undefined): string {
+  const slug = (sessionId ?? '').replace(/[^0-9a-z]/gi, '').slice(0, 8).toLowerCase();
+  return `claude-code:${slug === '' ? randomBytes(4).toString('hex') : slug}`;
+}
+
+export interface SessionStartResult {
+  agentId: string;
+  /** Context printed to stdout, which Claude Code injects into the session. */
+  message: string;
+}
+
+/**
+ * Register this Claude Code session as an agent so its presence exists even if
+ * the model never calls `register_agent`, and tell the model its `agent_id` plus
+ * who else is active. Reads a SessionStart JSON payload.
+ */
+export function handleSessionStart(repos: Repositories, rawJson: string): SessionStartResult {
+  let parsed: unknown = {};
+  try {
+    parsed = JSON.parse(rawJson);
+  } catch {
+    parsed = {};
+  }
+  const payload = sessionStartPayloadSchema.parse(parsed);
+  const agentId = sessionStartAgentId(payload.session_id);
+
+  repos.agents.upsert({
+    agentId,
+    kind: 'claude-code',
+    owner: null,
+    model: null,
+    pid: null,
+    cwd: payload.cwd ?? null,
+    worktree: null,
+    branch: null,
+    summary: null,
+    status: 'active',
+  });
+
+  const others = buildRoster(repos.agents.list(), Date.now()).filter(
+    (entry) => entry.agentId !== agentId,
+  );
+  const lines = [
+    `Concord: registered this session as agent \`${agentId}\`. Pass agent_id="${agentId}" to ` +
+      'Concord tools (claim_work, update_task, handoff) so your work is attributed and your ' +
+      'presence stays live.',
+  ];
+  if (others.length === 0) {
+    lines.push('No other agents are currently registered.');
+  } else {
+    lines.push('Who else is here:');
+    for (const entry of others) {
+      lines.push(`  - ${entry.agentId} [${entry.liveness}/${entry.status}]: ${entry.summary ?? '-'}`);
+    }
+  }
+  return { agentId, message: lines.join('\n') };
+}
+
 /** Read piped stdin to a string. Returns '' when attached to a TTY (no input). */
 function readStdin(): string {
   if (process.stdin.isTTY) {
@@ -82,9 +155,16 @@ export function registerHookCommand(program: Command): void {
   program
     .command('hook <event>')
     .description(
-      'Run a Concord hook. event: pre-tool-use (reads a Claude Code PreToolUse JSON payload on stdin)',
+      'Run a Concord hook. events: pre-tool-use (PreToolUse overlap gate) and ' +
+        'session-start (SessionStart presence auto-register); both read a Claude Code JSON ' +
+        'payload on stdin.',
     )
     .action((event) => {
+      if (event === 'session-start') {
+        const result = handleSessionStart(openContext(process.cwd()).repos, readStdin());
+        process.stdout.write(`${result.message}\n`);
+        return;
+      }
       if (event !== 'pre-tool-use') {
         process.stderr.write(`Unknown hook event: ${event}\n`);
         process.exitCode = 1;

--- a/src/cli/commands/who.ts
+++ b/src/cli/commands/who.ts
@@ -1,0 +1,20 @@
+import type { Command } from '@commander-js/extra-typings';
+
+import { renderRosterLines } from '../../artifacts/work-state-view.js';
+import { buildRoster } from '../../domain/presence.js';
+import { openContext } from '../context.js';
+
+/** Render the presence roster: who is registered and how live they are. */
+export function runWho(cwd: string, now: number = Date.now()): string {
+  const roster = buildRoster(openContext(cwd).repos.agents.list(), now);
+  return ["Who's here", ...renderRosterLines(roster)].join('\n');
+}
+
+export function registerWhoCommand(program: Command): void {
+  program
+    .command('who')
+    .description('Show which agents are present and what they are working on')
+    .action(() => {
+      process.stdout.write(`${runWho(process.cwd())}\n`);
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,6 +13,7 @@ import { registerReviewPacketCommand } from './commands/review-packet.js';
 import { registerStatus } from './commands/status.js';
 import { registerTasks } from './commands/tasks.js';
 import { registerWatchCommand } from './commands/watch.js';
+import { registerWhoCommand } from './commands/who.js';
 
 const program = new Command();
 program.name('concord').description('Shared work-state for coding agents').version(VERSION);
@@ -20,6 +21,7 @@ program.name('concord').description('Shared work-state for coding agents').versi
 registerInit(program);
 registerInstallCommand(program);
 registerStatus(program);
+registerWhoCommand(program);
 registerTasks(program);
 registerCheckCommand(program);
 registerWatchCommand(program);

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -26,6 +26,28 @@ export function findRepoRoot(startDir: string): string {
   }
 }
 
+/**
+ * Resolve the repo root for the MCP server, whose own `process.cwd()` is
+ * unreliable: when the server is registered at user scope it is launched from
+ * wherever the client started, not the repo the agent is editing — so a claim
+ * lands in one store while reads hit an empty repo-local `.concord/`. Prefer, in
+ * order, an explicit `CONCORD_REPO_ROOT`, Claude Code's `CLAUDE_PROJECT_DIR`
+ * (set in the server's env to the project root regardless of scope), then the
+ * cwd. Each candidate is normalized through `findRepoRoot`, so the store always
+ * lands at the `.concord/` in the root of the repo.
+ */
+export function resolveRepoRoot(cwd: string, env: NodeJS.ProcessEnv): string {
+  const override = env['CONCORD_REPO_ROOT'];
+  if (override !== undefined && override.trim() !== '') {
+    return findRepoRoot(override);
+  }
+  const projectDir = env['CLAUDE_PROJECT_DIR'];
+  if (projectDir !== undefined && projectDir.trim() !== '') {
+    return findRepoRoot(projectDir);
+  }
+  return findRepoRoot(cwd);
+}
+
 /** Absolute path to the `.concord/` directory for a given repo root. */
 export function concordDir(repoRoot: string): string {
   return join(repoRoot, CONCORD_DIR);

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,4 +1,5 @@
 import { openDatabase, type ConcordDatabase } from './connection.js';
+import { createAgentRepository, type AgentRepository } from './repositories/agents.js';
 import { createEventRepository, type EventRepository } from './repositories/events.js';
 import { createHandoffRepository, type HandoffRepository } from './repositories/handoffs.js';
 import { createReviewRepository, type ReviewRepository } from './repositories/reviews.js';
@@ -15,6 +16,7 @@ export type { NewHandoff, HandoffRepository } from './repositories/handoffs.js';
 export type { NewReview, ReviewRepository } from './repositories/reviews.js';
 export type { NewTaskUpdate, TaskUpdateRepository } from './repositories/task-updates.js';
 export type { NewEvent, EventRepository } from './repositories/events.js';
+export type { NewAgent, AgentRepository } from './repositories/agents.js';
 export type {
   TaskRecord,
   TaskStatus,
@@ -26,6 +28,8 @@ export type {
   ToolName,
   TaskUpdateKind,
   TaskUpdateRecord,
+  AgentRecord,
+  AgentStatus,
 } from './rows.js';
 
 /** The full set of Concord repositories bound to one database. */
@@ -36,6 +40,7 @@ export interface Repositories {
   reviews: ReviewRepository;
   taskUpdates: TaskUpdateRepository;
   events: EventRepository;
+  agents: AgentRepository;
 }
 
 /** Bind all repositories to an already-open database. */
@@ -47,6 +52,7 @@ export function createRepositories(db: ConcordDatabase): Repositories {
     reviews: createReviewRepository(db),
     taskUpdates: createTaskUpdateRepository(db),
     events: createEventRepository(db),
+    agents: createAgentRepository(db),
   };
 }
 

--- a/src/db/repositories/agents.ts
+++ b/src/db/repositories/agents.ts
@@ -1,0 +1,99 @@
+import { z } from 'zod';
+
+import type { ConcordDatabase } from '../connection.js';
+import { type AgentRecord, type AgentStatus, parseAgentRow } from '../rows.js';
+
+/** A registration payload. Optional fields are explicit `null`. `agentId` is
+ * supplied by the caller (generated once per session and reused). */
+export interface NewAgent {
+  agentId: string;
+  kind: string;
+  owner: string | null;
+  model: string | null;
+  pid: number | null;
+  cwd: string | null;
+  worktree: string | null;
+  branch: string | null;
+  summary: string | null;
+  status: AgentStatus;
+}
+
+export interface AgentRepository {
+  /** Insert or refresh an agent. On re-registration the mutable fields and
+   * `last_seen` are updated while `first_seen` is preserved. */
+  upsert(agent: NewAgent): AgentRecord;
+  get(agentId: string): AgentRecord | undefined;
+  list(): AgentRecord[];
+  /** Bump `last_seen` to now so an agent stays present just by doing work.
+   * Returns undefined if the agent has never registered. */
+  touch(agentId: string): AgentRecord | undefined;
+}
+
+const rawListSchema = z.array(z.unknown());
+
+export function createAgentRepository(db: ConcordDatabase): AgentRepository {
+  const upsertStmt = db.prepare(`
+    INSERT INTO agents (
+      agent_id, kind, owner, model, pid, cwd, worktree, branch, summary, status,
+      first_seen, last_seen
+    ) VALUES (
+      @agent_id, @kind, @owner, @model, @pid, @cwd, @worktree, @branch, @summary, @status,
+      @now, @now
+    )
+    ON CONFLICT(agent_id) DO UPDATE SET
+      kind = excluded.kind,
+      owner = excluded.owner,
+      model = excluded.model,
+      pid = excluded.pid,
+      cwd = excluded.cwd,
+      worktree = excluded.worktree,
+      branch = excluded.branch,
+      summary = excluded.summary,
+      status = excluded.status,
+      last_seen = excluded.last_seen
+  `);
+  const getStmt = db.prepare('SELECT * FROM agents WHERE agent_id = ?');
+  const listStmt = db.prepare('SELECT * FROM agents ORDER BY first_seen ASC, agent_id ASC');
+  const touchStmt = db.prepare('UPDATE agents SET last_seen = @now WHERE agent_id = @agent_id');
+
+  function get(agentId: string): AgentRecord | undefined {
+    const raw: unknown = getStmt.get(agentId);
+    if (raw === undefined) {
+      return undefined;
+    }
+    return parseAgentRow(raw);
+  }
+
+  return {
+    upsert(agent) {
+      const now = new Date().toISOString();
+      upsertStmt.run({
+        agent_id: agent.agentId,
+        kind: agent.kind,
+        owner: agent.owner,
+        model: agent.model,
+        pid: agent.pid,
+        cwd: agent.cwd,
+        worktree: agent.worktree,
+        branch: agent.branch,
+        summary: agent.summary,
+        status: agent.status,
+        now,
+      });
+      const stored = get(agent.agentId);
+      if (stored === undefined) {
+        throw new Error(`Agent ${agent.agentId} could not be read back after upsert`);
+      }
+      return stored;
+    },
+    get,
+    list() {
+      const raw: unknown = listStmt.all();
+      return rawListSchema.parse(raw).map(parseAgentRow);
+    },
+    touch(agentId) {
+      touchStmt.run({ agent_id: agentId, now: new Date().toISOString() });
+      return get(agentId);
+    },
+  };
+}

--- a/src/db/repositories/tasks.ts
+++ b/src/db/repositories/tasks.ts
@@ -17,6 +17,7 @@ export interface NewTask {
   riskTags: readonly string[];
   notes: string | null;
   parentTaskId: string | null;
+  agentId: string | null;
 }
 
 /** The declared surface of a claim, updated when an agent re-claims with an
@@ -43,11 +44,11 @@ export function createTaskRepository(db: ConcordDatabase): TaskRepository {
     INSERT INTO tasks (
       task_id, title, owner, agent, branch, worktree,
       expected_files, modules, domains, risk_tags, notes, status,
-      parent_task_id, created_at, updated_at
+      parent_task_id, agent_id, created_at, updated_at
     ) VALUES (
       @task_id, @title, @owner, @agent, @branch, @worktree,
       @expected_files, @modules, @domains, @risk_tags, @notes, @status,
-      @parent_task_id, @created_at, @updated_at
+      @parent_task_id, @agent_id, @created_at, @updated_at
     )
   `);
   const getStmt = db.prepare('SELECT * FROM tasks WHERE task_id = ?');
@@ -86,6 +87,7 @@ export function createTaskRepository(db: ConcordDatabase): TaskRepository {
         notes: task.notes,
         status: 'active',
         parent_task_id: task.parentTaskId,
+        agent_id: task.agentId,
         created_at: now,
         updated_at: now,
       });

--- a/src/db/rows.ts
+++ b/src/db/rows.ts
@@ -68,6 +68,10 @@ export interface TaskRecord {
   status: TaskStatus;
   /** The parent task this is a subtask of, or null for a top-level task. */
   parentTaskId: string | null;
+  /** The agent instance (register_agent identity) that claimed this, or null.
+   * Distinct from `agent` (the kind string): used to check the claimant's
+   * liveness for stale-claim detection. */
+  agentId: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -86,6 +90,7 @@ const taskDbRowSchema = z.object({
   notes: z.string().nullable(),
   status: taskStatusSchema,
   parent_task_id: z.string().nullable(),
+  agent_id: z.string().nullable(),
   created_at: z.string(),
   updated_at: z.string(),
 });
@@ -106,6 +111,7 @@ export function parseTaskRow(raw: unknown): TaskRecord {
     notes: row.notes,
     status: row.status,
     parentTaskId: row.parent_task_id,
+    agentId: row.agent_id,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/src/db/rows.ts
+++ b/src/db/rows.ts
@@ -284,3 +284,61 @@ export function parseEventRow(raw: unknown): EventRecord {
     createdAt: row.created_at,
   };
 }
+
+// --- agents ----------------------------------------------------------------
+
+/** Status an agent reports about its own work. Liveness (live/idle/away) is
+ * derived separately from `last_seen` in `domain/presence.ts`. */
+export const agentStatusValues = ['active', 'blocked', 'waiting_review', 'done'] as const;
+export type AgentStatus = (typeof agentStatusValues)[number];
+const agentStatusSchema = z.enum(agentStatusValues);
+
+/** A registered agent instance. `agentId` is a distinct per-session identity
+ * (e.g. `claude-code:7p8v`), unlike the `agent` *kind* string on a task. */
+export interface AgentRecord {
+  agentId: string;
+  kind: string;
+  owner: string | null;
+  model: string | null;
+  pid: number | null;
+  cwd: string | null;
+  worktree: string | null;
+  branch: string | null;
+  summary: string | null;
+  status: AgentStatus;
+  firstSeen: string;
+  lastSeen: string;
+}
+
+const agentDbRowSchema = z.object({
+  agent_id: z.string(),
+  kind: z.string(),
+  owner: z.string().nullable(),
+  model: z.string().nullable(),
+  pid: z.number().int().nullable(),
+  cwd: z.string().nullable(),
+  worktree: z.string().nullable(),
+  branch: z.string().nullable(),
+  summary: z.string().nullable(),
+  status: agentStatusSchema,
+  first_seen: z.string(),
+  last_seen: z.string(),
+});
+
+export function parseAgentRow(raw: unknown): AgentRecord {
+  const row = agentDbRowSchema.parse(raw);
+  return {
+    agentId: row.agent_id,
+    kind: row.kind,
+    owner: row.owner,
+    model: row.model,
+    pid: row.pid,
+    cwd: row.cwd,
+    worktree: row.worktree,
+    branch: row.branch,
+    summary: row.summary,
+    status: row.status,
+    firstSeen: row.first_seen,
+    lastSeen: row.last_seen,
+  };
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -87,4 +87,25 @@ export const migrations: readonly string[] = [
 
   CREATE INDEX idx_task_updates_task_id ON task_updates(task_id);
   `,
+  // 005 — agent presence registry. Each running agent registers a distinct
+  // instance identity (agent_id) so concurrent agents are distinguishable and
+  // can see who else is active. Liveness is derived from last_seen, not stored.
+  `
+  CREATE TABLE agents (
+    agent_id   TEXT PRIMARY KEY,
+    kind       TEXT NOT NULL,
+    owner      TEXT,
+    model      TEXT,
+    pid        INTEGER,
+    cwd        TEXT,
+    worktree   TEXT,
+    branch     TEXT,
+    summary    TEXT,
+    status     TEXT NOT NULL DEFAULT 'active',
+    first_seen TEXT NOT NULL,
+    last_seen  TEXT NOT NULL
+  );
+
+  CREATE INDEX idx_agents_last_seen ON agents(last_seen);
+  `,
 ];

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -108,4 +108,10 @@ export const migrations: readonly string[] = [
 
   CREATE INDEX idx_agents_last_seen ON agents(last_seen);
   `,
+  // 006 — link a claim to the agent instance that made it, so stale claims
+  // (an active task whose owning agent has gone away) can be detected. A soft
+  // reference (no FK): the agent may register after, or not at all.
+  `
+  ALTER TABLE tasks ADD COLUMN agent_id TEXT;
+  `,
 ];

--- a/src/domain/presence.ts
+++ b/src/domain/presence.ts
@@ -1,4 +1,4 @@
-import type { AgentRecord, AgentStatus } from '../db/index.js';
+import type { AgentRecord, AgentStatus, TaskRecord } from '../db/index.js';
 
 /**
  * Liveness is *derived* from how long ago an agent was last seen — never stored.
@@ -69,6 +69,58 @@ function ageSecondsOf(lastSeen: string, now: number): number {
  * most-recently-seen. This is the "who is here and what are they doing" view
  * that other agents read before or while working.
  */
+/** An active claim whose owning agent is no longer reliably present. */
+export interface StaleClaim {
+  taskId: string;
+  title: string;
+  agentId: string;
+  /** Why it is stale: the agent is `away`, or was never seen (unregistered). */
+  reason: 'agent-away' | 'agent-unregistered';
+  /** Seconds since the owning agent was last seen, or null when unregistered. */
+  ageSeconds: number | null;
+}
+
+/**
+ * Flag active claims whose owning agent has gone away — the "agent walked off
+ * without handing off" case a durable claim alone cannot surface. Only claims
+ * carrying an `agentId` are assessed; unattributed claims are left alone (they
+ * predate presence and would be noise). A claim is stale when its agent is
+ * `away`, or when the referenced agent never registered.
+ */
+export function detectStaleClaims(
+  tasks: readonly TaskRecord[],
+  agents: readonly AgentRecord[],
+  now: number,
+  thresholds: PresenceThresholds = DEFAULT_PRESENCE_THRESHOLDS,
+): StaleClaim[] {
+  const byId = new Map(agents.map((agent) => [agent.agentId, agent]));
+  const stale: StaleClaim[] = [];
+  for (const task of tasks) {
+    if (task.status !== 'active' || task.agentId === null) {
+      continue;
+    }
+    const agent = byId.get(task.agentId);
+    if (agent === undefined) {
+      stale.push({
+        taskId: task.taskId,
+        title: task.title,
+        agentId: task.agentId,
+        reason: 'agent-unregistered',
+        ageSeconds: null,
+      });
+    } else if (deriveLiveness(agent.lastSeen, now, thresholds) === 'away') {
+      stale.push({
+        taskId: task.taskId,
+        title: task.title,
+        agentId: task.agentId,
+        reason: 'agent-away',
+        ageSeconds: ageSecondsOf(agent.lastSeen, now),
+      });
+    }
+  }
+  return stale;
+}
+
 export function buildRoster(
   agents: readonly AgentRecord[],
   now: number,

--- a/src/domain/presence.ts
+++ b/src/domain/presence.ts
@@ -1,0 +1,95 @@
+import type { AgentRecord, AgentStatus } from '../db/index.js';
+
+/**
+ * Liveness is *derived* from how long ago an agent was last seen — never stored.
+ * A registered claim is durable, but presence must decay so a crashed or
+ * walked-away agent stops looking active. Distinct from the agent's *reported*
+ * status (active/blocked/waiting_review/done), which says what it is doing.
+ */
+export type Liveness = 'live' | 'idle' | 'away';
+
+/** How long since `last_seen` before an agent is considered idle, then away. */
+export interface PresenceThresholds {
+  idleAfterMs: number;
+  awayAfterMs: number;
+}
+
+/** Live under 5 min, idle under 30 min, away beyond. */
+export const DEFAULT_PRESENCE_THRESHOLDS: PresenceThresholds = {
+  idleAfterMs: 5 * 60 * 1000,
+  awayAfterMs: 30 * 60 * 1000,
+};
+
+/** A single agent's presence for display in a roster. */
+export interface PresenceEntry {
+  agentId: string;
+  kind: string;
+  owner: string | null;
+  summary: string | null;
+  status: AgentStatus;
+  liveness: Liveness;
+  lastSeen: string;
+  /** Whole seconds since `last_seen`, floored at 0. */
+  ageSeconds: number;
+}
+
+/** Derive liveness from a `last_seen` ISO timestamp relative to `now` (ms since
+ * epoch). Unparseable timestamps are treated as `away`. */
+export function deriveLiveness(
+  lastSeen: string,
+  now: number,
+  thresholds: PresenceThresholds = DEFAULT_PRESENCE_THRESHOLDS,
+): Liveness {
+  const seen = Date.parse(lastSeen);
+  if (Number.isNaN(seen)) {
+    return 'away';
+  }
+  const age = now - seen;
+  if (age >= thresholds.awayAfterMs) {
+    return 'away';
+  }
+  if (age >= thresholds.idleAfterMs) {
+    return 'idle';
+  }
+  return 'live';
+}
+
+const LIVENESS_ORDER: Record<Liveness, number> = { live: 0, idle: 1, away: 2 };
+
+function ageSecondsOf(lastSeen: string, now: number): number {
+  const seen = Date.parse(lastSeen);
+  if (Number.isNaN(seen)) {
+    return 0;
+  }
+  return Math.max(0, Math.floor((now - seen) / 1000));
+}
+
+/**
+ * Build the presence roster from registered agents: live agents first, then by
+ * most-recently-seen. This is the "who is here and what are they doing" view
+ * that other agents read before or while working.
+ */
+export function buildRoster(
+  agents: readonly AgentRecord[],
+  now: number,
+  thresholds: PresenceThresholds = DEFAULT_PRESENCE_THRESHOLDS,
+): PresenceEntry[] {
+  return agents
+    .map((agent) => ({
+      agentId: agent.agentId,
+      kind: agent.kind,
+      owner: agent.owner,
+      summary: agent.summary,
+      status: agent.status,
+      liveness: deriveLiveness(agent.lastSeen, now, thresholds),
+      lastSeen: agent.lastSeen,
+      ageSeconds: ageSecondsOf(agent.lastSeen, now),
+    }))
+    .sort((a, b) => {
+      const byLiveness = LIVENESS_ORDER[a.liveness] - LIVENESS_ORDER[b.liveness];
+      if (byLiveness !== 0) {
+        return byLiveness;
+      }
+      return b.lastSeen.localeCompare(a.lastSeen);
+    });
+}

--- a/src/domain/schemas.ts
+++ b/src/domain/schemas.ts
@@ -1,10 +1,49 @@
 import { z } from 'zod';
 
+import { agentStatusValues } from '../db/rows.js';
+
 /**
  * Zod input schemas for the MCP tools. Each tool exposes its schema as a raw
  * shape (the form `McpServer.registerTool` expects) plus an inferred input type.
  * Fields use snake_case to match the tool's public JSON contract.
  */
+
+/** Optional instance identity carried by every write so it refreshes presence.
+ * Distinct from the `agent` *kind* string — this identifies one running
+ * instance (e.g. `claude-code:7p8v`), obtained from `register_agent`. */
+const agentIdField = z
+  .string()
+  .optional()
+  .describe(
+    'Identity of the registered agent instance doing this work, e.g. claude-code:7p8v. ' +
+      "Supplying it refreshes the agent's presence (liveness) in the roster.",
+  );
+
+export const registerAgentInputShape = {
+  agent_id: z
+    .string()
+    .optional()
+    .describe(
+      'Stable per-session identity for this agent instance, e.g. claude-code:7p8v. Omit on the ' +
+        'first call to have one generated, then reuse the returned id on every later call so ' +
+        'presence stays attributed to the same instance.',
+    ),
+  kind: z.string().min(1).describe('Agent type / provider, e.g. claude-code, codex, cursor'),
+  owner: z.string().optional().describe('Human accountable for this agent'),
+  model: z.string().optional().describe('Model the agent is running, e.g. opus-4.8'),
+  summary: z.string().optional().describe('One line: what this agent is working on right now'),
+  status: z
+    .enum(agentStatusValues)
+    .optional()
+    .describe('Reported status: active, blocked, waiting_review, or done (default active)'),
+  branch: z.string().optional().describe('Git branch, if known'),
+  worktree: z.string().optional().describe('Git worktree path, if used'),
+  cwd: z.string().optional().describe('Working directory, for disambiguating instances'),
+  pid: z.number().int().optional().describe('Process id, for disambiguating instances'),
+} as const;
+
+export const registerAgentInputSchema = z.object(registerAgentInputShape);
+export type RegisterAgentInput = z.infer<typeof registerAgentInputSchema>;
 
 export const claimWorkInputShape = {
   task_id: z.string().min(1).describe('Stable identifier for the task, e.g. TASK-12'),
@@ -32,6 +71,7 @@ export const claimWorkInputShape = {
   domains: z.array(z.string()).optional().describe('Product domains touched, e.g. payments'),
   risk_tags: z.array(z.string()).optional().describe('Risk tags, e.g. payment-flow'),
   notes: z.string().optional().describe('Freeform notes'),
+  agent_id: agentIdField,
 } as const;
 
 export const claimWorkInputSchema = z.object(claimWorkInputShape);
@@ -53,6 +93,7 @@ export const updateTaskInputShape = {
     .describe('The kind of task-scoped update'),
   content: z.string().min(1).describe('Concise context another agent needs'),
   agent: z.string().optional().describe('Agent recording the update; defaults to the claimant'),
+  agent_id: agentIdField,
 } as const;
 
 export const updateTaskInputSchema = z.object(updateTaskInputShape);
@@ -93,6 +134,7 @@ export const handoffInputShape = {
     .array(z.object({ field: z.string(), source: z.string() }))
     .optional()
     .describe('Where each claim came from, e.g. { field: "tests", source: "command output" }'),
+  agent_id: agentIdField,
 } as const;
 
 export const handoffInputSchema = z.object(handoffInputShape);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,12 @@
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
 import { writeArtifacts } from './artifacts/index.js';
-import { concordDir, databasePath, findRepoRoot } from './config/paths.js';
+import { concordDir, databasePath, resolveRepoRoot } from './config/paths.js';
 import { openRepositories } from './db/index.js';
 import { createServer } from './server.js';
 
 async function main(): Promise<void> {
-  const repoRoot = findRepoRoot(process.cwd());
+  const repoRoot = resolveRepoRoot(process.cwd(), process.env);
   const repos = openRepositories(databasePath(repoRoot));
   const artifactsDir = concordDir(repoRoot);
   const server = createServer(repos, {

--- a/src/install/claude-hooks.ts
+++ b/src/install/claude-hooks.ts
@@ -7,51 +7,68 @@ import { z } from 'zod';
 const MATCHER = 'Edit|Write|MultiEdit';
 /** The command Claude Code runs on each matched PreToolUse event. */
 export const PRE_TOOL_USE_HOOK_COMMAND = 'concord hook pre-tool-use';
+/** The command Claude Code runs once on SessionStart to auto-register presence. */
+export const SESSION_START_HOOK_COMMAND = 'concord hook session-start';
 
 const settingsSchema = z
   .object({
     hooks: z
-      .object({ PreToolUse: z.array(z.unknown()).optional() })
+      .object({
+        PreToolUse: z.array(z.unknown()).optional(),
+        SessionStart: z.array(z.unknown()).optional(),
+      })
       .passthrough()
       .optional(),
   })
   .passthrough();
 
+/** Append `entry` to the named hook event unless a hook running `command` is
+ * already present. Returns the updated event array. */
+function withHook(
+  existing: readonly unknown[],
+  command: string,
+  entry: unknown,
+): unknown[] {
+  const present = existing.some((item) => JSON.stringify(item).includes(command));
+  return present ? [...existing] : [...existing, entry];
+}
+
 /**
- * Idempotently add Concord's PreToolUse overlap hook to a `settings.json` string,
- * preserving every other setting (and any other hook events). Returns the new
- * file content. Passing the previous output back in is a no-op.
+ * Idempotently add Concord's Claude Code hooks to a `settings.json` string: the
+ * PreToolUse overlap gate and the SessionStart presence auto-register. Every
+ * other setting (and any other hook events) is preserved. Passing the previous
+ * output back in is a no-op.
  */
-export function upsertPreToolUseHook(existing: string | undefined): string {
+export function upsertClaudeHooks(existing: string | undefined): string {
   const source: unknown =
     existing === undefined || existing.trim() === '' ? {} : JSON.parse(existing);
   const settings = settingsSchema.parse(source);
   const hooks = settings.hooks ?? {};
-  const preToolUse = hooks.PreToolUse ?? [];
 
-  const alreadyInstalled = preToolUse.some((entry) =>
-    JSON.stringify(entry).includes(PRE_TOOL_USE_HOOK_COMMAND),
-  );
-  const nextPreToolUse = alreadyInstalled
-    ? preToolUse
-    : [
-        ...preToolUse,
-        { matcher: MATCHER, hooks: [{ type: 'command', command: PRE_TOOL_USE_HOOK_COMMAND }] },
-      ];
+  const preToolUse = withHook(hooks.PreToolUse ?? [], PRE_TOOL_USE_HOOK_COMMAND, {
+    matcher: MATCHER,
+    hooks: [{ type: 'command', command: PRE_TOOL_USE_HOOK_COMMAND }],
+  });
+  const sessionStart = withHook(hooks.SessionStart ?? [], SESSION_START_HOOK_COMMAND, {
+    hooks: [{ type: 'command', command: SESSION_START_HOOK_COMMAND }],
+  });
 
-  const next = { ...settings, hooks: { ...hooks, PreToolUse: nextPreToolUse } };
+  const next = {
+    ...settings,
+    hooks: { ...hooks, PreToolUse: preToolUse, SessionStart: sessionStart },
+  };
   return `${JSON.stringify(next, null, 2)}\n`;
 }
 
 /**
- * Write the PreToolUse hook into `<repoRoot>/.claude/settings.json` (created if
- * absent), preserving existing settings. Returns the relative path written.
+ * Write Concord's Claude Code hooks into `<repoRoot>/.claude/settings.json`
+ * (created if absent), preserving existing settings. Returns the relative path.
  */
 export function installClaudeHook(repoRoot: string): string {
   const relPath = join('.claude', 'settings.json');
   const fullPath = join(repoRoot, relPath);
   const existing = existsSync(fullPath) ? readFileSync(fullPath, 'utf8') : undefined;
   mkdirSync(dirname(fullPath), { recursive: true });
-  writeFileSync(fullPath, upsertPreToolUseHook(existing));
+  writeFileSync(fullPath, upsertClaudeHooks(existing));
   return relPath;
 }

--- a/src/install/instructions.ts
+++ b/src/install/instructions.ts
@@ -33,7 +33,10 @@ shows per-task adoption either way. For edit-time enforcement, wire a PreToolUse
 (or git pre-commit) hook to \`concord check <files> --task <your-task-id>\`; it
 exits non-zero when your edits collide with another agent's active claim. On
 Claude Code, \`concord install --claude-hooks\` installs this automatically — set
-\`CONCORD_TASK=<your task id>\` so the hook excludes your own claim.`;
+\`CONCORD_TASK=<your task id>\` so the hook excludes your own claim. It also
+installs a SessionStart hook that auto-registers your presence and tells you the
+\`agent_id\` to reuse, so you are visible in the roster even before your first
+tool call.`;
 
 /** MDC frontmatter used when creating a fresh Cursor rules file. */
 export const CURSOR_MDC_HEADER = `---

--- a/src/install/instructions.ts
+++ b/src/install/instructions.ts
@@ -3,15 +3,22 @@ export const CONCORD_INSTRUCTIONS = `## Concord — shared work-state for coding
 
 This project uses Concord MCP. Use its tools so your work is visible before PRs:
 
+- **At session start, call \`register_agent\`** with your kind (e.g. claude-code),
+  a one-line summary of what you are working on, and your status. Reuse the
+  returned \`agent_id\` on every later Concord call so your presence stays
+  attributed to one instance, and call \`register_agent\` again when your focus
+  changes. Then call \`get_work_state\` to see who else is active before you
+  start — it shows the agent roster, active claims, overlaps, and stale claims.
 - **Keep each claim small.** Break work into the smallest independently
   handoff-able unit and \`claim_work\` each piece separately, rather than
   claiming one broad task. Concord flags claims that look too broad.
-- **Before editing code**, call \`claim_work\` with the task id, title, and the
-  files/modules you expect to touch. Concord warns about overlaps with other
-  active work.
-- **While working**, call \`update_task\` for durable intent, progress,
-  assumptions, decisions, questions, answers, blockers, and findings. When
-  resuming or coordinating on a task, call \`get_task_context\` first.
+- **Before editing code**, call \`claim_work\` with the task id, title, your
+  \`agent_id\`, and the files/modules you expect to touch. Concord warns about
+  overlaps with other active work.
+- **While working**, call \`update_task\` (with your \`agent_id\`) for durable
+  intent, progress, assumptions, decisions, questions, answers, blockers, and
+  findings. When resuming or coordinating on a task, call \`get_task_context\`
+  first.
 - **Before finishing or when blocked**, call \`handoff\` with what changed, tests
   run, assumptions, decisions, and guardrails you checked. **Before a PR**, set
   \`ready_for_review\` (with open questions and provenance) to also produce a

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import { registerClaimWork } from './tools/claim-work.js';
 import { registerGetTaskContext } from './tools/get-task-context.js';
 import { registerWorkState } from './tools/get-work-state.js';
 import { registerHandoff } from './tools/handoff.js';
+import { registerRegisterAgent } from './tools/register-agent.js';
 import { registerUpdateTask } from './tools/update-task.js';
 import { VERSION } from './version.js';
 
@@ -30,6 +31,7 @@ export function createServer(repos: Repositories, options: ServerOptions = {}): 
     notifyWorkStateChanged();
   };
   registerGetTaskContext(server, repos);
+  registerRegisterAgent(server, repos, onWrite);
   registerClaimWork(server, repos, onWrite);
   registerUpdateTask(server, repos, onWrite);
   registerHandoff(server, repos, onWrite);

--- a/src/tools/claim-work.ts
+++ b/src/tools/claim-work.ts
@@ -108,6 +108,11 @@ export function handleClaimWork(repos: Repositories, input: ClaimWorkInput): Cla
     detail: overlaps.length > 0 ? `${String(overlaps.length)} overlap(s)` : null,
   });
 
+  // Working refreshes presence: a registered agent stays live just by claiming.
+  if (input.agent_id !== undefined) {
+    repos.agents.touch(input.agent_id);
+  }
+
   return {
     task,
     alreadyClaimed: existing !== undefined,

--- a/src/tools/claim-work.ts
+++ b/src/tools/claim-work.ts
@@ -94,6 +94,7 @@ export function handleClaimWork(repos: Repositories, input: ClaimWorkInput): Cla
       ...scope,
       notes: input.notes ?? null,
       parentTaskId,
+      agentId: input.agent_id ?? null,
     });
   } else if (scopeAdded.length > 0) {
     task = repos.tasks.updateScope(input.task_id, scope) ?? existing;

--- a/src/tools/get-work-state.ts
+++ b/src/tools/get-work-state.ts
@@ -48,6 +48,7 @@ export function registerWorkState(server: McpServer, repos: Repositories): () =>
           presence: view.presence,
           active: view.active,
           overlaps: view.overlaps,
+          stale_claims: view.staleClaims,
           review_ready: view.reviewReady,
           open_questions: view.openQuestions,
         },

--- a/src/tools/get-work-state.ts
+++ b/src/tools/get-work-state.ts
@@ -35,15 +35,17 @@ export function registerWorkState(server: McpServer, repos: Repositories): () =>
     {
       title: 'Get work state',
       description:
-        'Read the current shared work-state: active claims, overlaps (recomputed live across ' +
-        'all active tasks), and review-ready tasks. Read-only — call this before claiming to ' +
-        'see what other agents are already working on.',
+        'Read the current shared work-state: who is present (the agent roster with liveness), ' +
+        'active claims, overlaps (recomputed live across all active tasks), and review-ready ' +
+        'tasks. Read-only — call this before claiming to see who else is here and what they are ' +
+        'already working on.',
     },
     () => {
       const view = handleGetWorkState(repos);
       return {
         content: [{ type: 'text', text: renderStatusText(view) }],
         structuredContent: {
+          presence: view.presence,
           active: view.active,
           overlaps: view.overlaps,
           review_ready: view.reviewReady,

--- a/src/tools/handoff.ts
+++ b/src/tools/handoff.ts
@@ -56,6 +56,9 @@ export function handleHandoff(repos: Repositories, input: HandoffInput): Handoff
     status: 'success',
     detail: input.status,
   });
+  if (input.agent_id !== undefined) {
+    repos.agents.touch(input.agent_id);
+  }
 
   // Folding review_ready into handoff: when flagged, produce the review packet
   // (and set status review_ready) via the shared review handler. Otherwise the

--- a/src/tools/handoff.ts
+++ b/src/tools/handoff.ts
@@ -33,6 +33,7 @@ export function handleHandoff(repos: Repositories, input: HandoffInput): Handoff
       riskTags: [],
       notes: null,
       parentTaskId: null,
+      agentId: input.agent_id ?? null,
     });
   }
 

--- a/src/tools/register-agent.ts
+++ b/src/tools/register-agent.ts
@@ -1,0 +1,123 @@
+import { randomBytes } from 'node:crypto';
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import type { AgentRecord, Repositories } from '../db/index.js';
+import { buildRoster, type PresenceEntry } from '../domain/presence.js';
+import { registerAgentInputShape, type RegisterAgentInput } from '../domain/schemas.js';
+
+export interface RegisterAgentResult {
+  agent: AgentRecord;
+  /** True when this call created the agent rather than refreshing it. */
+  firstRegistration: boolean;
+  /** Every registered agent with derived liveness, most-live first. Includes self. */
+  roster: PresenceEntry[];
+}
+
+/** A short, human-typable instance id, e.g. `claude-code:7p8v`. Generated when
+ * the caller does not supply one; returned so it can be reused thereafter. */
+export function generateAgentId(kind: string): string {
+  return `${kind}:${randomBytes(2).toString('hex')}`;
+}
+
+/**
+ * Register (or refresh) an agent's presence so concurrent agents are
+ * distinguishable and can see who else is active. Returns the resolved identity
+ * plus the current roster, so the caller learns who else is here immediately —
+ * without a task claim (recon and research agents are visible too).
+ */
+export function handleRegisterAgent(
+  repos: Repositories,
+  input: RegisterAgentInput,
+  now: number = Date.now(),
+): RegisterAgentResult {
+  const agentId = input.agent_id ?? generateAgentId(input.kind);
+  const firstRegistration = repos.agents.get(agentId) === undefined;
+
+  const agent = repos.agents.upsert({
+    agentId,
+    kind: input.kind,
+    owner: input.owner ?? null,
+    model: input.model ?? null,
+    pid: input.pid ?? null,
+    cwd: input.cwd ?? null,
+    worktree: input.worktree ?? null,
+    branch: input.branch ?? null,
+    summary: input.summary ?? null,
+    status: input.status ?? 'active',
+  });
+
+  return { agent, firstRegistration, roster: buildRoster(repos.agents.list(), now) };
+}
+
+export function formatRegisterAgentText(result: RegisterAgentResult): string {
+  const verb = result.firstRegistration ? 'Registered' : 'Refreshed presence';
+  const owner = result.agent.owner === null ? '' : ` (owner ${result.agent.owner})`;
+  const lines = [`${verb} as ${result.agent.agentId}${owner}.`];
+
+  const others = result.roster.filter((entry) => entry.agentId !== result.agent.agentId);
+  if (others.length === 0) {
+    lines.push('No other agents are registered yet.');
+  } else {
+    lines.push(`${String(others.length)} other agent(s) here:`);
+    for (const entry of others) {
+      const doing = entry.summary ?? 'no summary';
+      lines.push(`  - ${entry.agentId} [${entry.liveness}/${entry.status}]: ${doing}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+function rosterToStructured(roster: readonly PresenceEntry[]): {
+  agent_id: string;
+  kind: string;
+  owner: string | null;
+  summary: string | null;
+  status: string;
+  liveness: string;
+  last_seen: string;
+  age_seconds: number;
+}[] {
+  return roster.map((entry) => ({
+    agent_id: entry.agentId,
+    kind: entry.kind,
+    owner: entry.owner,
+    summary: entry.summary,
+    status: entry.status,
+    liveness: entry.liveness,
+    last_seen: entry.lastSeen,
+    age_seconds: entry.ageSeconds,
+  }));
+}
+
+export function registerRegisterAgent(
+  server: McpServer,
+  repos: Repositories,
+  onWrite?: () => void,
+): void {
+  server.registerTool(
+    'register_agent',
+    {
+      title: 'Register agent',
+      description:
+        'Register this agent instance so other agents know who you are and what you are working ' +
+        'on. Call once at session start (reuse the returned agent_id afterwards) and again to ' +
+        'refresh your summary/status. Returns the current roster of active agents. Works without ' +
+        'a task claim, so recon and research agents are visible too.',
+      inputSchema: registerAgentInputShape,
+    },
+    (args) => {
+      const result = handleRegisterAgent(repos, args);
+      onWrite?.();
+      return {
+        content: [{ type: 'text', text: formatRegisterAgentText(result) }],
+        structuredContent: {
+          agent_id: result.agent.agentId,
+          first_registration: result.firstRegistration,
+          status: result.agent.status,
+          roster: rosterToStructured(result.roster),
+        },
+      };
+    },
+  );
+}

--- a/src/tools/review-ready.ts
+++ b/src/tools/review-ready.ts
@@ -32,6 +32,7 @@ export function handleReviewReady(repos: Repositories, input: ReviewReadyInput):
       riskTags: [],
       notes: null,
       parentTaskId: null,
+      agentId: null,
     });
   }
 

--- a/src/tools/update-task.ts
+++ b/src/tools/update-task.ts
@@ -26,6 +26,9 @@ export function handleUpdateTask(repos: Repositories, input: UpdateTaskInput): U
     status: 'success',
     detail: input.kind,
   });
+  if (input.agent_id !== undefined) {
+    repos.agents.touch(input.agent_id);
+  }
   return { update };
 }
 

--- a/test/artifacts/artifacts.test.ts
+++ b/test/artifacts/artifacts.test.ts
@@ -11,6 +11,7 @@ import { openDatabase } from '../../src/db/connection.js';
 import { createRepositories, type Repositories } from '../../src/db/index.js';
 import { handleClaimWork } from '../../src/tools/claim-work.js';
 import { handleHandoff } from '../../src/tools/handoff.js';
+import { handleRegisterAgent } from '../../src/tools/register-agent.js';
 import { handleReviewReady } from '../../src/tools/review-ready.js';
 
 describe('renderReviewPacketMarkdown', () => {
@@ -55,16 +56,23 @@ describe('writeArtifacts', () => {
 
   it('writes WORK_STATE.json and events.jsonl reflecting the DB', () => {
     handleClaimWork(repos, { task_id: 'TASK-12', title: 'Retry', modules: ['billing'] });
+    handleRegisterAgent(repos, {
+      agent_id: 'claude-code:7p8v',
+      kind: 'claude-code',
+      summary: 'building frontend',
+    });
     writeArtifacts(dir, repos, '2026-07-17T00:00:00.000Z');
 
     const workState = z
       .object({
         generated_at: z.string(),
+        presence: z.array(z.object({ agent_id: z.string(), liveness: z.string() })),
         tasks: z.array(z.object({ task_id: z.string(), status: z.string() })),
       })
       .parse(JSON.parse(readFileSync(join(dir, 'WORK_STATE.json'), 'utf8')));
     expect(workState.generated_at).toBe('2026-07-17T00:00:00.000Z');
     expect(workState.tasks[0]?.task_id).toBe('TASK-12');
+    expect(workState.presence[0]?.agent_id).toBe('claude-code:7p8v');
 
     const events = readFileSync(join(dir, 'events.jsonl'), 'utf8').trim().split('\n');
     expect(events).toHaveLength(1);

--- a/test/cli/cli-commands.test.ts
+++ b/test/cli/cli-commands.test.ts
@@ -73,7 +73,7 @@ describe('CLI read/export commands', () => {
 
   it('doctor reports schema version and adoption', () => {
     const report = runDoctor(dir);
-    expect(report).toContain('schema v5, expected v5');
+    expect(report).toContain('schema v6, expected v6');
     expect(report).toContain('TASK-12');
     expect(report).toContain('claim_work: yes');
     // The resolved workspace path is surfaced so agents don't have to hunt for it.

--- a/test/cli/cli-commands.test.ts
+++ b/test/cli/cli-commands.test.ts
@@ -73,7 +73,7 @@ describe('CLI read/export commands', () => {
 
   it('doctor reports schema version and adoption', () => {
     const report = runDoctor(dir);
-    expect(report).toContain('schema v4, expected v4');
+    expect(report).toContain('schema v5, expected v5');
     expect(report).toContain('TASK-12');
     expect(report).toContain('claim_work: yes');
     // The resolved workspace path is surfaced so agents don't have to hunt for it.

--- a/test/cli/cli-core.test.ts
+++ b/test/cli/cli-core.test.ts
@@ -167,6 +167,30 @@ describe('buildStatus / renderStatusText', () => {
   it("shows Who's here / none when no agent has registered", () => {
     expect(renderStatusText(buildStatus(repos))).toContain("Who's here\n  none");
   });
+
+  it('flags a stale claim once its owning agent has gone away', () => {
+    handleRegisterAgent(repos, { agent_id: 'claude-code:7p8v', kind: 'claude-code' });
+    handleClaimWork(repos, {
+      task_id: 'TASK-42',
+      title: 'Retry',
+      modules: ['billing'],
+      agent_id: 'claude-code:7p8v',
+    });
+
+    // Fresh: nothing stale yet.
+    expect(buildStatus(repos).staleClaims).toEqual([]);
+
+    // 31 minutes later the agent is past the away threshold.
+    const later = Date.now() + 31 * 60 * 1000;
+    const view = buildStatus(repos, later);
+    expect(view.staleClaims).toHaveLength(1);
+    expect(view.staleClaims[0]?.taskId).toBe('TASK-42');
+
+    const text = renderStatusText(view);
+    expect(text).toContain('Stale claims');
+    expect(text).toContain('TASK-42');
+    expect(text).toContain('claude-code:7p8v');
+  });
 });
 
 describe('runWho', () => {

--- a/test/cli/cli-core.test.ts
+++ b/test/cli/cli-core.test.ts
@@ -7,9 +7,12 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { openDatabase } from '../../src/db/connection.js';
 import { createRepositories, type Repositories } from '../../src/db/index.js';
 import { buildStatus, renderStatusText } from '../../src/artifacts/work-state-view.js';
-import { renderTasks } from '../../src/cli/commands/tasks.js';
 import { runInit } from '../../src/cli/commands/init.js';
+import { renderTasks } from '../../src/cli/commands/tasks.js';
+import { runWho } from '../../src/cli/commands/who.js';
+import { openContext } from '../../src/cli/context.js';
 import { handleClaimWork } from '../../src/tools/claim-work.js';
+import { handleRegisterAgent } from '../../src/tools/register-agent.js';
 import { handleReviewReady } from '../../src/tools/review-ready.js';
 
 function repoDir(): string {
@@ -143,5 +146,47 @@ describe('buildStatus / renderStatusText', () => {
     expect(view.reviewReady[0]?.openQuestionCount).toBe(1);
     expect(view.active).toHaveLength(0);
     expect(renderStatusText(view)).toContain('Sync or queued retries?');
+  });
+
+  it("includes the presence roster and renders a Who's here section", () => {
+    handleRegisterAgent(repos, {
+      agent_id: 'claude-code:7p8v',
+      kind: 'claude-code',
+      summary: 'building frontend',
+    });
+    const view = buildStatus(repos);
+    expect(view.presence).toHaveLength(1);
+    expect(view.presence[0]?.liveness).toBe('live');
+
+    const text = renderStatusText(view);
+    expect(text).toContain("Who's here");
+    expect(text).toContain('claude-code:7p8v');
+    expect(text).toContain('building frontend');
+  });
+
+  it("shows Who's here / none when no agent has registered", () => {
+    expect(renderStatusText(buildStatus(repos))).toContain("Who's here\n  none");
+  });
+});
+
+describe('runWho', () => {
+  it('lists agents registered in the workspace', () => {
+    const dir = repoDir();
+    runInit(dir);
+    handleRegisterAgent(openContext(dir).repos, {
+      agent_id: 'claude-code:7p8v',
+      kind: 'claude-code',
+      summary: 'building frontend',
+    });
+    const out = runWho(dir);
+    expect(out).toContain("Who's here");
+    expect(out).toContain('claude-code:7p8v');
+    expect(out).toContain('building frontend');
+  });
+
+  it('shows none when nobody has registered', () => {
+    const dir = repoDir();
+    runInit(dir);
+    expect(runWho(dir)).toContain('none');
   });
 });

--- a/test/cli/hook.test.ts
+++ b/test/cli/hook.test.ts
@@ -1,9 +1,14 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { decidePreToolUse } from '../../src/cli/commands/hook.js';
+import {
+  decidePreToolUse,
+  handleSessionStart,
+  sessionStartAgentId,
+} from '../../src/cli/commands/hook.js';
 import { openDatabase } from '../../src/db/connection.js';
 import { createRepositories, type Repositories } from '../../src/db/index.js';
 import { handleClaimWork } from '../../src/tools/claim-work.js';
+import { handleRegisterAgent } from '../../src/tools/register-agent.js';
 
 function preToolUse(filePath: string): string {
   return JSON.stringify({ tool_name: 'Edit', tool_input: { file_path: filePath } });
@@ -47,5 +52,52 @@ describe('decidePreToolUse', () => {
       decidePreToolUse(repos, JSON.stringify({ tool_name: 'Bash', tool_input: {} }), 'MINE').block,
     ).toBe(false);
     expect(decidePreToolUse(repos, 'not valid json', 'MINE').block).toBe(false);
+  });
+});
+
+describe('sessionStartAgentId', () => {
+  it('derives a stable id from the session id', () => {
+    expect(sessionStartAgentId('a1b2c3d4-e5f6-7890')).toBe('claude-code:a1b2c3d4');
+  });
+
+  it('falls back to a random suffix when no session id is given', () => {
+    expect(sessionStartAgentId(undefined)).toMatch(/^claude-code:[0-9a-f]{8}$/);
+  });
+});
+
+describe('handleSessionStart', () => {
+  let repos: Repositories;
+  beforeEach(() => {
+    repos = createRepositories(openDatabase(':memory:'));
+  });
+
+  it('registers the session as an agent and reports its id', () => {
+    const result = handleSessionStart(
+      repos,
+      JSON.stringify({ session_id: 'a1b2c3d4-e5f6', cwd: '/repo' }),
+    );
+    expect(result.agentId).toBe('claude-code:a1b2c3d4');
+    expect(result.message).toContain('claude-code:a1b2c3d4');
+    expect(result.message).toContain('No other agents');
+    expect(repos.agents.get('claude-code:a1b2c3d4')?.cwd).toBe('/repo');
+  });
+
+  it('is idempotent for the same session and lists other present agents', () => {
+    handleRegisterAgent(repos, {
+      agent_id: 'codex:9q2r',
+      kind: 'codex',
+      summary: 'building the backend',
+    });
+    const payload = JSON.stringify({ session_id: 'a1b2c3d4' });
+    handleSessionStart(repos, payload);
+    const again = handleSessionStart(repos, payload);
+    expect(repos.agents.list()).toHaveLength(2);
+    expect(again.message).toContain('codex:9q2r');
+    expect(again.message).toContain('building the backend');
+  });
+
+  it('tolerates a malformed payload by generating a random id', () => {
+    const result = handleSessionStart(repos, 'not json');
+    expect(result.agentId).toMatch(/^claude-code:[0-9a-f]{8}$/);
   });
 });

--- a/test/config/paths.test.ts
+++ b/test/config/paths.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { concordDir, databasePath, findRepoRoot } from '../../src/config/paths.js';
+import { concordDir, databasePath, findRepoRoot, resolveRepoRoot } from '../../src/config/paths.js';
 
 describe('paths', () => {
   it('derives .concord and db paths from a repo root', () => {
@@ -23,5 +23,41 @@ describe('paths', () => {
   it('falls back to the start dir when no .git is found', () => {
     const dir = mkdtempSync(join(tmpdir(), 'concord-nogit-'));
     expect(findRepoRoot(dir)).toBe(dir);
+  });
+});
+
+describe('resolveRepoRoot', () => {
+  it('uses process cwd when no env override is set', () => {
+    const root = mkdtempSync(join(tmpdir(), 'concord-cwd-'));
+    mkdirSync(join(root, '.git'));
+    const nested = join(root, 'pkg');
+    mkdirSync(nested);
+    expect(resolveRepoRoot(nested, {})).toBe(root);
+  });
+
+  it('prefers CLAUDE_PROJECT_DIR over cwd and normalizes to the git root', () => {
+    const project = mkdtempSync(join(tmpdir(), 'concord-proj-'));
+    mkdirSync(join(project, '.git'));
+    const nested = join(project, 'src');
+    mkdirSync(nested);
+    const elsewhere = mkdtempSync(join(tmpdir(), 'concord-elsewhere-'));
+    // cwd is an unrelated directory; the project dir must win.
+    expect(resolveRepoRoot(elsewhere, { CLAUDE_PROJECT_DIR: nested })).toBe(project);
+  });
+
+  it('lets CONCORD_REPO_ROOT override CLAUDE_PROJECT_DIR', () => {
+    const forced = mkdtempSync(join(tmpdir(), 'concord-forced-'));
+    mkdirSync(join(forced, '.git'));
+    const project = mkdtempSync(join(tmpdir(), 'concord-proj2-'));
+    mkdirSync(join(project, '.git'));
+    expect(
+      resolveRepoRoot('/nowhere', { CONCORD_REPO_ROOT: forced, CLAUDE_PROJECT_DIR: project }),
+    ).toBe(forced);
+  });
+
+  it('ignores blank env values', () => {
+    const root = mkdtempSync(join(tmpdir(), 'concord-blank-'));
+    mkdirSync(join(root, '.git'));
+    expect(resolveRepoRoot(root, { CONCORD_REPO_ROOT: '  ', CLAUDE_PROJECT_DIR: '' })).toBe(root);
   });
 });

--- a/test/db/connection.test.ts
+++ b/test/db/connection.test.ts
@@ -8,7 +8,7 @@ describe('openDatabase', () => {
   it('applies all migrations (user_version at head) and creates tables', () => {
     const db = openDatabase(':memory:');
     const version: unknown = db.pragma('user_version', { simple: true });
-    expect(version).toBe(4);
+    expect(version).toBe(5);
 
     const raw: unknown = db.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all();
     const names = new Set(
@@ -22,6 +22,7 @@ describe('openDatabase', () => {
     expect(names.has('events')).toBe(true);
     expect(names.has('reviews')).toBe(true);
     expect(names.has('task_updates')).toBe(true);
+    expect(names.has('agents')).toBe(true);
   });
 });
 

--- a/test/db/connection.test.ts
+++ b/test/db/connection.test.ts
@@ -8,7 +8,7 @@ describe('openDatabase', () => {
   it('applies all migrations (user_version at head) and creates tables', () => {
     const db = openDatabase(':memory:');
     const version: unknown = db.pragma('user_version', { simple: true });
-    expect(version).toBe(5);
+    expect(version).toBe(6);
 
     const raw: unknown = db.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all();
     const names = new Set(
@@ -47,6 +47,7 @@ describe('row parsing', () => {
       notes: null,
       status: 'active',
       parent_task_id: null,
+      agent_id: null,
       created_at: '2026-07-17T00:00:00.000Z',
       updated_at: '2026-07-17T00:00:00.000Z',
     });

--- a/test/db/storage.test.ts
+++ b/test/db/storage.test.ts
@@ -21,6 +21,7 @@ const baseTask = {
   riskTags: ['payment-flow'],
   notes: null,
   parentTaskId: null,
+  agentId: null,
 } as const;
 
 const baseAgent = {
@@ -54,7 +55,7 @@ describe('migrations', () => {
   it('is idempotent when reopening (user_version already at head)', () => {
     const { db } = newRepos();
     const version: unknown = db.pragma('user_version', { simple: true });
-    expect(version).toBe(5);
+    expect(version).toBe(6);
   });
 });
 

--- a/test/db/storage.test.ts
+++ b/test/db/storage.test.ts
@@ -23,6 +23,19 @@ const baseTask = {
   parentTaskId: null,
 } as const;
 
+const baseAgent = {
+  agentId: 'claude-code:7p8v',
+  kind: 'claude-code',
+  owner: 'alex',
+  model: 'opus-4.8',
+  pid: 4242,
+  cwd: '/repo',
+  worktree: null,
+  branch: 'feat/x',
+  summary: 'building the todo frontend',
+  status: 'active',
+} as const;
+
 describe('migrations', () => {
   it('applies migrations and creates the core tables', () => {
     const { db } = newRepos();
@@ -35,12 +48,13 @@ describe('migrations', () => {
     expect(names.has('handoffs')).toBe(true);
     expect(names.has('events')).toBe(true);
     expect(names.has('task_updates')).toBe(true);
+    expect(names.has('agents')).toBe(true);
   });
 
   it('is idempotent when reopening (user_version already at head)', () => {
     const { db } = newRepos();
     const version: unknown = db.pragma('user_version', { simple: true });
-    expect(version).toBe(4);
+    expect(version).toBe(5);
   });
 });
 
@@ -176,5 +190,59 @@ describe('event repository', () => {
     expect(repos.events.list()).toHaveLength(3);
     const forTask = repos.events.listByTask('TASK-12');
     expect(forTask.map((e) => e.tool)).toEqual(['claim_work', 'handoff']);
+  });
+});
+
+describe('agent repository', () => {
+  let repos: Repositories;
+  beforeEach(() => {
+    repos = newRepos();
+  });
+
+  it('registers an agent and reads it back with fields intact', () => {
+    const created = repos.agents.upsert(baseAgent);
+    expect(created.agentId).toBe('claude-code:7p8v');
+    expect(created.kind).toBe('claude-code');
+    expect(created.pid).toBe(4242);
+    expect(created.worktree).toBeNull();
+    expect(created.status).toBe('active');
+    expect(created.firstSeen).toBe(created.lastSeen);
+
+    const fetched = repos.agents.get('claude-code:7p8v');
+    expect(fetched?.summary).toBe('building the todo frontend');
+  });
+
+  it('returns undefined for an unknown agent', () => {
+    expect(repos.agents.get('nope')).toBeUndefined();
+    expect(repos.agents.touch('nope')).toBeUndefined();
+  });
+
+  it('re-registration preserves first_seen but refreshes mutable fields', () => {
+    const first = repos.agents.upsert(baseAgent);
+    const updated = repos.agents.upsert({
+      ...baseAgent,
+      summary: 'now reviewing the PR',
+      status: 'waiting_review',
+    });
+    expect(updated.firstSeen).toBe(first.firstSeen);
+    expect(updated.summary).toBe('now reviewing the PR');
+    expect(updated.status).toBe('waiting_review');
+    expect(repos.agents.list()).toHaveLength(1);
+  });
+
+  it('touch bumps last_seen without changing first_seen', () => {
+    const first = repos.agents.upsert(baseAgent);
+    const touched = repos.agents.touch('claude-code:7p8v');
+    expect(touched?.firstSeen).toBe(first.firstSeen);
+    expect(Date.parse(touched?.lastSeen ?? '')).toBeGreaterThanOrEqual(Date.parse(first.lastSeen));
+  });
+
+  it('lists multiple registered agents', () => {
+    repos.agents.upsert(baseAgent);
+    repos.agents.upsert({ ...baseAgent, agentId: 'codex:9q2r', kind: 'codex' });
+    expect(repos.agents.list().map((a) => a.agentId)).toEqual([
+      'claude-code:7p8v',
+      'codex:9q2r',
+    ]);
   });
 });

--- a/test/domain/overlap.test.ts
+++ b/test/domain/overlap.test.ts
@@ -18,6 +18,7 @@ function task(partial: Partial<TaskRecord> & { taskId: string }): TaskRecord {
     notes: null,
     status: partial.status ?? 'active',
     parentTaskId: partial.parentTaskId ?? null,
+    agentId: null,
     createdAt: '2026-07-17T00:00:00.000Z',
     updatedAt: '2026-07-17T00:00:00.000Z',
   };

--- a/test/domain/presence.test.ts
+++ b/test/domain/presence.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AgentRecord } from '../../src/db/index.js';
+import { buildRoster, deriveLiveness } from '../../src/domain/presence.js';
+
+const NOW = Date.parse('2026-07-24T12:00:00.000Z');
+
+/** An ISO timestamp `ms` before NOW. */
+function ago(ms: number): string {
+  return new Date(NOW - ms).toISOString();
+}
+
+function agent(partial: Partial<AgentRecord> & { agentId: string }): AgentRecord {
+  return {
+    agentId: partial.agentId,
+    kind: partial.kind ?? 'claude-code',
+    owner: partial.owner ?? null,
+    model: partial.model ?? null,
+    pid: partial.pid ?? null,
+    cwd: partial.cwd ?? null,
+    worktree: partial.worktree ?? null,
+    branch: partial.branch ?? null,
+    summary: partial.summary ?? null,
+    status: partial.status ?? 'active',
+    firstSeen: partial.firstSeen ?? ago(60 * 60 * 1000),
+    lastSeen: partial.lastSeen ?? ago(0),
+  };
+}
+
+describe('deriveLiveness', () => {
+  it('is live under the idle threshold', () => {
+    expect(deriveLiveness(ago(60 * 1000), NOW)).toBe('live');
+  });
+
+  it('is idle between the idle and away thresholds', () => {
+    expect(deriveLiveness(ago(10 * 60 * 1000), NOW)).toBe('idle');
+  });
+
+  it('is away beyond the away threshold', () => {
+    expect(deriveLiveness(ago(60 * 60 * 1000), NOW)).toBe('away');
+  });
+
+  it('treats the boundary as the later state (>=)', () => {
+    expect(deriveLiveness(ago(5 * 60 * 1000), NOW)).toBe('idle');
+    expect(deriveLiveness(ago(30 * 60 * 1000), NOW)).toBe('away');
+  });
+
+  it('treats an unparseable timestamp as away', () => {
+    expect(deriveLiveness('not-a-date', NOW)).toBe('away');
+  });
+
+  it('honours custom thresholds', () => {
+    expect(deriveLiveness(ago(2000), NOW, { idleAfterMs: 1000, awayAfterMs: 5000 })).toBe('idle');
+  });
+});
+
+describe('buildRoster', () => {
+  it('maps fields and computes whole-second age', () => {
+    const [entry] = buildRoster(
+      [agent({ agentId: 'claude-code:7p8v', summary: 'building frontend', lastSeen: ago(90_000) })],
+      NOW,
+    );
+    expect(entry?.agentId).toBe('claude-code:7p8v');
+    expect(entry?.summary).toBe('building frontend');
+    expect(entry?.liveness).toBe('live');
+    expect(entry?.ageSeconds).toBe(90);
+  });
+
+  it('orders live agents first, then most-recently-seen', () => {
+    const roster = buildRoster(
+      [
+        agent({ agentId: 'away-old', lastSeen: ago(60 * 60 * 1000) }),
+        agent({ agentId: 'live-older', lastSeen: ago(2 * 60 * 1000) }),
+        agent({ agentId: 'idle-mid', lastSeen: ago(10 * 60 * 1000) }),
+        agent({ agentId: 'live-newer', lastSeen: ago(30 * 1000) }),
+      ],
+      NOW,
+    );
+    expect(roster.map((entry) => entry.agentId)).toEqual([
+      'live-newer',
+      'live-older',
+      'idle-mid',
+      'away-old',
+    ]);
+  });
+
+  it('returns an empty roster when no agents are registered', () => {
+    expect(buildRoster([], NOW)).toEqual([]);
+  });
+});

--- a/test/domain/presence.test.ts
+++ b/test/domain/presence.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import type { AgentRecord } from '../../src/db/index.js';
-import { buildRoster, deriveLiveness } from '../../src/domain/presence.js';
+import type { AgentRecord, TaskRecord } from '../../src/db/index.js';
+import { buildRoster, detectStaleClaims, deriveLiveness } from '../../src/domain/presence.js';
 
 const NOW = Date.parse('2026-07-24T12:00:00.000Z');
 
@@ -86,5 +86,68 @@ describe('buildRoster', () => {
 
   it('returns an empty roster when no agents are registered', () => {
     expect(buildRoster([], NOW)).toEqual([]);
+  });
+});
+
+function task(partial: Partial<TaskRecord> & { taskId: string }): TaskRecord {
+  return {
+    taskId: partial.taskId,
+    title: partial.title ?? partial.taskId,
+    owner: null,
+    agent: null,
+    branch: null,
+    worktree: null,
+    expectedFiles: [],
+    modules: [],
+    domains: [],
+    riskTags: [],
+    notes: null,
+    status: partial.status ?? 'active',
+    parentTaskId: null,
+    agentId: partial.agentId ?? null,
+    createdAt: '2026-07-24T00:00:00.000Z',
+    updatedAt: '2026-07-24T00:00:00.000Z',
+  };
+}
+
+describe('detectStaleClaims', () => {
+  it('flags an active claim whose owning agent is away', () => {
+    const stale = detectStaleClaims(
+      [task({ taskId: 'T-1', agentId: 'claude-code:7p8v' })],
+      [agent({ agentId: 'claude-code:7p8v', lastSeen: ago(60 * 60 * 1000) })],
+      NOW,
+    );
+    expect(stale).toHaveLength(1);
+    expect(stale[0]?.reason).toBe('agent-away');
+    expect(stale[0]?.taskId).toBe('T-1');
+    expect(stale[0]?.ageSeconds).toBe(3600);
+  });
+
+  it('flags a claim whose agent never registered', () => {
+    const stale = detectStaleClaims([task({ taskId: 'T-1', agentId: 'ghost:zzzz' })], [], NOW);
+    expect(stale).toHaveLength(1);
+    expect(stale[0]?.reason).toBe('agent-unregistered');
+    expect(stale[0]?.ageSeconds).toBeNull();
+  });
+
+  it('does not flag a claim whose agent is still live', () => {
+    const stale = detectStaleClaims(
+      [task({ taskId: 'T-1', agentId: 'claude-code:7p8v' })],
+      [agent({ agentId: 'claude-code:7p8v', lastSeen: ago(60 * 1000) })],
+      NOW,
+    );
+    expect(stale).toEqual([]);
+  });
+
+  it('ignores unattributed claims (no agent_id) and non-active tasks', () => {
+    const stale = detectStaleClaims(
+      [
+        task({ taskId: 'T-1', agentId: null }),
+        task({ taskId: 'T-2', agentId: 'ghost:zzzz', status: 'handed_off' }),
+      ],
+      [],
+      NOW,
+    );
+    expect(stale).toEqual([]);
   });
 });

--- a/test/install/claude-hooks.test.ts
+++ b/test/install/claude-hooks.test.ts
@@ -1,18 +1,24 @@
 import { describe, expect, it } from 'vitest';
 
-import { PRE_TOOL_USE_HOOK_COMMAND, upsertPreToolUseHook } from '../../src/install/claude-hooks.js';
+import {
+  PRE_TOOL_USE_HOOK_COMMAND,
+  SESSION_START_HOOK_COMMAND,
+  upsertClaudeHooks,
+} from '../../src/install/claude-hooks.js';
 
-describe('upsertPreToolUseHook', () => {
-  it('adds the PreToolUse hook to empty settings', () => {
-    const out = upsertPreToolUseHook(undefined);
+describe('upsertClaudeHooks', () => {
+  it('adds the PreToolUse and SessionStart hooks to empty settings', () => {
+    const out = upsertClaudeHooks(undefined);
     expect(out).toContain('PreToolUse');
     expect(out).toContain(PRE_TOOL_USE_HOOK_COMMAND);
     expect(out).toContain('Edit|Write|MultiEdit');
+    expect(out).toContain('SessionStart');
+    expect(out).toContain(SESSION_START_HOOK_COMMAND);
   });
 
   it('is idempotent: re-running produces identical output', () => {
-    const once = upsertPreToolUseHook(undefined);
-    const twice = upsertPreToolUseHook(once);
+    const once = upsertClaudeHooks(undefined);
+    const twice = upsertClaudeHooks(once);
     expect(twice).toBe(once);
   });
 
@@ -21,16 +27,17 @@ describe('upsertPreToolUseHook', () => {
       model: 'opus',
       hooks: { PostToolUse: [{ matcher: 'Bash', hooks: [] }] },
     });
-    const out = upsertPreToolUseHook(existing);
+    const out = upsertClaudeHooks(existing);
     expect(out).toContain('"model": "opus"');
     expect(out).toContain('PostToolUse');
     expect(out).toContain(PRE_TOOL_USE_HOOK_COMMAND);
+    expect(out).toContain(SESSION_START_HOOK_COMMAND);
   });
 
-  it('does not duplicate the hook when one is already present', () => {
-    const once = upsertPreToolUseHook(undefined);
-    const twice = upsertPreToolUseHook(once);
-    const occurrences = twice.split(PRE_TOOL_USE_HOOK_COMMAND).length - 1;
-    expect(occurrences).toBe(1);
+  it('does not duplicate hooks when they are already present', () => {
+    const once = upsertClaudeHooks(undefined);
+    const twice = upsertClaudeHooks(once);
+    expect(twice.split(PRE_TOOL_USE_HOOK_COMMAND).length - 1).toBe(1);
+    expect(twice.split(SESSION_START_HOOK_COMMAND).length - 1).toBe(1);
   });
 });

--- a/test/tools/register-agent.test.ts
+++ b/test/tools/register-agent.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { openDatabase } from '../../src/db/connection.js';
+import { createRepositories, type Repositories } from '../../src/db/index.js';
+import { handleClaimWork } from '../../src/tools/claim-work.js';
+import { handleHandoff } from '../../src/tools/handoff.js';
+import {
+  formatRegisterAgentText,
+  generateAgentId,
+  handleRegisterAgent,
+} from '../../src/tools/register-agent.js';
+import { handleUpdateTask } from '../../src/tools/update-task.js';
+
+describe('handleRegisterAgent', () => {
+  let repos: Repositories;
+  beforeEach(() => {
+    repos = createRepositories(openDatabase(':memory:'));
+  });
+
+  it('generates a kind-prefixed id and registers a new agent', () => {
+    const result = handleRegisterAgent(repos, { kind: 'claude-code', owner: 'alex' });
+    expect(result.firstRegistration).toBe(true);
+    expect(result.agent.agentId).toMatch(/^claude-code:[0-9a-f]{4}$/);
+    expect(result.agent.status).toBe('active');
+    expect(result.roster).toHaveLength(1);
+    expect(result.roster[0]?.liveness).toBe('live');
+  });
+
+  it('reuses a supplied agent_id and refreshes on re-register without duplicating', () => {
+    const first = handleRegisterAgent(repos, {
+      agent_id: 'claude-code:7p8v',
+      kind: 'claude-code',
+      summary: 'building frontend',
+    });
+    expect(first.firstRegistration).toBe(true);
+
+    const again = handleRegisterAgent(repos, {
+      agent_id: 'claude-code:7p8v',
+      kind: 'claude-code',
+      summary: 'now reviewing',
+      status: 'waiting_review',
+    });
+    expect(again.firstRegistration).toBe(false);
+    expect(again.agent.summary).toBe('now reviewing');
+    expect(again.agent.status).toBe('waiting_review');
+    expect(repos.agents.list()).toHaveLength(1);
+  });
+
+  it('returns a roster of every registered agent and names others in the text', () => {
+    handleRegisterAgent(repos, {
+      agent_id: 'codex:9q2r',
+      kind: 'codex',
+      summary: 'building the backend',
+    });
+    const result = handleRegisterAgent(repos, { agent_id: 'claude-code:7p8v', kind: 'claude-code' });
+    expect(result.roster.map((entry) => entry.agentId).sort()).toEqual([
+      'claude-code:7p8v',
+      'codex:9q2r',
+    ]);
+    const text = formatRegisterAgentText(result);
+    expect(text).toContain('Registered as claude-code:7p8v');
+    expect(text).toContain('1 other agent(s) here');
+    expect(text).toContain('codex:9q2r');
+    expect(text).toContain('building the backend');
+  });
+
+  it('says so when no other agents are registered', () => {
+    const result = handleRegisterAgent(repos, { agent_id: 'solo:0001', kind: 'claude-code' });
+    expect(formatRegisterAgentText(result)).toContain('No other agents are registered yet.');
+  });
+
+  it('generateAgentId produces distinct kind-prefixed ids', () => {
+    const a = generateAgentId('codex');
+    const b = generateAgentId('codex');
+    expect(a).toMatch(/^codex:[0-9a-f]{4}$/);
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('presence refresh through write tools', () => {
+  let repos: Repositories;
+  beforeEach(() => {
+    repos = createRepositories(openDatabase(':memory:'));
+    handleRegisterAgent(repos, { agent_id: 'claude-code:7p8v', kind: 'claude-code' });
+  });
+
+  it('claim_work with a registered agent_id keeps the agent present, adds no rows', () => {
+    handleClaimWork(repos, {
+      task_id: 'TASK-1',
+      title: 'Work',
+      modules: ['billing'],
+      agent_id: 'claude-code:7p8v',
+    });
+    expect(repos.agents.get('claude-code:7p8v')).toBeDefined();
+    expect(repos.agents.list()).toHaveLength(1);
+  });
+
+  it('a write with an unregistered agent_id is a safe no-op (no throw, no ghost row)', () => {
+    expect(() =>
+      handleClaimWork(repos, { task_id: 'TASK-2', title: 'Work', agent_id: 'ghost:zzzz' }),
+    ).not.toThrow();
+    expect(repos.agents.get('ghost:zzzz')).toBeUndefined();
+    expect(repos.agents.list()).toHaveLength(1);
+  });
+
+  it('update_task and handoff also accept and refresh a registered agent_id', () => {
+    handleClaimWork(repos, { task_id: 'TASK-3', title: 'Work', agent_id: 'claude-code:7p8v' });
+    handleUpdateTask(repos, {
+      task_id: 'TASK-3',
+      kind: 'progress',
+      content: 'halfway',
+      agent_id: 'claude-code:7p8v',
+    });
+    handleHandoff(repos, {
+      task_id: 'TASK-3',
+      status: 'done',
+      what_changed: 'finished',
+      agent_id: 'claude-code:7p8v',
+    });
+    expect(repos.agents.get('claude-code:7p8v')).toBeDefined();
+    expect(repos.agents.list()).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Why

Presence was Concord's **#1 collaboration primitive** in the founding research ("who is active, idle, blocked, waiting, or done?") but was deliberately deferred for the YC MVP. Two real concurrent sessions on the same repo proved the gap now bites: both agents wrote the non-unique kind label `agent:"claude-code"`, overlap detection returned `[]` every time, one hit a **false-negative empty store**, and the human had to broker coordination by hand — *"tell the other agents what you are working on in concord."*

This adds the smallest useful version of agent presence: agents **register who they are and what they're working on**, everyone can see the roster, and abandoned claims surface.

## What

Delivered as 7 focused commits (each one concern, each <600 LOC):

- **Registry + presence core** — `agents` table (distinct per-instance `agent_id`, e.g. `claude-code:7p8v`), agents repository, and pure `domain/presence.ts` where liveness (`live`/`idle`/`away`) is *derived* from `last_seen`, never stored.
- **`register_agent` (6th MCP tool)** — registers/refreshes identity + summary + status and returns the live roster; works without a task claim (recon/research agents are visible too). `agent_id` is threaded through `claim_work`/`update_task`/`handoff` so presence stays live just by working.
- **Roster on the read paths** — `get_work_state`, new `concord who`, `concord status`, and `WORK_STATE.json` all show who's here.
- **Stale-claim detection** — `tasks.agent_id` links a claim to its instance; an active claim whose owner is away or never registered is flagged ("agent walked away without handing off").
- **Claude Code `SessionStart` hook** — `concord install --claude-hooks` now also auto-registers the session (id derived from `session_id`), so presence isn't dependent on the model remembering.
- **Repo-root store fix** — the MCP server resolved its store from `process.cwd()`, which breaks when it's user-scoped; now `CONCORD_REPO_ROOT` → `CLAUDE_PROJECT_DIR` (Claude Code sets this to the project root) → cwd, each normalized to the git root. This is what makes concurrent same-repo agents share one store — the prerequisite for presence to work at all.

## Surface change

Tool surface goes 5 → 6 (`register_agent` added). This was an explicit product decision; `CLAUDE.md` is updated to record it.

## Testing

`pnpm typecheck && pnpm lint && pnpm test && pnpm build` all green — 139 tests (26 new). Each new surface was also smoke-tested end-to-end against a real SQLite store (roster, stale detection, the session-start hook, and repo-root precedence).

## Note

This is intentionally one stacked PR of all 7 commits (~1460 LOC), so the `pr-size-check` job will fail the 600-LOC gate. The commits are independent and can be split into 7 sequential PRs if you'd prefer to respect that gate.

## Follow-ups (not in this PR)

- Auto-refresh presence on each edit via the PreToolUse hook.
- MCP `roots` discovery as a richer alternative to `CLAUDE_PROJECT_DIR` (works, but deprecated in the 2026-07-28 spec).
- Cross-worktree / cross-machine presence → Concord Cloud.