### PR TITLE
feat: add the local agent presence registry

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,4 +1,5 @@
 import { openDatabase, type ConcordDatabase } from './connection.js';
+import { createAgentRepository, type AgentRepository } from './repositories/agents.js';
 import { createEventRepository, type EventRepository } from './repositories/events.js';
 import { createHandoffRepository, type HandoffRepository } from './repositories/handoffs.js';
 import { createReviewRepository, type ReviewRepository } from './repositories/reviews.js';
@@ -15,6 +16,7 @@ export type { NewHandoff, HandoffRepository } from './repositories/handoffs.js';
 export type { NewReview, ReviewRepository } from './repositories/reviews.js';
 export type { NewTaskUpdate, TaskUpdateRepository } from './repositories/task-updates.js';
 export type { NewEvent, EventRepository } from './repositories/events.js';
+export type { NewAgent, AgentRepository } from './repositories/agents.js';
 export type {
   TaskRecord,
   TaskStatus,
@@ -26,6 +28,8 @@ export type {
   ToolName,
   TaskUpdateKind,
   TaskUpdateRecord,
+  AgentRecord,
+  AgentStatus,
 } from './rows.js';
 
 /** The full set of Concord repositories bound to one database. */
@@ -36,6 +40,7 @@ export interface Repositories {
   reviews: ReviewRepository;
   taskUpdates: TaskUpdateRepository;
   events: EventRepository;
+  agents: AgentRepository;
 }
 
 /** Bind all repositories to an already-open database. */
@@ -47,6 +52,7 @@ export function createRepositories(db: ConcordDatabase): Repositories {
     reviews: createReviewRepository(db),
     taskUpdates: createTaskUpdateRepository(db),
     events: createEventRepository(db),
+    agents: createAgentRepository(db),
   };
 }
 

--- a/src/db/repositories/agents.ts
+++ b/src/db/repositories/agents.ts
@@ -1,0 +1,99 @@
+import { z } from 'zod';
+
+import type { ConcordDatabase } from '../connection.js';
+import { type AgentRecord, type AgentStatus, parseAgentRow } from '../rows.js';
+
+/** A registration payload. Optional fields are explicit `null`. `agentId` is
+ * supplied by the caller (generated once per session and reused). */
+export interface NewAgent {
+  agentId: string;
+  kind: string;
+  owner: string | null;
+  model: string | null;
+  pid: number | null;
+  cwd: string | null;
+  worktree: string | null;
+  branch: string | null;
+  summary: string | null;
+  status: AgentStatus;
+}
+
+export interface AgentRepository {
+  /** Insert or refresh an agent. On re-registration the mutable fields and
+   * `last_seen` are updated while `first_seen` is preserved. */
+  upsert(agent: NewAgent): AgentRecord;
+  get(agentId: string): AgentRecord | undefined;
+  list(): AgentRecord[];
+  /** Bump `last_seen` to now so an agent stays present just by doing work.
+   * Returns undefined if the agent has never registered. */
+  touch(agentId: string): AgentRecord | undefined;
+}
+
+const rawListSchema = z.array(z.unknown());
+
+export function createAgentRepository(db: ConcordDatabase): AgentRepository {
+  const upsertStmt = db.prepare(`
+    INSERT INTO agents (
+      agent_id, kind, owner, model, pid, cwd, worktree, branch, summary, status,
+      first_seen, last_seen
+    ) VALUES (
+      @agent_id, @kind, @owner, @model, @pid, @cwd, @worktree, @branch, @summary, @status,
+      @now, @now
+    )
+    ON CONFLICT(agent_id) DO UPDATE SET
+      kind = excluded.kind,
+      owner = excluded.owner,
+      model = excluded.model,
+      pid = excluded.pid,
+      cwd = excluded.cwd,
+      worktree = excluded.worktree,
+      branch = excluded.branch,
+      summary = excluded.summary,
+      status = excluded.status,
+      last_seen = excluded.last_seen
+  `);
+  const getStmt = db.prepare('SELECT * FROM agents WHERE agent_id = ?');
+  const listStmt = db.prepare('SELECT * FROM agents ORDER BY first_seen ASC, agent_id ASC');
+  const touchStmt = db.prepare('UPDATE agents SET last_seen = @now WHERE agent_id = @agent_id');
+
+  function get(agentId: string): AgentRecord | undefined {
+    const raw: unknown = getStmt.get(agentId);
+    if (raw === undefined) {
+      return undefined;
+    }
+    return parseAgentRow(raw);
+  }
+
+  return {
+    upsert(agent) {
+      const now = new Date().toISOString();
+      upsertStmt.run({
+        agent_id: agent.agentId,
+        kind: agent.kind,
+        owner: agent.owner,
+        model: agent.model,
+        pid: agent.pid,
+        cwd: agent.cwd,
+        worktree: agent.worktree,
+        branch: agent.branch,
+        summary: agent.summary,
+        status: agent.status,
+        now,
+      });
+      const stored = get(agent.agentId);
+      if (stored === undefined) {
+        throw new Error(`Agent ${agent.agentId} could not be read back after upsert`);
+      }
+      return stored;
+    },
+    get,
+    list() {
+      const raw: unknown = listStmt.all();
+      return rawListSchema.parse(raw).map(parseAgentRow);
+    },
+    touch(agentId) {
+      touchStmt.run({ agent_id: agentId, now: new Date().toISOString() });
+      return get(agentId);
+    },
+  };
+}

--- a/src/db/rows.ts
+++ b/src/db/rows.ts
@@ -284,3 +284,61 @@ export function parseEventRow(raw: unknown): EventRecord {
     createdAt: row.created_at,
   };
 }
+
+// --- agents ----------------------------------------------------------------
+
+/** Status an agent reports about its own work. Liveness (live/idle/away) is
+ * derived separately from `last_seen` in `domain/presence.ts`. */
+export const agentStatusValues = ['active', 'blocked', 'waiting_review', 'done'] as const;
+export type AgentStatus = (typeof agentStatusValues)[number];
+const agentStatusSchema = z.enum(agentStatusValues);
+
+/** A registered agent instance. `agentId` is a distinct per-session identity
+ * (e.g. `claude-code:7p8v`), unlike the `agent` *kind* string on a task. */
+export interface AgentRecord {
+  agentId: string;
+  kind: string;
+  owner: string | null;
+  model: string | null;
+  pid: number | null;
+  cwd: string | null;
+  worktree: string | null;
+  branch: string | null;
+  summary: string | null;
+  status: AgentStatus;
+  firstSeen: string;
+  lastSeen: string;
+}
+
+const agentDbRowSchema = z.object({
+  agent_id: z.string(),
+  kind: z.string(),
+  owner: z.string().nullable(),
+  model: z.string().nullable(),
+  pid: z.number().int().nullable(),
+  cwd: z.string().nullable(),
+  worktree: z.string().nullable(),
+  branch: z.string().nullable(),
+  summary: z.string().nullable(),
+  status: agentStatusSchema,
+  first_seen: z.string(),
+  last_seen: z.string(),
+});
+
+export function parseAgentRow(raw: unknown): AgentRecord {
+  const row = agentDbRowSchema.parse(raw);
+  return {
+    agentId: row.agent_id,
+    kind: row.kind,
+    owner: row.owner,
+    model: row.model,
+    pid: row.pid,
+    cwd: row.cwd,
+    worktree: row.worktree,
+    branch: row.branch,
+    summary: row.summary,
+    status: row.status,
+    firstSeen: row.first_seen,
+    lastSeen: row.last_seen,
+  };
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -87,4 +87,25 @@ export const migrations: readonly string[] = [
 
   CREATE INDEX idx_task_updates_task_id ON task_updates(task_id);
   `,
+  // 005 — agent presence registry. Each running agent registers a distinct
+  // instance identity (agent_id) so concurrent agents are distinguishable and
+  // can see who else is active. Liveness is derived from last_seen, not stored.
+  `
+  CREATE TABLE agents (
+    agent_id   TEXT PRIMARY KEY,
+    kind       TEXT NOT NULL,
+    owner      TEXT,
+    model      TEXT,
+    pid        INTEGER,
+    cwd        TEXT,
+    worktree   TEXT,
+    branch     TEXT,
+    summary    TEXT,
+    status     TEXT NOT NULL DEFAULT 'active',
+    first_seen TEXT NOT NULL,
+    last_seen  TEXT NOT NULL
+  );
+
+  CREATE INDEX idx_agents_last_seen ON agents(last_seen);
+  `,
 ];

--- a/src/domain/presence.ts
+++ b/src/domain/presence.ts
@@ -1,0 +1,95 @@
+import type { AgentRecord, AgentStatus } from '../db/index.js';
+
+/**
+ * Liveness is *derived* from how long ago an agent was last seen — never stored.
+ * A registered claim is durable, but presence must decay so a crashed or
+ * walked-away agent stops looking active. Distinct from the agent's *reported*
+ * status (active/blocked/waiting_review/done), which says what it is doing.
+ */
+export type Liveness = 'live' | 'idle' | 'away';
+
+/** How long since `last_seen` before an agent is considered idle, then away. */
+export interface PresenceThresholds {
+  idleAfterMs: number;
+  awayAfterMs: number;
+}
+
+/** Live under 5 min, idle under 30 min, away beyond. */
+export const DEFAULT_PRESENCE_THRESHOLDS: PresenceThresholds = {
+  idleAfterMs: 5 * 60 * 1000,
+  awayAfterMs: 30 * 60 * 1000,
+};
+
+/** A single agent's presence for display in a roster. */
+export interface PresenceEntry {
+  agentId: string;
+  kind: string;
+  owner: string | null;
+  summary: string | null;
+  status: AgentStatus;
+  liveness: Liveness;
+  lastSeen: string;
+  /** Whole seconds since `last_seen`, floored at 0. */
+  ageSeconds: number;
+}
+
+/** Derive liveness from a `last_seen` ISO timestamp relative to `now` (ms since
+ * epoch). Unparseable timestamps are treated as `away`. */
+export function deriveLiveness(
+  lastSeen: string,
+  now: number,
+  thresholds: PresenceThresholds = DEFAULT_PRESENCE_THRESHOLDS,
+): Liveness {
+  const seen = Date.parse(lastSeen);
+  if (Number.isNaN(seen)) {
+    return 'away';
+  }
+  const age = now - seen;
+  if (age >= thresholds.awayAfterMs) {
+    return 'away';
+  }
+  if (age >= thresholds.idleAfterMs) {
+    return 'idle';
+  }
+  return 'live';
+}
+
+const LIVENESS_ORDER: Record<Liveness, number> = { live: 0, idle: 1, away: 2 };
+
+function ageSecondsOf(lastSeen: string, now: number): number {
+  const seen = Date.parse(lastSeen);
+  if (Number.isNaN(seen)) {
+    return 0;
+  }
+  return Math.max(0, Math.floor((now - seen) / 1000));
+}
+
+/**
+ * Build the presence roster from registered agents: live agents first, then by
+ * most-recently-seen. This is the "who is here and what are they doing" view
+ * that other agents read before or while working.
+ */
+export function buildRoster(
+  agents: readonly AgentRecord[],
+  now: number,
+  thresholds: PresenceThresholds = DEFAULT_PRESENCE_THRESHOLDS,
+): PresenceEntry[] {
+  return agents
+    .map((agent) => ({
+      agentId: agent.agentId,
+      kind: agent.kind,
+      owner: agent.owner,
+      summary: agent.summary,
+      status: agent.status,
+      liveness: deriveLiveness(agent.lastSeen, now, thresholds),
+      lastSeen: agent.lastSeen,
+      ageSeconds: ageSecondsOf(agent.lastSeen, now),
+    }))
+    .sort((a, b) => {
+      const byLiveness = LIVENESS_ORDER[a.liveness] - LIVENESS_ORDER[b.liveness];
+      if (byLiveness !== 0) {
+        return byLiveness;
+      }
+      return b.lastSeen.localeCompare(a.lastSeen);
+    });
+}

--- a/test/cli/cli-commands.test.ts
+++ b/test/cli/cli-commands.test.ts
@@ -73,7 +73,7 @@ describe('CLI read/export commands', () => {
 
   it('doctor reports schema version and adoption', () => {
     const report = runDoctor(dir);
-    expect(report).toContain('schema v4, expected v4');
+    expect(report).toContain('schema v5, expected v5');
     expect(report).toContain('TASK-12');
     expect(report).toContain('claim_work: yes');
     // The resolved workspace path is surfaced so agents don't have to hunt for it.

--- a/test/db/connection.test.ts
+++ b/test/db/connection.test.ts
@@ -8,7 +8,7 @@ describe('openDatabase', () => {
   it('applies all migrations (user_version at head) and creates tables', () => {
     const db = openDatabase(':memory:');
     const version: unknown = db.pragma('user_version', { simple: true });
-    expect(version).toBe(4);
+    expect(version).toBe(5);
 
     const raw: unknown = db.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all();
     const names = new Set(
@@ -22,6 +22,7 @@ describe('openDatabase', () => {
     expect(names.has('events')).toBe(true);
     expect(names.has('reviews')).toBe(true);
     expect(names.has('task_updates')).toBe(true);
+    expect(names.has('agents')).toBe(true);
   });
 });
 

--- a/test/db/storage.test.ts
+++ b/test/db/storage.test.ts
@@ -23,6 +23,19 @@ const baseTask = {
   parentTaskId: null,
 } as const;
 
+const baseAgent = {
+  agentId: 'claude-code:7p8v',
+  kind: 'claude-code',
+  owner: 'alex',
+  model: 'opus-4.8',
+  pid: 4242,
+  cwd: '/repo',
+  worktree: null,
+  branch: 'feat/x',
+  summary: 'building the todo frontend',
+  status: 'active',
+} as const;
+
 describe('migrations', () => {
   it('applies migrations and creates the core tables', () => {
     const { db } = newRepos();
@@ -35,12 +48,13 @@ describe('migrations', () => {
     expect(names.has('handoffs')).toBe(true);
     expect(names.has('events')).toBe(true);
     expect(names.has('task_updates')).toBe(true);
+    expect(names.has('agents')).toBe(true);
   });
 
   it('is idempotent when reopening (user_version already at head)', () => {
     const { db } = newRepos();
     const version: unknown = db.pragma('user_version', { simple: true });
-    expect(version).toBe(4);
+    expect(version).toBe(5);
   });
 });
 
@@ -176,5 +190,59 @@ describe('event repository', () => {
     expect(repos.events.list()).toHaveLength(3);
     const forTask = repos.events.listByTask('TASK-12');
     expect(forTask.map((e) => e.tool)).toEqual(['claim_work', 'handoff']);
+  });
+});
+
+describe('agent repository', () => {
+  let repos: Repositories;
+  beforeEach(() => {
+    repos = newRepos();
+  });
+
+  it('registers an agent and reads it back with fields intact', () => {
+    const created = repos.agents.upsert(baseAgent);
+    expect(created.agentId).toBe('claude-code:7p8v');
+    expect(created.kind).toBe('claude-code');
+    expect(created.pid).toBe(4242);
+    expect(created.worktree).toBeNull();
+    expect(created.status).toBe('active');
+    expect(created.firstSeen).toBe(created.lastSeen);
+
+    const fetched = repos.agents.get('claude-code:7p8v');
+    expect(fetched?.summary).toBe('building the todo frontend');
+  });
+
+  it('returns undefined for an unknown agent', () => {
+    expect(repos.agents.get('nope')).toBeUndefined();
+    expect(repos.agents.touch('nope')).toBeUndefined();
+  });
+
+  it('re-registration preserves first_seen but refreshes mutable fields', () => {
+    const first = repos.agents.upsert(baseAgent);
+    const updated = repos.agents.upsert({
+      ...baseAgent,
+      summary: 'now reviewing the PR',
+      status: 'waiting_review',
+    });
+    expect(updated.firstSeen).toBe(first.firstSeen);
+    expect(updated.summary).toBe('now reviewing the PR');
+    expect(updated.status).toBe('waiting_review');
+    expect(repos.agents.list()).toHaveLength(1);
+  });
+
+  it('touch bumps last_seen without changing first_seen', () => {
+    const first = repos.agents.upsert(baseAgent);
+    const touched = repos.agents.touch('claude-code:7p8v');
+    expect(touched?.firstSeen).toBe(first.firstSeen);
+    expect(Date.parse(touched?.lastSeen ?? '')).toBeGreaterThanOrEqual(Date.parse(first.lastSeen));
+  });
+
+  it('lists multiple registered agents', () => {
+    repos.agents.upsert(baseAgent);
+    repos.agents.upsert({ ...baseAgent, agentId: 'codex:9q2r', kind: 'codex' });
+    expect(repos.agents.list().map((a) => a.agentId)).toEqual([
+      'claude-code:7p8v',
+      'codex:9q2r',
+    ]);
   });
 });

--- a/test/db/storage.test.ts
+++ b/test/db/storage.test.ts
@@ -240,9 +240,6 @@ describe('agent repository', () => {
   it('lists multiple registered agents', () => {
     repos.agents.upsert(baseAgent);
     repos.agents.upsert({ ...baseAgent, agentId: 'codex:9q2r', kind: 'codex' });
-    expect(repos.agents.list().map((a) => a.agentId)).toEqual([
-      'claude-code:7p8v',
-      'codex:9q2r',
-    ]);
+    expect(repos.agents.list().map((a) => a.agentId)).toEqual(['claude-code:7p8v', 'codex:9q2r']);
   });
 });

--- a/test/domain/presence.test.ts
+++ b/test/domain/presence.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AgentRecord } from '../../src/db/index.js';
+import { buildRoster, deriveLiveness } from '../../src/domain/presence.js';
+
+const NOW = Date.parse('2026-07-24T12:00:00.000Z');
+
+/** An ISO timestamp `ms` before NOW. */
+function ago(ms: number): string {
+  return new Date(NOW - ms).toISOString();
+}
+
+function agent(partial: Partial<AgentRecord> & { agentId: string }): AgentRecord {
+  return {
+    agentId: partial.agentId,
+    kind: partial.kind ?? 'claude-code',
+    owner: partial.owner ?? null,
+    model: partial.model ?? null,
+    pid: partial.pid ?? null,
+    cwd: partial.cwd ?? null,
+    worktree: partial.worktree ?? null,
+    branch: partial.branch ?? null,
+    summary: partial.summary ?? null,
+    status: partial.status ?? 'active',
+    firstSeen: partial.firstSeen ?? ago(60 * 60 * 1000),
+    lastSeen: partial.lastSeen ?? ago(0),
+  };
+}
+
+describe('deriveLiveness', () => {
+  it('is live under the idle threshold', () => {
+    expect(deriveLiveness(ago(60 * 1000), NOW)).toBe('live');
+  });
+
+  it('is idle between the idle and away thresholds', () => {
+    expect(deriveLiveness(ago(10 * 60 * 1000), NOW)).toBe('idle');
+  });
+
+  it('is away beyond the away threshold', () => {
+    expect(deriveLiveness(ago(60 * 60 * 1000), NOW)).toBe('away');
+  });
+
+  it('treats the boundary as the later state (>=)', () => {
+    expect(deriveLiveness(ago(5 * 60 * 1000), NOW)).toBe('idle');
+    expect(deriveLiveness(ago(30 * 60 * 1000), NOW)).toBe('away');
+  });
+
+  it('treats an unparseable timestamp as away', () => {
+    expect(deriveLiveness('not-a-date', NOW)).toBe('away');
+  });
+
+  it('honours custom thresholds', () => {
+    expect(deriveLiveness(ago(2000), NOW, { idleAfterMs: 1000, awayAfterMs: 5000 })).toBe('idle');
+  });
+});
+
+describe('buildRoster', () => {
+  it('maps fields and computes whole-second age', () => {
+    const [entry] = buildRoster(
+      [agent({ agentId: 'claude-code:7p8v', summary: 'building frontend', lastSeen: ago(90_000) })],
+      NOW,
+    );
+    expect(entry?.agentId).toBe('claude-code:7p8v');
+    expect(entry?.summary).toBe('building frontend');
+    expect(entry?.liveness).toBe('live');
+    expect(entry?.ageSeconds).toBe(90);
+  });
+
+  it('orders live agents first, then most-recently-seen', () => {
+    const roster = buildRoster(
+      [
+        agent({ agentId: 'away-old', lastSeen: ago(60 * 60 * 1000) }),
+        agent({ agentId: 'live-older', lastSeen: ago(2 * 60 * 1000) }),
+        agent({ agentId: 'idle-mid', lastSeen: ago(10 * 60 * 1000) }),
+        agent({ agentId: 'live-newer', lastSeen: ago(30 * 1000) }),
+      ],
+      NOW,
+    );
+    expect(roster.map((entry) => entry.agentId)).toEqual([
+      'live-newer',
+      'live-older',
+      'idle-mid',
+      'away-old',
+    ]);
+  });
+
+  it('returns an empty roster when no agents are registered', () => {
+    expect(buildRoster([], NOW)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What changed

- add the agents table and repository
- derive live, idle, and away presence states
- add schema/storage and presence-domain coverage

## Why

Concord needs a durable local identity for each coding-agent session before it can show who is active or associate claims with a live agent.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- tracked files pass Prettier

This is slice 1 of the presence prerequisite and stays below the 600 LOC PR limit.