### PR TITLE
feat: auto-register Claude sessions and resolve repo-root state

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,14 @@ gone away without handing off.
 
 ## What you get
 
-SQLite is the local source of truth. `concord init` adds `.concord/` to the
+SQLite is the local source of truth, kept in the `.concord/` at the **root of
+the repo** the work is happening in. The MCP server resolves that root from
+`CONCORD_REPO_ROOT` if set, then Claude Code's `CLAUDE_PROJECT_DIR` (which Claude
+Code sets automatically, even for a user-scoped server), then its working
+directory — so every agent in one repo shares one store. Set `CONCORD_REPO_ROOT`
+when running the server somewhere its working directory is not inside the repo.
+
+`concord init` adds `.concord/` to the
 repository's `.gitignore`, so the generated workspace stays local by default.
 Teams that want selected artifacts in PRs can remove that rule or force-add the
 human-readable files:

--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ setup:
 
 ## The six tools
 
-| Tool               | When                     | What it does                                                                      |
-| ------------------ | ------------------------ | --------------------------------------------------------------------------------- |
-| `register_agent`   | at session start         | registers this instance's identity + summary + status; returns the live roster    |
-| `get_work_state`   | before choosing work     | shows the agent roster, active tasks, overlaps, stale claims, and open questions   |
-| `claim_work`       | before editing           | records the task + expected files/modules; flags overlaps with other active work  |
-| `update_task`      | while working            | appends typed intent, progress, decisions, questions, blockers, and findings      |
-| `get_task_context` | resuming or coordinating | returns the task, ordered updates, handoff, review evidence, and live overlaps    |
-| `handoff`          | done, blocked, or pre-PR | captures evidence; `ready_for_review` also produces the review packet             |
+| Tool               | When                     | What it does                                                                     |
+| ------------------ | ------------------------ | -------------------------------------------------------------------------------- |
+| `register_agent`   | at session start         | registers this instance's identity + summary + status; returns the live roster   |
+| `get_work_state`   | before choosing work     | shows the agent roster, active tasks, overlaps, stale claims, and open questions |
+| `claim_work`       | before editing           | records the task + expected files/modules; flags overlaps with other active work |
+| `update_task`      | while working            | appends typed intent, progress, decisions, questions, blockers, and findings     |
+| `get_task_context` | resuming or coordinating | returns the task, ordered updates, handoff, review evidence, and live overlaps   |
+| `handoff`          | done, blocked, or pre-PR | captures evidence; `ready_for_review` also produces the review packet            |
 
 Every write tool accepts your `register_agent` `agent_id`, which keeps your
 presence live just by working. `get_work_state` shows **who is here** (with

--- a/src/cli/commands/hook.ts
+++ b/src/cli/commands/hook.ts
@@ -1,9 +1,11 @@
+import { randomBytes } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 
 import type { Command } from '@commander-js/extra-typings';
 import { z } from 'zod';
 
 import type { Repositories } from '../../db/index.js';
+import { buildRoster } from '../../domain/presence.js';
 import { openContext } from '../context.js';
 import { checkFileOverlaps } from './check.js';
 
@@ -66,6 +68,77 @@ export function decidePreToolUse(
   };
 }
 
+/** The subset of Claude Code's SessionStart payload we use. */
+const sessionStartPayloadSchema = z
+  .object({
+    session_id: z.string().optional(),
+    cwd: z.string().optional(),
+  })
+  .passthrough();
+
+/**
+ * A stable per-session agent id for Claude Code. Derived from the session id so
+ * the same session always maps to the same identity (SessionStart is idempotent
+ * via upsert); falls back to a random suffix when no session id is provided.
+ */
+export function sessionStartAgentId(sessionId: string | undefined): string {
+  const slug = (sessionId ?? '').replace(/[^0-9a-z]/gi, '').slice(0, 8).toLowerCase();
+  return `claude-code:${slug === '' ? randomBytes(4).toString('hex') : slug}`;
+}
+
+export interface SessionStartResult {
+  agentId: string;
+  /** Context printed to stdout, which Claude Code injects into the session. */
+  message: string;
+}
+
+/**
+ * Register this Claude Code session as an agent so its presence exists even if
+ * the model never calls `register_agent`, and tell the model its `agent_id` plus
+ * who else is active. Reads a SessionStart JSON payload.
+ */
+export function handleSessionStart(repos: Repositories, rawJson: string): SessionStartResult {
+  let parsed: unknown = {};
+  try {
+    parsed = JSON.parse(rawJson);
+  } catch {
+    parsed = {};
+  }
+  const payload = sessionStartPayloadSchema.parse(parsed);
+  const agentId = sessionStartAgentId(payload.session_id);
+
+  repos.agents.upsert({
+    agentId,
+    kind: 'claude-code',
+    owner: null,
+    model: null,
+    pid: null,
+    cwd: payload.cwd ?? null,
+    worktree: null,
+    branch: null,
+    summary: null,
+    status: 'active',
+  });
+
+  const others = buildRoster(repos.agents.list(), Date.now()).filter(
+    (entry) => entry.agentId !== agentId,
+  );
+  const lines = [
+    `Concord: registered this session as agent \`${agentId}\`. Pass agent_id="${agentId}" to ` +
+      'Concord tools (claim_work, update_task, handoff) so your work is attributed and your ' +
+      'presence stays live.',
+  ];
+  if (others.length === 0) {
+    lines.push('No other agents are currently registered.');
+  } else {
+    lines.push('Who else is here:');
+    for (const entry of others) {
+      lines.push(`  - ${entry.agentId} [${entry.liveness}/${entry.status}]: ${entry.summary ?? '-'}`);
+    }
+  }
+  return { agentId, message: lines.join('\n') };
+}
+
 /** Read piped stdin to a string. Returns '' when attached to a TTY (no input). */
 function readStdin(): string {
   if (process.stdin.isTTY) {
@@ -82,9 +155,16 @@ export function registerHookCommand(program: Command): void {
   program
     .command('hook <event>')
     .description(
-      'Run a Concord hook. event: pre-tool-use (reads a Claude Code PreToolUse JSON payload on stdin)',
+      'Run a Concord hook. events: pre-tool-use (PreToolUse overlap gate) and ' +
+        'session-start (SessionStart presence auto-register); both read a Claude Code JSON ' +
+        'payload on stdin.',
     )
     .action((event) => {
+      if (event === 'session-start') {
+        const result = handleSessionStart(openContext(process.cwd()).repos, readStdin());
+        process.stdout.write(`${result.message}\n`);
+        return;
+      }
       if (event !== 'pre-tool-use') {
         process.stderr.write(`Unknown hook event: ${event}\n`);
         process.exitCode = 1;

--- a/src/cli/commands/hook.ts
+++ b/src/cli/commands/hook.ts
@@ -82,7 +82,10 @@ const sessionStartPayloadSchema = z
  * via upsert); falls back to a random suffix when no session id is provided.
  */
 export function sessionStartAgentId(sessionId: string | undefined): string {
-  const slug = (sessionId ?? '').replace(/[^0-9a-z]/gi, '').slice(0, 8).toLowerCase();
+  const slug = (sessionId ?? '')
+    .replace(/[^0-9a-z]/gi, '')
+    .slice(0, 8)
+    .toLowerCase();
   return `claude-code:${slug === '' ? randomBytes(4).toString('hex') : slug}`;
 }
 
@@ -133,7 +136,9 @@ export function handleSessionStart(repos: Repositories, rawJson: string): Sessio
   } else {
     lines.push('Who else is here:');
     for (const entry of others) {
-      lines.push(`  - ${entry.agentId} [${entry.liveness}/${entry.status}]: ${entry.summary ?? '-'}`);
+      lines.push(
+        `  - ${entry.agentId} [${entry.liveness}/${entry.status}]: ${entry.summary ?? '-'}`,
+      );
     }
   }
   return { agentId, message: lines.join('\n') };

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -26,6 +26,28 @@ export function findRepoRoot(startDir: string): string {
   }
 }
 
+/**
+ * Resolve the repo root for the MCP server, whose own `process.cwd()` is
+ * unreliable: when the server is registered at user scope it is launched from
+ * wherever the client started, not the repo the agent is editing — so a claim
+ * lands in one store while reads hit an empty repo-local `.concord/`. Prefer, in
+ * order, an explicit `CONCORD_REPO_ROOT`, Claude Code's `CLAUDE_PROJECT_DIR`
+ * (set in the server's env to the project root regardless of scope), then the
+ * cwd. Each candidate is normalized through `findRepoRoot`, so the store always
+ * lands at the `.concord/` in the root of the repo.
+ */
+export function resolveRepoRoot(cwd: string, env: NodeJS.ProcessEnv): string {
+  const override = env['CONCORD_REPO_ROOT'];
+  if (override !== undefined && override.trim() !== '') {
+    return findRepoRoot(override);
+  }
+  const projectDir = env['CLAUDE_PROJECT_DIR'];
+  if (projectDir !== undefined && projectDir.trim() !== '') {
+    return findRepoRoot(projectDir);
+  }
+  return findRepoRoot(cwd);
+}
+
 /** Absolute path to the `.concord/` directory for a given repo root. */
 export function concordDir(repoRoot: string): string {
   return join(repoRoot, CONCORD_DIR);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,12 @@
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
 import { writeArtifacts } from './artifacts/index.js';
-import { concordDir, databasePath, findRepoRoot } from './config/paths.js';
+import { concordDir, databasePath, resolveRepoRoot } from './config/paths.js';
 import { openRepositories } from './db/index.js';
 import { createServer } from './server.js';
 
 async function main(): Promise<void> {
-  const repoRoot = findRepoRoot(process.cwd());
+  const repoRoot = resolveRepoRoot(process.cwd(), process.env);
   const repos = openRepositories(databasePath(repoRoot));
   const artifactsDir = concordDir(repoRoot);
   const server = createServer(repos, {

--- a/src/install/claude-hooks.ts
+++ b/src/install/claude-hooks.ts
@@ -7,51 +7,68 @@ import { z } from 'zod';
 const MATCHER = 'Edit|Write|MultiEdit';
 /** The command Claude Code runs on each matched PreToolUse event. */
 export const PRE_TOOL_USE_HOOK_COMMAND = 'concord hook pre-tool-use';
+/** The command Claude Code runs once on SessionStart to auto-register presence. */
+export const SESSION_START_HOOK_COMMAND = 'concord hook session-start';
 
 const settingsSchema = z
   .object({
     hooks: z
-      .object({ PreToolUse: z.array(z.unknown()).optional() })
+      .object({
+        PreToolUse: z.array(z.unknown()).optional(),
+        SessionStart: z.array(z.unknown()).optional(),
+      })
       .passthrough()
       .optional(),
   })
   .passthrough();
 
+/** Append `entry` to the named hook event unless a hook running `command` is
+ * already present. Returns the updated event array. */
+function withHook(
+  existing: readonly unknown[],
+  command: string,
+  entry: unknown,
+): unknown[] {
+  const present = existing.some((item) => JSON.stringify(item).includes(command));
+  return present ? [...existing] : [...existing, entry];
+}
+
 /**
- * Idempotently add Concord's PreToolUse overlap hook to a `settings.json` string,
- * preserving every other setting (and any other hook events). Returns the new
- * file content. Passing the previous output back in is a no-op.
+ * Idempotently add Concord's Claude Code hooks to a `settings.json` string: the
+ * PreToolUse overlap gate and the SessionStart presence auto-register. Every
+ * other setting (and any other hook events) is preserved. Passing the previous
+ * output back in is a no-op.
  */
-export function upsertPreToolUseHook(existing: string | undefined): string {
+export function upsertClaudeHooks(existing: string | undefined): string {
   const source: unknown =
     existing === undefined || existing.trim() === '' ? {} : JSON.parse(existing);
   const settings = settingsSchema.parse(source);
   const hooks = settings.hooks ?? {};
-  const preToolUse = hooks.PreToolUse ?? [];
 
-  const alreadyInstalled = preToolUse.some((entry) =>
-    JSON.stringify(entry).includes(PRE_TOOL_USE_HOOK_COMMAND),
-  );
-  const nextPreToolUse = alreadyInstalled
-    ? preToolUse
-    : [
-        ...preToolUse,
-        { matcher: MATCHER, hooks: [{ type: 'command', command: PRE_TOOL_USE_HOOK_COMMAND }] },
-      ];
+  const preToolUse = withHook(hooks.PreToolUse ?? [], PRE_TOOL_USE_HOOK_COMMAND, {
+    matcher: MATCHER,
+    hooks: [{ type: 'command', command: PRE_TOOL_USE_HOOK_COMMAND }],
+  });
+  const sessionStart = withHook(hooks.SessionStart ?? [], SESSION_START_HOOK_COMMAND, {
+    hooks: [{ type: 'command', command: SESSION_START_HOOK_COMMAND }],
+  });
 
-  const next = { ...settings, hooks: { ...hooks, PreToolUse: nextPreToolUse } };
+  const next = {
+    ...settings,
+    hooks: { ...hooks, PreToolUse: preToolUse, SessionStart: sessionStart },
+  };
   return `${JSON.stringify(next, null, 2)}\n`;
 }
 
 /**
- * Write the PreToolUse hook into `<repoRoot>/.claude/settings.json` (created if
- * absent), preserving existing settings. Returns the relative path written.
+ * Write Concord's Claude Code hooks into `<repoRoot>/.claude/settings.json`
+ * (created if absent), preserving existing settings. Returns the relative path.
  */
 export function installClaudeHook(repoRoot: string): string {
   const relPath = join('.claude', 'settings.json');
   const fullPath = join(repoRoot, relPath);
   const existing = existsSync(fullPath) ? readFileSync(fullPath, 'utf8') : undefined;
   mkdirSync(dirname(fullPath), { recursive: true });
-  writeFileSync(fullPath, upsertPreToolUseHook(existing));
+  writeFileSync(fullPath, upsertClaudeHooks(existing));
   return relPath;
 }

--- a/src/install/claude-hooks.ts
+++ b/src/install/claude-hooks.ts
@@ -24,11 +24,7 @@ const settingsSchema = z
 
 /** Append `entry` to the named hook event unless a hook running `command` is
  * already present. Returns the updated event array. */
-function withHook(
-  existing: readonly unknown[],
-  command: string,
-  entry: unknown,
-): unknown[] {
+function withHook(existing: readonly unknown[], command: string, entry: unknown): unknown[] {
   const present = existing.some((item) => JSON.stringify(item).includes(command));
   return present ? [...existing] : [...existing, entry];
 }

--- a/src/install/instructions.ts
+++ b/src/install/instructions.ts
@@ -33,7 +33,10 @@ shows per-task adoption either way. For edit-time enforcement, wire a PreToolUse
 (or git pre-commit) hook to \`concord check <files> --task <your-task-id>\`; it
 exits non-zero when your edits collide with another agent's active claim. On
 Claude Code, \`concord install --claude-hooks\` installs this automatically — set
-\`CONCORD_TASK=<your task id>\` so the hook excludes your own claim.`;
+\`CONCORD_TASK=<your task id>\` so the hook excludes your own claim. It also
+installs a SessionStart hook that auto-registers your presence and tells you the
+\`agent_id\` to reuse, so you are visible in the roster even before your first
+tool call.`;
 
 /** MDC frontmatter used when creating a fresh Cursor rules file. */
 export const CURSOR_MDC_HEADER = `---

--- a/test/cli/hook.test.ts
+++ b/test/cli/hook.test.ts
@@ -1,9 +1,14 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { decidePreToolUse } from '../../src/cli/commands/hook.js';
+import {
+  decidePreToolUse,
+  handleSessionStart,
+  sessionStartAgentId,
+} from '../../src/cli/commands/hook.js';
 import { openDatabase } from '../../src/db/connection.js';
 import { createRepositories, type Repositories } from '../../src/db/index.js';
 import { handleClaimWork } from '../../src/tools/claim-work.js';
+import { handleRegisterAgent } from '../../src/tools/register-agent.js';
 
 function preToolUse(filePath: string): string {
   return JSON.stringify({ tool_name: 'Edit', tool_input: { file_path: filePath } });
@@ -47,5 +52,52 @@ describe('decidePreToolUse', () => {
       decidePreToolUse(repos, JSON.stringify({ tool_name: 'Bash', tool_input: {} }), 'MINE').block,
     ).toBe(false);
     expect(decidePreToolUse(repos, 'not valid json', 'MINE').block).toBe(false);
+  });
+});
+
+describe('sessionStartAgentId', () => {
+  it('derives a stable id from the session id', () => {
+    expect(sessionStartAgentId('a1b2c3d4-e5f6-7890')).toBe('claude-code:a1b2c3d4');
+  });
+
+  it('falls back to a random suffix when no session id is given', () => {
+    expect(sessionStartAgentId(undefined)).toMatch(/^claude-code:[0-9a-f]{8}$/);
+  });
+});
+
+describe('handleSessionStart', () => {
+  let repos: Repositories;
+  beforeEach(() => {
+    repos = createRepositories(openDatabase(':memory:'));
+  });
+
+  it('registers the session as an agent and reports its id', () => {
+    const result = handleSessionStart(
+      repos,
+      JSON.stringify({ session_id: 'a1b2c3d4-e5f6', cwd: '/repo' }),
+    );
+    expect(result.agentId).toBe('claude-code:a1b2c3d4');
+    expect(result.message).toContain('claude-code:a1b2c3d4');
+    expect(result.message).toContain('No other agents');
+    expect(repos.agents.get('claude-code:a1b2c3d4')?.cwd).toBe('/repo');
+  });
+
+  it('is idempotent for the same session and lists other present agents', () => {
+    handleRegisterAgent(repos, {
+      agent_id: 'codex:9q2r',
+      kind: 'codex',
+      summary: 'building the backend',
+    });
+    const payload = JSON.stringify({ session_id: 'a1b2c3d4' });
+    handleSessionStart(repos, payload);
+    const again = handleSessionStart(repos, payload);
+    expect(repos.agents.list()).toHaveLength(2);
+    expect(again.message).toContain('codex:9q2r');
+    expect(again.message).toContain('building the backend');
+  });
+
+  it('tolerates a malformed payload by generating a random id', () => {
+    const result = handleSessionStart(repos, 'not json');
+    expect(result.agentId).toMatch(/^claude-code:[0-9a-f]{8}$/);
   });
 });

--- a/test/config/paths.test.ts
+++ b/test/config/paths.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { concordDir, databasePath, findRepoRoot } from '../../src/config/paths.js';
+import { concordDir, databasePath, findRepoRoot, resolveRepoRoot } from '../../src/config/paths.js';
 
 describe('paths', () => {
   it('derives .concord and db paths from a repo root', () => {
@@ -23,5 +23,41 @@ describe('paths', () => {
   it('falls back to the start dir when no .git is found', () => {
     const dir = mkdtempSync(join(tmpdir(), 'concord-nogit-'));
     expect(findRepoRoot(dir)).toBe(dir);
+  });
+});
+
+describe('resolveRepoRoot', () => {
+  it('uses process cwd when no env override is set', () => {
+    const root = mkdtempSync(join(tmpdir(), 'concord-cwd-'));
+    mkdirSync(join(root, '.git'));
+    const nested = join(root, 'pkg');
+    mkdirSync(nested);
+    expect(resolveRepoRoot(nested, {})).toBe(root);
+  });
+
+  it('prefers CLAUDE_PROJECT_DIR over cwd and normalizes to the git root', () => {
+    const project = mkdtempSync(join(tmpdir(), 'concord-proj-'));
+    mkdirSync(join(project, '.git'));
+    const nested = join(project, 'src');
+    mkdirSync(nested);
+    const elsewhere = mkdtempSync(join(tmpdir(), 'concord-elsewhere-'));
+    // cwd is an unrelated directory; the project dir must win.
+    expect(resolveRepoRoot(elsewhere, { CLAUDE_PROJECT_DIR: nested })).toBe(project);
+  });
+
+  it('lets CONCORD_REPO_ROOT override CLAUDE_PROJECT_DIR', () => {
+    const forced = mkdtempSync(join(tmpdir(), 'concord-forced-'));
+    mkdirSync(join(forced, '.git'));
+    const project = mkdtempSync(join(tmpdir(), 'concord-proj2-'));
+    mkdirSync(join(project, '.git'));
+    expect(
+      resolveRepoRoot('/nowhere', { CONCORD_REPO_ROOT: forced, CLAUDE_PROJECT_DIR: project }),
+    ).toBe(forced);
+  });
+
+  it('ignores blank env values', () => {
+    const root = mkdtempSync(join(tmpdir(), 'concord-blank-'));
+    mkdirSync(join(root, '.git'));
+    expect(resolveRepoRoot(root, { CONCORD_REPO_ROOT: '  ', CLAUDE_PROJECT_DIR: '' })).toBe(root);
   });
 });

--- a/test/db/storage.test.ts
+++ b/test/db/storage.test.ts
@@ -241,9 +241,6 @@ describe('agent repository', () => {
   it('lists multiple registered agents', () => {
     repos.agents.upsert(baseAgent);
     repos.agents.upsert({ ...baseAgent, agentId: 'codex:9q2r', kind: 'codex' });
-    expect(repos.agents.list().map((a) => a.agentId)).toEqual([
-      'claude-code:7p8v',
-      'codex:9q2r',
-    ]);
+    expect(repos.agents.list().map((a) => a.agentId)).toEqual(['claude-code:7p8v', 'codex:9q2r']);
   });
 });

--- a/test/install/claude-hooks.test.ts
+++ b/test/install/claude-hooks.test.ts
@@ -1,18 +1,24 @@
 import { describe, expect, it } from 'vitest';
 
-import { PRE_TOOL_USE_HOOK_COMMAND, upsertPreToolUseHook } from '../../src/install/claude-hooks.js';
+import {
+  PRE_TOOL_USE_HOOK_COMMAND,
+  SESSION_START_HOOK_COMMAND,
+  upsertClaudeHooks,
+} from '../../src/install/claude-hooks.js';
 
-describe('upsertPreToolUseHook', () => {
-  it('adds the PreToolUse hook to empty settings', () => {
-    const out = upsertPreToolUseHook(undefined);
+describe('upsertClaudeHooks', () => {
+  it('adds the PreToolUse and SessionStart hooks to empty settings', () => {
+    const out = upsertClaudeHooks(undefined);
     expect(out).toContain('PreToolUse');
     expect(out).toContain(PRE_TOOL_USE_HOOK_COMMAND);
     expect(out).toContain('Edit|Write|MultiEdit');
+    expect(out).toContain('SessionStart');
+    expect(out).toContain(SESSION_START_HOOK_COMMAND);
   });
 
   it('is idempotent: re-running produces identical output', () => {
-    const once = upsertPreToolUseHook(undefined);
-    const twice = upsertPreToolUseHook(once);
+    const once = upsertClaudeHooks(undefined);
+    const twice = upsertClaudeHooks(once);
     expect(twice).toBe(once);
   });
 
@@ -21,16 +27,17 @@ describe('upsertPreToolUseHook', () => {
       model: 'opus',
       hooks: { PostToolUse: [{ matcher: 'Bash', hooks: [] }] },
     });
-    const out = upsertPreToolUseHook(existing);
+    const out = upsertClaudeHooks(existing);
     expect(out).toContain('"model": "opus"');
     expect(out).toContain('PostToolUse');
     expect(out).toContain(PRE_TOOL_USE_HOOK_COMMAND);
+    expect(out).toContain(SESSION_START_HOOK_COMMAND);
   });
 
-  it('does not duplicate the hook when one is already present', () => {
-    const once = upsertPreToolUseHook(undefined);
-    const twice = upsertPreToolUseHook(once);
-    const occurrences = twice.split(PRE_TOOL_USE_HOOK_COMMAND).length - 1;
-    expect(occurrences).toBe(1);
+  it('does not duplicate hooks when they are already present', () => {
+    const once = upsertClaudeHooks(undefined);
+    const twice = upsertClaudeHooks(once);
+    expect(twice.split(PRE_TOOL_USE_HOOK_COMMAND).length - 1).toBe(1);
+    expect(twice.split(SESSION_START_HOOK_COMMAND).length - 1).toBe(1);
   });
 });

--- a/test/tools/register-agent.test.ts
+++ b/test/tools/register-agent.test.ts
@@ -52,7 +52,10 @@ describe('handleRegisterAgent', () => {
       kind: 'codex',
       summary: 'building the backend',
     });
-    const result = handleRegisterAgent(repos, { agent_id: 'claude-code:7p8v', kind: 'claude-code' });
+    const result = handleRegisterAgent(repos, {
+      agent_id: 'claude-code:7p8v',
+      kind: 'claude-code',
+    });
     expect(result.roster.map((entry) => entry.agentId).sort()).toEqual([
       'claude-code:7p8v',
       'codex:9q2r',


### PR DESCRIPTION
## What changed

- auto-register Claude Code sessions through the SessionStart hook
- keep hook installation idempotent
- resolve the MCP store at the actual repository root instead of the server process cwd
- finish formatting the presence changes

## Why

Presence should work without manual ceremony, and every agent in a repository must converge on the same `.concord` database even when the MCP server starts elsewhere.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- tracked files pass Prettier

This is the final presence prerequisite slice and stays below the 600 LOC PR limit.