### PR TITLE
feat: register agents and surface the live roster

### DIFF
--- a/src/artifacts/index.ts
+++ b/src/artifacts/index.ts
@@ -2,6 +2,7 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import type { HandoffRecord, Repositories, ReviewRecord, TaskRecord } from '../db/index.js';
+import { buildRoster } from '../domain/presence.js';
 import { renderEventsJsonl } from './events-jsonl.js';
 import { renderHandoffMarkdown } from './handoff-md.js';
 import { renderReviewPacketMarkdown } from './review-packet-md.js';
@@ -65,8 +66,12 @@ export function writeArtifacts(
 ): void {
   mkdirSync(concordDirPath, { recursive: true });
   const tasks = repos.tasks.list();
+  const roster = buildRoster(repos.agents.list(), Date.parse(generatedAt));
 
-  writeFileSync(join(concordDirPath, 'WORK_STATE.json'), renderWorkStateJson(tasks, generatedAt));
+  writeFileSync(
+    join(concordDirPath, 'WORK_STATE.json'),
+    renderWorkStateJson(tasks, roster, generatedAt),
+  );
   writeFileSync(join(concordDirPath, 'events.jsonl'), renderEventsJsonl(repos.events.list()));
 
   const handoff = latestHandoff(repos, tasks);

--- a/src/artifacts/work-state-json.ts
+++ b/src/artifacts/work-state-json.ts
@@ -1,4 +1,5 @@
 import type { TaskRecord } from '../db/index.js';
+import type { PresenceEntry } from '../domain/presence.js';
 
 interface WorkStateTask {
   task_id: string;
@@ -13,8 +14,20 @@ interface WorkStateTask {
   expected_files: string[];
 }
 
+interface WorkStatePresence {
+  agent_id: string;
+  kind: string;
+  owner: string | null;
+  summary: string | null;
+  status: string;
+  liveness: string;
+  last_seen: string;
+  age_seconds: number;
+}
+
 interface WorkState {
   generated_at: string;
+  presence: WorkStatePresence[];
   tasks: WorkStateTask[];
 }
 
@@ -33,10 +46,28 @@ function toWorkStateTask(task: TaskRecord): WorkStateTask {
   };
 }
 
-/** Render WORK_STATE.json: a snapshot of all tasks and their current status. */
-export function renderWorkStateJson(tasks: readonly TaskRecord[], generatedAt: string): string {
+function toWorkStatePresence(entry: PresenceEntry): WorkStatePresence {
+  return {
+    agent_id: entry.agentId,
+    kind: entry.kind,
+    owner: entry.owner,
+    summary: entry.summary,
+    status: entry.status,
+    liveness: entry.liveness,
+    last_seen: entry.lastSeen,
+    age_seconds: entry.ageSeconds,
+  };
+}
+
+/** Render WORK_STATE.json: a snapshot of the agent roster and all tasks. */
+export function renderWorkStateJson(
+  tasks: readonly TaskRecord[],
+  roster: readonly PresenceEntry[],
+  generatedAt: string,
+): string {
   const state: WorkState = {
     generated_at: generatedAt,
+    presence: roster.map(toWorkStatePresence),
     tasks: tasks.map(toWorkStateTask),
   };
   return `${JSON.stringify(state, null, 2)}\n`;

--- a/src/artifacts/work-state-view.ts
+++ b/src/artifacts/work-state-view.ts
@@ -2,6 +2,7 @@ import { dirname } from 'node:path';
 
 import type { Repositories, TaskRecord } from '../db/index.js';
 import { detectOverlaps } from '../domain/overlap.js';
+import { buildRoster, type PresenceEntry } from '../domain/presence.js';
 
 interface ActiveEntry {
   taskId: string;
@@ -38,6 +39,9 @@ export interface StatusView {
   overlaps: OverlapPair[];
   reviewReady: ReviewEntry[];
   openQuestions: OpenQuestionEntry[];
+  /** Registered agents with derived liveness — "who is here and what they are
+   * doing", most-live first. */
+  presence: PresenceEntry[];
 }
 
 function touchesOf(task: TaskRecord): string {
@@ -46,7 +50,7 @@ function touchesOf(task: TaskRecord): string {
   return unique.length > 0 ? unique.join(', ') : '-';
 }
 
-export function buildStatus(repos: Repositories): StatusView {
+export function buildStatus(repos: Repositories, now: number = Date.now()): StatusView {
   const tasks = repos.tasks.list();
   const active = tasks.filter((task) => task.status === 'active');
 
@@ -101,11 +105,27 @@ export function buildStatus(repos: Repositories): StatusView {
     overlaps,
     reviewReady,
     openQuestions,
+    presence: buildRoster(repos.agents.list(), now),
   };
 }
 
+/** Render the presence roster as indented lines, or a placeholder when empty. */
+export function renderRosterLines(roster: readonly PresenceEntry[]): string[] {
+  if (roster.length === 0) {
+    return ['  none'];
+  }
+  return roster.map((entry) => {
+    const state = `${entry.liveness}/${entry.status}`;
+    const doing = entry.summary ?? '-';
+    return `  ${entry.agentId.padEnd(18)} ${state.padEnd(20)} ${doing}  (${String(entry.ageSeconds)}s ago)`;
+  });
+}
+
 export function renderStatusText(view: StatusView): string {
-  const lines = ['Concord workspace', '', 'Active work'];
+  const lines = ['Concord workspace', '', "Who's here"];
+  lines.push(...renderRosterLines(view.presence));
+
+  lines.push('', 'Active work');
   if (view.active.length === 0) {
     lines.push('  none');
   } else {

--- a/src/cli/commands/who.ts
+++ b/src/cli/commands/who.ts
@@ -1,0 +1,20 @@
+import type { Command } from '@commander-js/extra-typings';
+
+import { renderRosterLines } from '../../artifacts/work-state-view.js';
+import { buildRoster } from '../../domain/presence.js';
+import { openContext } from '../context.js';
+
+/** Render the presence roster: who is registered and how live they are. */
+export function runWho(cwd: string, now: number = Date.now()): string {
+  const roster = buildRoster(openContext(cwd).repos.agents.list(), now);
+  return ["Who's here", ...renderRosterLines(roster)].join('\n');
+}
+
+export function registerWhoCommand(program: Command): void {
+  program
+    .command('who')
+    .description('Show which agents are present and what they are working on')
+    .action(() => {
+      process.stdout.write(`${runWho(process.cwd())}\n`);
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,6 +13,7 @@ import { registerReviewPacketCommand } from './commands/review-packet.js';
 import { registerStatus } from './commands/status.js';
 import { registerTasks } from './commands/tasks.js';
 import { registerWatchCommand } from './commands/watch.js';
+import { registerWhoCommand } from './commands/who.js';
 
 const program = new Command();
 program.name('concord').description('Shared work-state for coding agents').version(VERSION);
@@ -20,6 +21,7 @@ program.name('concord').description('Shared work-state for coding agents').versi
 registerInit(program);
 registerInstallCommand(program);
 registerStatus(program);
+registerWhoCommand(program);
 registerTasks(program);
 registerCheckCommand(program);
 registerWatchCommand(program);

--- a/src/domain/schemas.ts
+++ b/src/domain/schemas.ts
@@ -1,10 +1,49 @@
 import { z } from 'zod';
 
+import { agentStatusValues } from '../db/rows.js';
+
 /**
  * Zod input schemas for the MCP tools. Each tool exposes its schema as a raw
  * shape (the form `McpServer.registerTool` expects) plus an inferred input type.
  * Fields use snake_case to match the tool's public JSON contract.
  */
+
+/** Optional instance identity carried by every write so it refreshes presence.
+ * Distinct from the `agent` *kind* string — this identifies one running
+ * instance (e.g. `claude-code:7p8v`), obtained from `register_agent`. */
+const agentIdField = z
+  .string()
+  .optional()
+  .describe(
+    'Identity of the registered agent instance doing this work, e.g. claude-code:7p8v. ' +
+      "Supplying it refreshes the agent's presence (liveness) in the roster.",
+  );
+
+export const registerAgentInputShape = {
+  agent_id: z
+    .string()
+    .optional()
+    .describe(
+      'Stable per-session identity for this agent instance, e.g. claude-code:7p8v. Omit on the ' +
+        'first call to have one generated, then reuse the returned id on every later call so ' +
+        'presence stays attributed to the same instance.',
+    ),
+  kind: z.string().min(1).describe('Agent type / provider, e.g. claude-code, codex, cursor'),
+  owner: z.string().optional().describe('Human accountable for this agent'),
+  model: z.string().optional().describe('Model the agent is running, e.g. opus-4.8'),
+  summary: z.string().optional().describe('One line: what this agent is working on right now'),
+  status: z
+    .enum(agentStatusValues)
+    .optional()
+    .describe('Reported status: active, blocked, waiting_review, or done (default active)'),
+  branch: z.string().optional().describe('Git branch, if known'),
+  worktree: z.string().optional().describe('Git worktree path, if used'),
+  cwd: z.string().optional().describe('Working directory, for disambiguating instances'),
+  pid: z.number().int().optional().describe('Process id, for disambiguating instances'),
+} as const;
+
+export const registerAgentInputSchema = z.object(registerAgentInputShape);
+export type RegisterAgentInput = z.infer<typeof registerAgentInputSchema>;
 
 export const claimWorkInputShape = {
   task_id: z.string().min(1).describe('Stable identifier for the task, e.g. TASK-12'),
@@ -32,6 +71,7 @@ export const claimWorkInputShape = {
   domains: z.array(z.string()).optional().describe('Product domains touched, e.g. payments'),
   risk_tags: z.array(z.string()).optional().describe('Risk tags, e.g. payment-flow'),
   notes: z.string().optional().describe('Freeform notes'),
+  agent_id: agentIdField,
 } as const;
 
 export const claimWorkInputSchema = z.object(claimWorkInputShape);
@@ -53,6 +93,7 @@ export const updateTaskInputShape = {
     .describe('The kind of task-scoped update'),
   content: z.string().min(1).describe('Concise context another agent needs'),
   agent: z.string().optional().describe('Agent recording the update; defaults to the claimant'),
+  agent_id: agentIdField,
 } as const;
 
 export const updateTaskInputSchema = z.object(updateTaskInputShape);
@@ -93,6 +134,7 @@ export const handoffInputShape = {
     .array(z.object({ field: z.string(), source: z.string() }))
     .optional()
     .describe('Where each claim came from, e.g. { field: "tests", source: "command output" }'),
+  agent_id: agentIdField,
 } as const;
 
 export const handoffInputSchema = z.object(handoffInputShape);

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import { registerClaimWork } from './tools/claim-work.js';
 import { registerGetTaskContext } from './tools/get-task-context.js';
 import { registerWorkState } from './tools/get-work-state.js';
 import { registerHandoff } from './tools/handoff.js';
+import { registerRegisterAgent } from './tools/register-agent.js';
 import { registerUpdateTask } from './tools/update-task.js';
 import { VERSION } from './version.js';
 
@@ -30,6 +31,7 @@ export function createServer(repos: Repositories, options: ServerOptions = {}): 
     notifyWorkStateChanged();
   };
   registerGetTaskContext(server, repos);
+  registerRegisterAgent(server, repos, onWrite);
   registerClaimWork(server, repos, onWrite);
   registerUpdateTask(server, repos, onWrite);
   registerHandoff(server, repos, onWrite);

--- a/src/tools/claim-work.ts
+++ b/src/tools/claim-work.ts
@@ -108,6 +108,11 @@ export function handleClaimWork(repos: Repositories, input: ClaimWorkInput): Cla
     detail: overlaps.length > 0 ? `${String(overlaps.length)} overlap(s)` : null,
   });
 
+  // Working refreshes presence: a registered agent stays live just by claiming.
+  if (input.agent_id !== undefined) {
+    repos.agents.touch(input.agent_id);
+  }
+
   return {
     task,
     alreadyClaimed: existing !== undefined,

--- a/src/tools/get-work-state.ts
+++ b/src/tools/get-work-state.ts
@@ -35,15 +35,17 @@ export function registerWorkState(server: McpServer, repos: Repositories): () =>
     {
       title: 'Get work state',
       description:
-        'Read the current shared work-state: active claims, overlaps (recomputed live across ' +
-        'all active tasks), and review-ready tasks. Read-only — call this before claiming to ' +
-        'see what other agents are already working on.',
+        'Read the current shared work-state: who is present (the agent roster with liveness), ' +
+        'active claims, overlaps (recomputed live across all active tasks), and review-ready ' +
+        'tasks. Read-only — call this before claiming to see who else is here and what they are ' +
+        'already working on.',
     },
     () => {
       const view = handleGetWorkState(repos);
       return {
         content: [{ type: 'text', text: renderStatusText(view) }],
         structuredContent: {
+          presence: view.presence,
           active: view.active,
           overlaps: view.overlaps,
           review_ready: view.reviewReady,

--- a/src/tools/handoff.ts
+++ b/src/tools/handoff.ts
@@ -56,6 +56,9 @@ export function handleHandoff(repos: Repositories, input: HandoffInput): Handoff
     status: 'success',
     detail: input.status,
   });
+  if (input.agent_id !== undefined) {
+    repos.agents.touch(input.agent_id);
+  }
 
   // Folding review_ready into handoff: when flagged, produce the review packet
   // (and set status review_ready) via the shared review handler. Otherwise the

--- a/src/tools/register-agent.ts
+++ b/src/tools/register-agent.ts
@@ -1,0 +1,123 @@
+import { randomBytes } from 'node:crypto';
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import type { AgentRecord, Repositories } from '../db/index.js';
+import { buildRoster, type PresenceEntry } from '../domain/presence.js';
+import { registerAgentInputShape, type RegisterAgentInput } from '../domain/schemas.js';
+
+export interface RegisterAgentResult {
+  agent: AgentRecord;
+  /** True when this call created the agent rather than refreshing it. */
+  firstRegistration: boolean;
+  /** Every registered agent with derived liveness, most-live first. Includes self. */
+  roster: PresenceEntry[];
+}
+
+/** A short, human-typable instance id, e.g. `claude-code:7p8v`. Generated when
+ * the caller does not supply one; returned so it can be reused thereafter. */
+export function generateAgentId(kind: string): string {
+  return `${kind}:${randomBytes(2).toString('hex')}`;
+}
+
+/**
+ * Register (or refresh) an agent's presence so concurrent agents are
+ * distinguishable and can see who else is active. Returns the resolved identity
+ * plus the current roster, so the caller learns who else is here immediately —
+ * without a task claim (recon and research agents are visible too).
+ */
+export function handleRegisterAgent(
+  repos: Repositories,
+  input: RegisterAgentInput,
+  now: number = Date.now(),
+): RegisterAgentResult {
+  const agentId = input.agent_id ?? generateAgentId(input.kind);
+  const firstRegistration = repos.agents.get(agentId) === undefined;
+
+  const agent = repos.agents.upsert({
+    agentId,
+    kind: input.kind,
+    owner: input.owner ?? null,
+    model: input.model ?? null,
+    pid: input.pid ?? null,
+    cwd: input.cwd ?? null,
+    worktree: input.worktree ?? null,
+    branch: input.branch ?? null,
+    summary: input.summary ?? null,
+    status: input.status ?? 'active',
+  });
+
+  return { agent, firstRegistration, roster: buildRoster(repos.agents.list(), now) };
+}
+
+export function formatRegisterAgentText(result: RegisterAgentResult): string {
+  const verb = result.firstRegistration ? 'Registered' : 'Refreshed presence';
+  const owner = result.agent.owner === null ? '' : ` (owner ${result.agent.owner})`;
+  const lines = [`${verb} as ${result.agent.agentId}${owner}.`];
+
+  const others = result.roster.filter((entry) => entry.agentId !== result.agent.agentId);
+  if (others.length === 0) {
+    lines.push('No other agents are registered yet.');
+  } else {
+    lines.push(`${String(others.length)} other agent(s) here:`);
+    for (const entry of others) {
+      const doing = entry.summary ?? 'no summary';
+      lines.push(`  - ${entry.agentId} [${entry.liveness}/${entry.status}]: ${doing}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+function rosterToStructured(roster: readonly PresenceEntry[]): {
+  agent_id: string;
+  kind: string;
+  owner: string | null;
+  summary: string | null;
+  status: string;
+  liveness: string;
+  last_seen: string;
+  age_seconds: number;
+}[] {
+  return roster.map((entry) => ({
+    agent_id: entry.agentId,
+    kind: entry.kind,
+    owner: entry.owner,
+    summary: entry.summary,
+    status: entry.status,
+    liveness: entry.liveness,
+    last_seen: entry.lastSeen,
+    age_seconds: entry.ageSeconds,
+  }));
+}
+
+export function registerRegisterAgent(
+  server: McpServer,
+  repos: Repositories,
+  onWrite?: () => void,
+): void {
+  server.registerTool(
+    'register_agent',
+    {
+      title: 'Register agent',
+      description:
+        'Register this agent instance so other agents know who you are and what you are working ' +
+        'on. Call once at session start (reuse the returned agent_id afterwards) and again to ' +
+        'refresh your summary/status. Returns the current roster of active agents. Works without ' +
+        'a task claim, so recon and research agents are visible too.',
+      inputSchema: registerAgentInputShape,
+    },
+    (args) => {
+      const result = handleRegisterAgent(repos, args);
+      onWrite?.();
+      return {
+        content: [{ type: 'text', text: formatRegisterAgentText(result) }],
+        structuredContent: {
+          agent_id: result.agent.agentId,
+          first_registration: result.firstRegistration,
+          status: result.agent.status,
+          roster: rosterToStructured(result.roster),
+        },
+      };
+    },
+  );
+}

--- a/src/tools/update-task.ts
+++ b/src/tools/update-task.ts
@@ -26,6 +26,9 @@ export function handleUpdateTask(repos: Repositories, input: UpdateTaskInput): U
     status: 'success',
     detail: input.kind,
   });
+  if (input.agent_id !== undefined) {
+    repos.agents.touch(input.agent_id);
+  }
   return { update };
 }
 

--- a/test/artifacts/artifacts.test.ts
+++ b/test/artifacts/artifacts.test.ts
@@ -11,6 +11,7 @@ import { openDatabase } from '../../src/db/connection.js';
 import { createRepositories, type Repositories } from '../../src/db/index.js';
 import { handleClaimWork } from '../../src/tools/claim-work.js';
 import { handleHandoff } from '../../src/tools/handoff.js';
+import { handleRegisterAgent } from '../../src/tools/register-agent.js';
 import { handleReviewReady } from '../../src/tools/review-ready.js';
 
 describe('renderReviewPacketMarkdown', () => {
@@ -55,16 +56,23 @@ describe('writeArtifacts', () => {
 
   it('writes WORK_STATE.json and events.jsonl reflecting the DB', () => {
     handleClaimWork(repos, { task_id: 'TASK-12', title: 'Retry', modules: ['billing'] });
+    handleRegisterAgent(repos, {
+      agent_id: 'claude-code:7p8v',
+      kind: 'claude-code',
+      summary: 'building frontend',
+    });
     writeArtifacts(dir, repos, '2026-07-17T00:00:00.000Z');
 
     const workState = z
       .object({
         generated_at: z.string(),
+        presence: z.array(z.object({ agent_id: z.string(), liveness: z.string() })),
         tasks: z.array(z.object({ task_id: z.string(), status: z.string() })),
       })
       .parse(JSON.parse(readFileSync(join(dir, 'WORK_STATE.json'), 'utf8')));
     expect(workState.generated_at).toBe('2026-07-17T00:00:00.000Z');
     expect(workState.tasks[0]?.task_id).toBe('TASK-12');
+    expect(workState.presence[0]?.agent_id).toBe('claude-code:7p8v');
 
     const events = readFileSync(join(dir, 'events.jsonl'), 'utf8').trim().split('\n');
     expect(events).toHaveLength(1);

--- a/test/cli/cli-core.test.ts
+++ b/test/cli/cli-core.test.ts
@@ -7,9 +7,12 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { openDatabase } from '../../src/db/connection.js';
 import { createRepositories, type Repositories } from '../../src/db/index.js';
 import { buildStatus, renderStatusText } from '../../src/artifacts/work-state-view.js';
-import { renderTasks } from '../../src/cli/commands/tasks.js';
 import { runInit } from '../../src/cli/commands/init.js';
+import { renderTasks } from '../../src/cli/commands/tasks.js';
+import { runWho } from '../../src/cli/commands/who.js';
+import { openContext } from '../../src/cli/context.js';
 import { handleClaimWork } from '../../src/tools/claim-work.js';
+import { handleRegisterAgent } from '../../src/tools/register-agent.js';
 import { handleReviewReady } from '../../src/tools/review-ready.js';
 
 function repoDir(): string {
@@ -143,5 +146,47 @@ describe('buildStatus / renderStatusText', () => {
     expect(view.reviewReady[0]?.openQuestionCount).toBe(1);
     expect(view.active).toHaveLength(0);
     expect(renderStatusText(view)).toContain('Sync or queued retries?');
+  });
+
+  it("includes the presence roster and renders a Who's here section", () => {
+    handleRegisterAgent(repos, {
+      agent_id: 'claude-code:7p8v',
+      kind: 'claude-code',
+      summary: 'building frontend',
+    });
+    const view = buildStatus(repos);
+    expect(view.presence).toHaveLength(1);
+    expect(view.presence[0]?.liveness).toBe('live');
+
+    const text = renderStatusText(view);
+    expect(text).toContain("Who's here");
+    expect(text).toContain('claude-code:7p8v');
+    expect(text).toContain('building frontend');
+  });
+
+  it("shows Who's here / none when no agent has registered", () => {
+    expect(renderStatusText(buildStatus(repos))).toContain("Who's here\n  none");
+  });
+});
+
+describe('runWho', () => {
+  it('lists agents registered in the workspace', () => {
+    const dir = repoDir();
+    runInit(dir);
+    handleRegisterAgent(openContext(dir).repos, {
+      agent_id: 'claude-code:7p8v',
+      kind: 'claude-code',
+      summary: 'building frontend',
+    });
+    const out = runWho(dir);
+    expect(out).toContain("Who's here");
+    expect(out).toContain('claude-code:7p8v');
+    expect(out).toContain('building frontend');
+  });
+
+  it('shows none when nobody has registered', () => {
+    const dir = repoDir();
+    runInit(dir);
+    expect(runWho(dir)).toContain('none');
   });
 });

--- a/test/db/storage.test.ts
+++ b/test/db/storage.test.ts
@@ -240,9 +240,6 @@ describe('agent repository', () => {
   it('lists multiple registered agents', () => {
     repos.agents.upsert(baseAgent);
     repos.agents.upsert({ ...baseAgent, agentId: 'codex:9q2r', kind: 'codex' });
-    expect(repos.agents.list().map((a) => a.agentId)).toEqual([
-      'claude-code:7p8v',
-      'codex:9q2r',
-    ]);
+    expect(repos.agents.list().map((a) => a.agentId)).toEqual(['claude-code:7p8v', 'codex:9q2r']);
   });
 });

--- a/test/tools/register-agent.test.ts
+++ b/test/tools/register-agent.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { openDatabase } from '../../src/db/connection.js';
+import { createRepositories, type Repositories } from '../../src/db/index.js';
+import { handleClaimWork } from '../../src/tools/claim-work.js';
+import { handleHandoff } from '../../src/tools/handoff.js';
+import {
+  formatRegisterAgentText,
+  generateAgentId,
+  handleRegisterAgent,
+} from '../../src/tools/register-agent.js';
+import { handleUpdateTask } from '../../src/tools/update-task.js';
+
+describe('handleRegisterAgent', () => {
+  let repos: Repositories;
+  beforeEach(() => {
+    repos = createRepositories(openDatabase(':memory:'));
+  });
+
+  it('generates a kind-prefixed id and registers a new agent', () => {
+    const result = handleRegisterAgent(repos, { kind: 'claude-code', owner: 'alex' });
+    expect(result.firstRegistration).toBe(true);
+    expect(result.agent.agentId).toMatch(/^claude-code:[0-9a-f]{4}$/);
+    expect(result.agent.status).toBe('active');
+    expect(result.roster).toHaveLength(1);
+    expect(result.roster[0]?.liveness).toBe('live');
+  });
+
+  it('reuses a supplied agent_id and refreshes on re-register without duplicating', () => {
+    const first = handleRegisterAgent(repos, {
+      agent_id: 'claude-code:7p8v',
+      kind: 'claude-code',
+      summary: 'building frontend',
+    });
+    expect(first.firstRegistration).toBe(true);
+
+    const again = handleRegisterAgent(repos, {
+      agent_id: 'claude-code:7p8v',
+      kind: 'claude-code',
+      summary: 'now reviewing',
+      status: 'waiting_review',
+    });
+    expect(again.firstRegistration).toBe(false);
+    expect(again.agent.summary).toBe('now reviewing');
+    expect(again.agent.status).toBe('waiting_review');
+    expect(repos.agents.list()).toHaveLength(1);
+  });
+
+  it('returns a roster of every registered agent and names others in the text', () => {
+    handleRegisterAgent(repos, {
+      agent_id: 'codex:9q2r',
+      kind: 'codex',
+      summary: 'building the backend',
+    });
+    const result = handleRegisterAgent(repos, { agent_id: 'claude-code:7p8v', kind: 'claude-code' });
+    expect(result.roster.map((entry) => entry.agentId).sort()).toEqual([
+      'claude-code:7p8v',
+      'codex:9q2r',
+    ]);
+    const text = formatRegisterAgentText(result);
+    expect(text).toContain('Registered as claude-code:7p8v');
+    expect(text).toContain('1 other agent(s) here');
+    expect(text).toContain('codex:9q2r');
+    expect(text).toContain('building the backend');
+  });
+
+  it('says so when no other agents are registered', () => {
+    const result = handleRegisterAgent(repos, { agent_id: 'solo:0001', kind: 'claude-code' });
+    expect(formatRegisterAgentText(result)).toContain('No other agents are registered yet.');
+  });
+
+  it('generateAgentId produces distinct kind-prefixed ids', () => {
+    const a = generateAgentId('codex');
+    const b = generateAgentId('codex');
+    expect(a).toMatch(/^codex:[0-9a-f]{4}$/);
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('presence refresh through write tools', () => {
+  let repos: Repositories;
+  beforeEach(() => {
+    repos = createRepositories(openDatabase(':memory:'));
+    handleRegisterAgent(repos, { agent_id: 'claude-code:7p8v', kind: 'claude-code' });
+  });
+
+  it('claim_work with a registered agent_id keeps the agent present, adds no rows', () => {
+    handleClaimWork(repos, {
+      task_id: 'TASK-1',
+      title: 'Work',
+      modules: ['billing'],
+      agent_id: 'claude-code:7p8v',
+    });
+    expect(repos.agents.get('claude-code:7p8v')).toBeDefined();
+    expect(repos.agents.list()).toHaveLength(1);
+  });
+
+  it('a write with an unregistered agent_id is a safe no-op (no throw, no ghost row)', () => {
+    expect(() =>
+      handleClaimWork(repos, { task_id: 'TASK-2', title: 'Work', agent_id: 'ghost:zzzz' }),
+    ).not.toThrow();
+    expect(repos.agents.get('ghost:zzzz')).toBeUndefined();
+    expect(repos.agents.list()).toHaveLength(1);
+  });
+
+  it('update_task and handoff also accept and refresh a registered agent_id', () => {
+    handleClaimWork(repos, { task_id: 'TASK-3', title: 'Work', agent_id: 'claude-code:7p8v' });
+    handleUpdateTask(repos, {
+      task_id: 'TASK-3',
+      kind: 'progress',
+      content: 'halfway',
+      agent_id: 'claude-code:7p8v',
+    });
+    handleHandoff(repos, {
+      task_id: 'TASK-3',
+      status: 'done',
+      what_changed: 'finished',
+      agent_id: 'claude-code:7p8v',
+    });
+    expect(repos.agents.get('claude-code:7p8v')).toBeDefined();
+    expect(repos.agents.list()).toHaveLength(1);
+  });
+});

--- a/test/tools/register-agent.test.ts
+++ b/test/tools/register-agent.test.ts
@@ -52,7 +52,10 @@ describe('handleRegisterAgent', () => {
       kind: 'codex',
       summary: 'building the backend',
     });
-    const result = handleRegisterAgent(repos, { agent_id: 'claude-code:7p8v', kind: 'claude-code' });
+    const result = handleRegisterAgent(repos, {
+      agent_id: 'claude-code:7p8v',
+      kind: 'claude-code',
+    });
     expect(result.roster.map((entry) => entry.agentId).sort()).toEqual([
       'claude-code:7p8v',
       'codex:9q2r',


### PR DESCRIPTION
## What changed

- add the `register_agent` MCP tool
- thread `agent_id` through write tools so normal work refreshes presence
- surface the derived roster through work-state reads and `concord who`
- add tool, CLI, and artifact coverage

## Why

Once identities can be stored, agents and humans need a minimal way to register sessions and see who is currently working.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- tracked files pass Prettier

This is slice 2 of the presence prerequisite and stays below the 600 LOC PR limit.