### PR TITLE
feat: connect live agents to claims and flag stale work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,15 +7,18 @@ before making changes.
 ## What this project is
 
 `concord-mcp` is a local MCP server plus a `concord` CLI that gives coding agents
-shared work-state: agents **claim work**, share typed **task context**, leave
-**handoffs**, and generate **review packets** before opening PRs. SQLite is the
-source of truth; human-readable markdown artifacts are rendered from it for PR
-visibility.
+shared work-state: agents **register their presence**, **claim work**, share
+typed **task context**, leave **handoffs**, and generate **review packets**
+before opening PRs. SQLite is the source of truth; human-readable markdown
+artifacts are rendered from it for PR visibility.
 
-The surface is intentionally five MCP tools: `get_work_state`, `claim_work`,
-`update_task`, `get_task_context`, and `handoff`. Review packets are produced by
-`handoff` with `ready_for_review` set, not a separate tool. Do not add more tools
-without explicit product pull.
+The surface is intentionally six MCP tools: `register_agent`, `get_work_state`,
+`claim_work`, `update_task`, `get_task_context`, and `handoff`. Review packets
+are produced by `handoff` with `ready_for_review` set, not a separate tool.
+`register_agent` was added with explicit product pull for agent presence (who is
+here and what they are working on); liveness is derived from `last_seen` in
+`domain/presence.ts`, not stored. Do not add more tools without explicit product
+pull.
 
 ## Coding rules (non-negotiable)
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
 
 **Shared work-state for coding agents.** Concord MCP gives Claude Code, Codex,
 Cursor, and other MCP-capable coding assistants a shared work log. Agents can
-claim work, share task context, leave handoffs, and generate review-ready
-packets before opening PRs.
+register their presence, claim work, share task context, leave handoffs, and
+generate review-ready packets before opening PRs.
 
-> ⚠️ Early and under active development. The surface is five focused MCP tools:
-> `get_work_state`, `claim_work`, `update_task`, `get_task_context`, and
-> `handoff`.
+> ⚠️ Early and under active development. The surface is six focused MCP tools:
+> `register_agent`, `get_work_state`, `claim_work`, `update_task`,
+> `get_task_context`, and `handoff`.
 
 ## Why
 
@@ -42,15 +42,21 @@ setup:
 > Concord works through MCP tools plus the installed instructions on any
 > MCP-capable client.
 
-## The five tools
+## The six tools
 
-| Tool               | When                     | What it does                                                                     |
-| ------------------ | ------------------------ | -------------------------------------------------------------------------------- |
-| `get_work_state`   | before choosing work     | shows active tasks, overlaps, review-ready work, and open questions              |
-| `claim_work`       | before editing           | records the task + expected files/modules; flags overlaps with other active work |
-| `update_task`      | while working            | appends typed intent, progress, decisions, questions, blockers, and findings     |
-| `get_task_context` | resuming or coordinating | returns the task, ordered updates, handoff, review evidence, and live overlaps   |
-| `handoff`          | done, blocked, or pre-PR | captures evidence; `ready_for_review` also produces the review packet            |
+| Tool               | When                     | What it does                                                                      |
+| ------------------ | ------------------------ | --------------------------------------------------------------------------------- |
+| `register_agent`   | at session start         | registers this instance's identity + summary + status; returns the live roster    |
+| `get_work_state`   | before choosing work     | shows the agent roster, active tasks, overlaps, stale claims, and open questions   |
+| `claim_work`       | before editing           | records the task + expected files/modules; flags overlaps with other active work  |
+| `update_task`      | while working            | appends typed intent, progress, decisions, questions, blockers, and findings      |
+| `get_task_context` | resuming or coordinating | returns the task, ordered updates, handoff, review evidence, and live overlaps    |
+| `handoff`          | done, blocked, or pre-PR | captures evidence; `ready_for_review` also produces the review packet             |
+
+Every write tool accepts your `register_agent` `agent_id`, which keeps your
+presence live just by working. `get_work_state` shows **who is here** (with
+liveness), and flags **stale claims** — an active claim whose owning agent has
+gone away without handing off.
 
 ## What you get
 
@@ -73,7 +79,8 @@ Agents use the MCP tools; humans use the CLI.
 
 ```bash
 concord init                 # create the .concord/ workspace
-concord status               # active work, overlaps, review-ready, open questions
+concord status               # roster, active work, overlaps, stale claims, review-ready
+concord who                  # which agents are present and what they are working on
 concord tasks                # list all tracked tasks
 concord handoff <task-id>    # print the latest handoff
 concord review-packet <id>   # print the latest review packet

--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ setup:
 
 ## The six tools
 
-| Tool               | When                     | What it does                                                                      |
-| ------------------ | ------------------------ | --------------------------------------------------------------------------------- |
-| `register_agent`   | at session start         | registers this instance's identity + summary + status; returns the live roster    |
-| `get_work_state`   | before choosing work     | shows the agent roster, active tasks, overlaps, stale claims, and open questions   |
-| `claim_work`       | before editing           | records the task + expected files/modules; flags overlaps with other active work  |
-| `update_task`      | while working            | appends typed intent, progress, decisions, questions, blockers, and findings      |
-| `get_task_context` | resuming or coordinating | returns the task, ordered updates, handoff, review evidence, and live overlaps    |
-| `handoff`          | done, blocked, or pre-PR | captures evidence; `ready_for_review` also produces the review packet             |
+| Tool               | When                     | What it does                                                                     |
+| ------------------ | ------------------------ | -------------------------------------------------------------------------------- |
+| `register_agent`   | at session start         | registers this instance's identity + summary + status; returns the live roster   |
+| `get_work_state`   | before choosing work     | shows the agent roster, active tasks, overlaps, stale claims, and open questions |
+| `claim_work`       | before editing           | records the task + expected files/modules; flags overlaps with other active work |
+| `update_task`      | while working            | appends typed intent, progress, decisions, questions, blockers, and findings     |
+| `get_task_context` | resuming or coordinating | returns the task, ordered updates, handoff, review evidence, and live overlaps   |
+| `handoff`          | done, blocked, or pre-PR | captures evidence; `ready_for_review` also produces the review packet            |
 
 Every write tool accepts your `register_agent` `agent_id`, which keeps your
 presence live just by working. `get_work_state` shows **who is here** (with

--- a/src/artifacts/work-state-view.ts
+++ b/src/artifacts/work-state-view.ts
@@ -2,7 +2,12 @@ import { dirname } from 'node:path';
 
 import type { Repositories, TaskRecord } from '../db/index.js';
 import { detectOverlaps } from '../domain/overlap.js';
-import { buildRoster, type PresenceEntry } from '../domain/presence.js';
+import {
+  buildRoster,
+  detectStaleClaims,
+  type PresenceEntry,
+  type StaleClaim,
+} from '../domain/presence.js';
 
 interface ActiveEntry {
   taskId: string;
@@ -42,6 +47,8 @@ export interface StatusView {
   /** Registered agents with derived liveness — "who is here and what they are
    * doing", most-live first. */
   presence: PresenceEntry[];
+  /** Active claims whose owning agent has gone away or never registered. */
+  staleClaims: StaleClaim[];
 }
 
 function touchesOf(task: TaskRecord): string {
@@ -106,6 +113,7 @@ export function buildStatus(repos: Repositories, now: number = Date.now()): Stat
     reviewReady,
     openQuestions,
     presence: buildRoster(repos.agents.list(), now),
+    staleClaims: detectStaleClaims(tasks, repos.agents.list(), now),
   };
 }
 
@@ -143,6 +151,19 @@ export function renderStatusText(view: StatusView): string {
   } else {
     for (const overlap of view.overlaps) {
       lines.push(`  ${overlap.a} <-> ${overlap.b}: ${overlap.reasons.join('; ')}`);
+    }
+  }
+
+  lines.push('', 'Stale claims');
+  if (view.staleClaims.length === 0) {
+    lines.push('  none');
+  } else {
+    for (const claim of view.staleClaims) {
+      const detail =
+        claim.reason === 'agent-unregistered'
+          ? 'agent never registered'
+          : `agent away ${String(claim.ageSeconds ?? 0)}s`;
+      lines.push(`  ${claim.taskId.padEnd(10)} ${claim.agentId} (${detail})`);
     }
   }
 

--- a/src/db/repositories/tasks.ts
+++ b/src/db/repositories/tasks.ts
@@ -17,6 +17,7 @@ export interface NewTask {
   riskTags: readonly string[];
   notes: string | null;
   parentTaskId: string | null;
+  agentId: string | null;
 }
 
 /** The declared surface of a claim, updated when an agent re-claims with an
@@ -43,11 +44,11 @@ export function createTaskRepository(db: ConcordDatabase): TaskRepository {
     INSERT INTO tasks (
       task_id, title, owner, agent, branch, worktree,
       expected_files, modules, domains, risk_tags, notes, status,
-      parent_task_id, created_at, updated_at
+      parent_task_id, agent_id, created_at, updated_at
     ) VALUES (
       @task_id, @title, @owner, @agent, @branch, @worktree,
       @expected_files, @modules, @domains, @risk_tags, @notes, @status,
-      @parent_task_id, @created_at, @updated_at
+      @parent_task_id, @agent_id, @created_at, @updated_at
     )
   `);
   const getStmt = db.prepare('SELECT * FROM tasks WHERE task_id = ?');
@@ -86,6 +87,7 @@ export function createTaskRepository(db: ConcordDatabase): TaskRepository {
         notes: task.notes,
         status: 'active',
         parent_task_id: task.parentTaskId,
+        agent_id: task.agentId,
         created_at: now,
         updated_at: now,
       });

--- a/src/db/rows.ts
+++ b/src/db/rows.ts
@@ -68,6 +68,10 @@ export interface TaskRecord {
   status: TaskStatus;
   /** The parent task this is a subtask of, or null for a top-level task. */
   parentTaskId: string | null;
+  /** The agent instance (register_agent identity) that claimed this, or null.
+   * Distinct from `agent` (the kind string): used to check the claimant's
+   * liveness for stale-claim detection. */
+  agentId: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -86,6 +90,7 @@ const taskDbRowSchema = z.object({
   notes: z.string().nullable(),
   status: taskStatusSchema,
   parent_task_id: z.string().nullable(),
+  agent_id: z.string().nullable(),
   created_at: z.string(),
   updated_at: z.string(),
 });
@@ -106,6 +111,7 @@ export function parseTaskRow(raw: unknown): TaskRecord {
     notes: row.notes,
     status: row.status,
     parentTaskId: row.parent_task_id,
+    agentId: row.agent_id,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -108,4 +108,10 @@ export const migrations: readonly string[] = [
 
   CREATE INDEX idx_agents_last_seen ON agents(last_seen);
   `,
+  // 006 — link a claim to the agent instance that made it, so stale claims
+  // (an active task whose owning agent has gone away) can be detected. A soft
+  // reference (no FK): the agent may register after, or not at all.
+  `
+  ALTER TABLE tasks ADD COLUMN agent_id TEXT;
+  `,
 ];

--- a/src/domain/presence.ts
+++ b/src/domain/presence.ts
@@ -1,4 +1,4 @@
-import type { AgentRecord, AgentStatus } from '../db/index.js';
+import type { AgentRecord, AgentStatus, TaskRecord } from '../db/index.js';
 
 /**
  * Liveness is *derived* from how long ago an agent was last seen — never stored.
@@ -69,6 +69,58 @@ function ageSecondsOf(lastSeen: string, now: number): number {
  * most-recently-seen. This is the "who is here and what are they doing" view
  * that other agents read before or while working.
  */
+/** An active claim whose owning agent is no longer reliably present. */
+export interface StaleClaim {
+  taskId: string;
+  title: string;
+  agentId: string;
+  /** Why it is stale: the agent is `away`, or was never seen (unregistered). */
+  reason: 'agent-away' | 'agent-unregistered';
+  /** Seconds since the owning agent was last seen, or null when unregistered. */
+  ageSeconds: number | null;
+}
+
+/**
+ * Flag active claims whose owning agent has gone away — the "agent walked off
+ * without handing off" case a durable claim alone cannot surface. Only claims
+ * carrying an `agentId` are assessed; unattributed claims are left alone (they
+ * predate presence and would be noise). A claim is stale when its agent is
+ * `away`, or when the referenced agent never registered.
+ */
+export function detectStaleClaims(
+  tasks: readonly TaskRecord[],
+  agents: readonly AgentRecord[],
+  now: number,
+  thresholds: PresenceThresholds = DEFAULT_PRESENCE_THRESHOLDS,
+): StaleClaim[] {
+  const byId = new Map(agents.map((agent) => [agent.agentId, agent]));
+  const stale: StaleClaim[] = [];
+  for (const task of tasks) {
+    if (task.status !== 'active' || task.agentId === null) {
+      continue;
+    }
+    const agent = byId.get(task.agentId);
+    if (agent === undefined) {
+      stale.push({
+        taskId: task.taskId,
+        title: task.title,
+        agentId: task.agentId,
+        reason: 'agent-unregistered',
+        ageSeconds: null,
+      });
+    } else if (deriveLiveness(agent.lastSeen, now, thresholds) === 'away') {
+      stale.push({
+        taskId: task.taskId,
+        title: task.title,
+        agentId: task.agentId,
+        reason: 'agent-away',
+        ageSeconds: ageSecondsOf(agent.lastSeen, now),
+      });
+    }
+  }
+  return stale;
+}
+
 export function buildRoster(
   agents: readonly AgentRecord[],
   now: number,

--- a/src/install/instructions.ts
+++ b/src/install/instructions.ts
@@ -3,15 +3,22 @@ export const CONCORD_INSTRUCTIONS = `## Concord — shared work-state for coding
 
 This project uses Concord MCP. Use its tools so your work is visible before PRs:
 
+- **At session start, call \`register_agent\`** with your kind (e.g. claude-code),
+  a one-line summary of what you are working on, and your status. Reuse the
+  returned \`agent_id\` on every later Concord call so your presence stays
+  attributed to one instance, and call \`register_agent\` again when your focus
+  changes. Then call \`get_work_state\` to see who else is active before you
+  start — it shows the agent roster, active claims, overlaps, and stale claims.
 - **Keep each claim small.** Break work into the smallest independently
   handoff-able unit and \`claim_work\` each piece separately, rather than
   claiming one broad task. Concord flags claims that look too broad.
-- **Before editing code**, call \`claim_work\` with the task id, title, and the
-  files/modules you expect to touch. Concord warns about overlaps with other
-  active work.
-- **While working**, call \`update_task\` for durable intent, progress,
-  assumptions, decisions, questions, answers, blockers, and findings. When
-  resuming or coordinating on a task, call \`get_task_context\` first.
+- **Before editing code**, call \`claim_work\` with the task id, title, your
+  \`agent_id\`, and the files/modules you expect to touch. Concord warns about
+  overlaps with other active work.
+- **While working**, call \`update_task\` (with your \`agent_id\`) for durable
+  intent, progress, assumptions, decisions, questions, answers, blockers, and
+  findings. When resuming or coordinating on a task, call \`get_task_context\`
+  first.
 - **Before finishing or when blocked**, call \`handoff\` with what changed, tests
   run, assumptions, decisions, and guardrails you checked. **Before a PR**, set
   \`ready_for_review\` (with open questions and provenance) to also produce a

--- a/src/tools/claim-work.ts
+++ b/src/tools/claim-work.ts
@@ -94,6 +94,7 @@ export function handleClaimWork(repos: Repositories, input: ClaimWorkInput): Cla
       ...scope,
       notes: input.notes ?? null,
       parentTaskId,
+      agentId: input.agent_id ?? null,
     });
   } else if (scopeAdded.length > 0) {
     task = repos.tasks.updateScope(input.task_id, scope) ?? existing;

--- a/src/tools/get-work-state.ts
+++ b/src/tools/get-work-state.ts
@@ -48,6 +48,7 @@ export function registerWorkState(server: McpServer, repos: Repositories): () =>
           presence: view.presence,
           active: view.active,
           overlaps: view.overlaps,
+          stale_claims: view.staleClaims,
           review_ready: view.reviewReady,
           open_questions: view.openQuestions,
         },

--- a/src/tools/handoff.ts
+++ b/src/tools/handoff.ts
@@ -33,6 +33,7 @@ export function handleHandoff(repos: Repositories, input: HandoffInput): Handoff
       riskTags: [],
       notes: null,
       parentTaskId: null,
+      agentId: input.agent_id ?? null,
     });
   }
 

--- a/src/tools/review-ready.ts
+++ b/src/tools/review-ready.ts
@@ -32,6 +32,7 @@ export function handleReviewReady(repos: Repositories, input: ReviewReadyInput):
       riskTags: [],
       notes: null,
       parentTaskId: null,
+      agentId: null,
     });
   }
 

--- a/test/cli/cli-commands.test.ts
+++ b/test/cli/cli-commands.test.ts
@@ -73,7 +73,7 @@ describe('CLI read/export commands', () => {
 
   it('doctor reports schema version and adoption', () => {
     const report = runDoctor(dir);
-    expect(report).toContain('schema v5, expected v5');
+    expect(report).toContain('schema v6, expected v6');
     expect(report).toContain('TASK-12');
     expect(report).toContain('claim_work: yes');
     // The resolved workspace path is surfaced so agents don't have to hunt for it.

--- a/test/cli/cli-core.test.ts
+++ b/test/cli/cli-core.test.ts
@@ -167,6 +167,30 @@ describe('buildStatus / renderStatusText', () => {
   it("shows Who's here / none when no agent has registered", () => {
     expect(renderStatusText(buildStatus(repos))).toContain("Who's here\n  none");
   });
+
+  it('flags a stale claim once its owning agent has gone away', () => {
+    handleRegisterAgent(repos, { agent_id: 'claude-code:7p8v', kind: 'claude-code' });
+    handleClaimWork(repos, {
+      task_id: 'TASK-42',
+      title: 'Retry',
+      modules: ['billing'],
+      agent_id: 'claude-code:7p8v',
+    });
+
+    // Fresh: nothing stale yet.
+    expect(buildStatus(repos).staleClaims).toEqual([]);
+
+    // 31 minutes later the agent is past the away threshold.
+    const later = Date.now() + 31 * 60 * 1000;
+    const view = buildStatus(repos, later);
+    expect(view.staleClaims).toHaveLength(1);
+    expect(view.staleClaims[0]?.taskId).toBe('TASK-42');
+
+    const text = renderStatusText(view);
+    expect(text).toContain('Stale claims');
+    expect(text).toContain('TASK-42');
+    expect(text).toContain('claude-code:7p8v');
+  });
 });
 
 describe('runWho', () => {

--- a/test/db/connection.test.ts
+++ b/test/db/connection.test.ts
@@ -8,7 +8,7 @@ describe('openDatabase', () => {
   it('applies all migrations (user_version at head) and creates tables', () => {
     const db = openDatabase(':memory:');
     const version: unknown = db.pragma('user_version', { simple: true });
-    expect(version).toBe(5);
+    expect(version).toBe(6);
 
     const raw: unknown = db.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all();
     const names = new Set(
@@ -47,6 +47,7 @@ describe('row parsing', () => {
       notes: null,
       status: 'active',
       parent_task_id: null,
+      agent_id: null,
       created_at: '2026-07-17T00:00:00.000Z',
       updated_at: '2026-07-17T00:00:00.000Z',
     });

--- a/test/db/storage.test.ts
+++ b/test/db/storage.test.ts
@@ -21,6 +21,7 @@ const baseTask = {
   riskTags: ['payment-flow'],
   notes: null,
   parentTaskId: null,
+  agentId: null,
 } as const;
 
 const baseAgent = {
@@ -54,7 +55,7 @@ describe('migrations', () => {
   it('is idempotent when reopening (user_version already at head)', () => {
     const { db } = newRepos();
     const version: unknown = db.pragma('user_version', { simple: true });
-    expect(version).toBe(5);
+    expect(version).toBe(6);
   });
 });
 

--- a/test/db/storage.test.ts
+++ b/test/db/storage.test.ts
@@ -241,9 +241,6 @@ describe('agent repository', () => {
   it('lists multiple registered agents', () => {
     repos.agents.upsert(baseAgent);
     repos.agents.upsert({ ...baseAgent, agentId: 'codex:9q2r', kind: 'codex' });
-    expect(repos.agents.list().map((a) => a.agentId)).toEqual([
-      'claude-code:7p8v',
-      'codex:9q2r',
-    ]);
+    expect(repos.agents.list().map((a) => a.agentId)).toEqual(['claude-code:7p8v', 'codex:9q2r']);
   });
 });

--- a/test/domain/overlap.test.ts
+++ b/test/domain/overlap.test.ts
@@ -18,6 +18,7 @@ function task(partial: Partial<TaskRecord> & { taskId: string }): TaskRecord {
     notes: null,
     status: partial.status ?? 'active',
     parentTaskId: partial.parentTaskId ?? null,
+    agentId: null,
     createdAt: '2026-07-17T00:00:00.000Z',
     updatedAt: '2026-07-17T00:00:00.000Z',
   };

--- a/test/domain/presence.test.ts
+++ b/test/domain/presence.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import type { AgentRecord } from '../../src/db/index.js';
-import { buildRoster, deriveLiveness } from '../../src/domain/presence.js';
+import type { AgentRecord, TaskRecord } from '../../src/db/index.js';
+import { buildRoster, detectStaleClaims, deriveLiveness } from '../../src/domain/presence.js';
 
 const NOW = Date.parse('2026-07-24T12:00:00.000Z');
 
@@ -86,5 +86,68 @@ describe('buildRoster', () => {
 
   it('returns an empty roster when no agents are registered', () => {
     expect(buildRoster([], NOW)).toEqual([]);
+  });
+});
+
+function task(partial: Partial<TaskRecord> & { taskId: string }): TaskRecord {
+  return {
+    taskId: partial.taskId,
+    title: partial.title ?? partial.taskId,
+    owner: null,
+    agent: null,
+    branch: null,
+    worktree: null,
+    expectedFiles: [],
+    modules: [],
+    domains: [],
+    riskTags: [],
+    notes: null,
+    status: partial.status ?? 'active',
+    parentTaskId: null,
+    agentId: partial.agentId ?? null,
+    createdAt: '2026-07-24T00:00:00.000Z',
+    updatedAt: '2026-07-24T00:00:00.000Z',
+  };
+}
+
+describe('detectStaleClaims', () => {
+  it('flags an active claim whose owning agent is away', () => {
+    const stale = detectStaleClaims(
+      [task({ taskId: 'T-1', agentId: 'claude-code:7p8v' })],
+      [agent({ agentId: 'claude-code:7p8v', lastSeen: ago(60 * 60 * 1000) })],
+      NOW,
+    );
+    expect(stale).toHaveLength(1);
+    expect(stale[0]?.reason).toBe('agent-away');
+    expect(stale[0]?.taskId).toBe('T-1');
+    expect(stale[0]?.ageSeconds).toBe(3600);
+  });
+
+  it('flags a claim whose agent never registered', () => {
+    const stale = detectStaleClaims([task({ taskId: 'T-1', agentId: 'ghost:zzzz' })], [], NOW);
+    expect(stale).toHaveLength(1);
+    expect(stale[0]?.reason).toBe('agent-unregistered');
+    expect(stale[0]?.ageSeconds).toBeNull();
+  });
+
+  it('does not flag a claim whose agent is still live', () => {
+    const stale = detectStaleClaims(
+      [task({ taskId: 'T-1', agentId: 'claude-code:7p8v' })],
+      [agent({ agentId: 'claude-code:7p8v', lastSeen: ago(60 * 1000) })],
+      NOW,
+    );
+    expect(stale).toEqual([]);
+  });
+
+  it('ignores unattributed claims (no agent_id) and non-active tasks', () => {
+    const stale = detectStaleClaims(
+      [
+        task({ taskId: 'T-1', agentId: null }),
+        task({ taskId: 'T-2', agentId: 'ghost:zzzz', status: 'handed_off' }),
+      ],
+      [],
+      NOW,
+    );
+    expect(stale).toEqual([]);
   });
 });

--- a/test/tools/register-agent.test.ts
+++ b/test/tools/register-agent.test.ts
@@ -52,7 +52,10 @@ describe('handleRegisterAgent', () => {
       kind: 'codex',
       summary: 'building the backend',
     });
-    const result = handleRegisterAgent(repos, { agent_id: 'claude-code:7p8v', kind: 'claude-code' });
+    const result = handleRegisterAgent(repos, {
+      agent_id: 'claude-code:7p8v',
+      kind: 'claude-code',
+    });
     expect(result.roster.map((entry) => entry.agentId).sort()).toEqual([
       'claude-code:7p8v',
       'codex:9q2r',


### PR DESCRIPTION
## What changed

- associate task claims with registered agent instances
- detect active claims whose agent is away or unregistered
- expose stale claims through the work-state surfaces
- update the installed agent instructions and public tool documentation

## Why

A durable claim is only useful if teammates can tell whether its owner is still present. This closes the abandoned-work gap and documents the six-tool workflow.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- tracked files pass Prettier

This is slice 3 of the presence prerequisite and stays below the 600 LOC PR limit.