### PR TITLE
feat: add the live Concord dashboard

### DIFF
--- a/src/cli/commands/dashboard.tsx
+++ b/src/cli/commands/dashboard.tsx
@@ -1,0 +1,53 @@
+import type { Command } from '@commander-js/extra-typings';
+import { render } from 'ink';
+
+import { DashboardApp } from '../dashboard/app.js';
+import { buildDashboardSnapshot } from '../dashboard/model.js';
+import { openContext } from '../context.js';
+
+export const DASHBOARD_TTY_ERROR =
+  'concord dashboard needs an interactive terminal. Use `concord status` for plain-text output.';
+
+export async function runDashboard(
+  cwd: string,
+  stdin: NodeJS.ReadStream = process.stdin,
+  stdout: NodeJS.WriteStream = process.stdout,
+): Promise<void> {
+  if (!stdin.isTTY || !stdout.isTTY) {
+    throw new Error(DASHBOARD_TTY_ERROR);
+  }
+
+  const context = openContext(cwd);
+  const loadSnapshot = (): ReturnType<typeof buildDashboardSnapshot> =>
+    buildDashboardSnapshot(context.repoRoot, context.repos);
+
+  try {
+    const app = render(
+      <DashboardApp initialSnapshot={loadSnapshot()} loadSnapshot={loadSnapshot} />,
+      {
+        stdin,
+        stdout,
+        exitOnCtrlC: true,
+        incrementalRendering: true,
+      },
+    );
+    await app.waitUntilExit();
+  } finally {
+    context.repos.db.close();
+  }
+}
+
+export function registerDashboardCommand(program: Command): void {
+  program
+    .command('dashboard')
+    .description('Open a live, read-only view of agents, tasks, alerts, and activity')
+    .action(async () => {
+      try {
+        await runDashboard(process.cwd());
+      } catch (cause: unknown) {
+        const message = cause instanceof Error ? cause.message : String(cause);
+        process.stderr.write(`${message}\n`);
+        process.exitCode = 1;
+      }
+    });
+}

--- a/src/cli/dashboard/app.tsx
+++ b/src/cli/dashboard/app.tsx
@@ -1,0 +1,440 @@
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { Box, Text, useApp, useInput, useStdout } from 'ink';
+
+import type { PresenceEntry } from '../../domain/presence.js';
+import type { DashboardSnapshot, DashboardTask } from './model.js';
+
+type Pane = 'agents' | 'tasks' | 'alerts' | 'context' | 'timeline';
+type Layout = 'wide' | 'stacked' | 'compact';
+
+export interface DashboardAppProps {
+  initialSnapshot: DashboardSnapshot;
+  loadSnapshot: () => DashboardSnapshot;
+  refreshMs?: number;
+  width?: number;
+}
+
+interface PanelProps {
+  title: string;
+  focused: boolean;
+  children: ReactNode;
+}
+
+function Panel({ title, focused, children }: PanelProps): ReactNode {
+  return (
+    <Box
+      borderStyle="round"
+      borderColor={focused ? 'cyan' : 'gray'}
+      flexDirection="column"
+      paddingX={1}
+    >
+      <Text bold color={focused ? 'cyan' : 'gray'}>
+        {title}
+      </Text>
+      {children}
+    </Box>
+  );
+}
+
+function layoutFor(columns: number): Layout {
+  if (columns >= 100) {
+    return 'wide';
+  }
+  if (columns >= 70) {
+    return 'stacked';
+  }
+  return 'compact';
+}
+
+function panesFor(layout: Layout): Pane[] {
+  return layout === 'compact'
+    ? ['tasks', 'alerts', 'timeline']
+    : ['agents', 'tasks', 'alerts', 'context', 'timeline'];
+}
+
+function ageLabel(seconds: number): string {
+  if (seconds < 60) {
+    return `${String(seconds)}s`;
+  }
+  return `${String(Math.floor(seconds / 60))}m`;
+}
+
+function livenessMarker(entry: PresenceEntry): ReactNode {
+  if (entry.liveness === 'live') {
+    return <Text color="green">●</Text>;
+  }
+  if (entry.liveness === 'idle') {
+    return <Text color="yellow">◐</Text>;
+  }
+  return <Text color="red">○</Text>;
+}
+
+function Agents({ snapshot }: { snapshot: DashboardSnapshot }): ReactNode {
+  if (snapshot.status.presence.length === 0) {
+    return <Text dimColor>No registered agents</Text>;
+  }
+  return snapshot.status.presence.map((agent) => (
+    <Text key={agent.agentId} wrap="truncate-end">
+      {livenessMarker(agent)} {agent.agentId} · {agent.status} · {ageLabel(agent.ageSeconds)}
+      {agent.summary === null ? '' : ` · ${agent.summary}`}
+    </Text>
+  ));
+}
+
+function taskMatches(item: DashboardTask, filter: string): boolean {
+  if (filter === '') {
+    return true;
+  }
+  const haystack = [
+    item.task.taskId,
+    item.task.title,
+    item.task.agent ?? '',
+    item.task.owner ?? '',
+    item.touches,
+  ]
+    .join(' ')
+    .toLowerCase();
+  return haystack.includes(filter.toLowerCase());
+}
+
+function Tasks({
+  tasks,
+  selectedIndex,
+}: {
+  tasks: DashboardTask[];
+  selectedIndex: number;
+}): ReactNode {
+  if (tasks.length === 0) {
+    return <Text dimColor>No matching tasks</Text>;
+  }
+  return tasks.map((item, index) => {
+    const selected = index === selectedIndex;
+    return (
+      <Text key={item.task.taskId} color={selected ? 'cyan' : 'white'} wrap="truncate-end">
+        {selected ? '›' : ' '} {item.task.taskId} · {item.task.status} ·{' '}
+        {item.task.agent ?? 'unassigned'} · {item.task.title}
+      </Text>
+    );
+  });
+}
+
+function alertLines(snapshot: DashboardSnapshot): ReactNode[] {
+  const lines: ReactNode[] = [];
+  for (const overlap of snapshot.status.overlaps) {
+    lines.push(
+      <Text key={`overlap-${overlap.a}-${overlap.b}`} color="yellow" wrap="truncate-end">
+        ! {overlap.a} ↔ {overlap.b}: {overlap.reasons.join('; ')}
+      </Text>,
+    );
+  }
+  for (const claim of snapshot.status.staleClaims) {
+    lines.push(
+      <Text key={`stale-${claim.taskId}`} color="red" wrap="truncate-end">
+        ! {claim.taskId}: stale claim by {claim.agentId}
+      </Text>,
+    );
+  }
+  for (const question of snapshot.status.openQuestions) {
+    lines.push(
+      <Text
+        key={`question-${question.taskId}-${question.question}`}
+        color="magenta"
+        wrap="truncate-end"
+      >
+        ? {question.taskId}: {question.question}
+      </Text>,
+    );
+  }
+  for (const event of snapshot.events.filter((item) => item.status === 'error')) {
+    lines.push(
+      <Text key={`event-${String(event.id)}`} color="red" wrap="truncate-end">
+        × {event.taskId ?? 'workspace'}: {event.tool} failed
+      </Text>,
+    );
+  }
+  return lines;
+}
+
+function Alerts({ snapshot }: { snapshot: DashboardSnapshot }): ReactNode {
+  const lines = alertLines(snapshot);
+  return lines.length === 0 ? <Text dimColor>No coordination alerts</Text> : lines;
+}
+
+function Context({ item }: { item: DashboardTask | undefined }): ReactNode {
+  if (item === undefined) {
+    return <Text dimColor>Select a task to inspect its shared memory</Text>;
+  }
+  return (
+    <>
+      <Text bold>
+        {item.task.taskId} — {item.task.title}
+      </Text>
+      <Text wrap="truncate-end">
+        owner {item.task.owner ?? '-'} · branch {item.task.branch ?? '-'} · touches {item.touches}
+      </Text>
+      {item.updates.slice(-5).map((update) => (
+        <Text key={`update-${String(update.id)}`} wrap="truncate-end">
+          <Text color={update.kind === 'decision' ? 'green' : 'blue'}>{update.kind}</Text>{' '}
+          {update.content}
+        </Text>
+      ))}
+      {item.latestHandoff === undefined ? null : (
+        <Text wrap="truncate-end">
+          <Text color="yellow">handoff</Text> {item.latestHandoff.whatChanged}
+        </Text>
+      )}
+      {item.latestReview === undefined ? null : (
+        <Text wrap="truncate-end">
+          <Text color="magenta">review</Text> {item.latestReview.planSummary}
+        </Text>
+      )}
+    </>
+  );
+}
+
+function shortTime(value: string): string {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime())
+    ? '--:--'
+    : date.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' });
+}
+
+function Timeline({
+  snapshot,
+  filter,
+}: {
+  snapshot: DashboardSnapshot;
+  filter: string;
+}): ReactNode {
+  const events = snapshot.events
+    .filter((event) => {
+      if (filter === '') {
+        return true;
+      }
+      return [event.taskId ?? '', event.tool, event.detail ?? '']
+        .join(' ')
+        .toLowerCase()
+        .includes(filter.toLowerCase());
+    })
+    .slice(0, 8);
+  if (events.length === 0) {
+    return <Text dimColor>No matching activity</Text>;
+  }
+  return events.map((event) => (
+    <Text key={event.id} color={event.status === 'error' ? 'red' : 'white'} wrap="truncate-end">
+      {shortTime(event.createdAt)} · {event.taskId ?? 'workspace'} · {event.tool}
+      {event.detail === null ? '' : ` · ${event.detail}`}
+    </Text>
+  ));
+}
+
+function Help(): ReactNode {
+  return (
+    <Panel title="Keyboard help" focused>
+      <Text>Tab/Shift-Tab pane · ↑↓ or j/k select task · / filter · r refresh</Text>
+      <Text>? close help · q or Ctrl-C quit · Esc clear filter</Text>
+    </Panel>
+  );
+}
+
+function DashboardBody({
+  snapshot,
+  layout,
+  pane,
+  tasks,
+  selectedIndex,
+  filter,
+}: {
+  snapshot: DashboardSnapshot;
+  layout: Layout;
+  pane: Pane;
+  tasks: DashboardTask[];
+  selectedIndex: number;
+  filter: string;
+}): ReactNode {
+  const selected = tasks[selectedIndex];
+  if (layout === 'compact') {
+    return (
+      <>
+        <Panel title="Tasks" focused={pane === 'tasks'}>
+          <Tasks tasks={tasks} selectedIndex={selectedIndex} />
+        </Panel>
+        <Panel title="Alerts" focused={pane === 'alerts'}>
+          <Alerts snapshot={snapshot} />
+        </Panel>
+        <Panel title="Timeline" focused={pane === 'timeline'}>
+          <Timeline snapshot={snapshot} filter={filter} />
+        </Panel>
+        <Text dimColor>
+          Compact view — widen terminal to 70+ columns for agent and task context.
+        </Text>
+      </>
+    );
+  }
+
+  const overview = (
+    <>
+      <Panel title="Agents" focused={pane === 'agents'}>
+        <Agents snapshot={snapshot} />
+      </Panel>
+      <Panel title="Alerts" focused={pane === 'alerts'}>
+        <Alerts snapshot={snapshot} />
+      </Panel>
+    </>
+  );
+  const work = (
+    <>
+      <Panel title="Tasks" focused={pane === 'tasks'}>
+        <Tasks tasks={tasks} selectedIndex={selectedIndex} />
+      </Panel>
+      <Panel title="Task context" focused={pane === 'context'}>
+        <Context item={selected} />
+      </Panel>
+    </>
+  );
+
+  return (
+    <>
+      <Box flexDirection={layout === 'wide' ? 'row' : 'column'}>
+        <Box flexDirection="column" width={layout === 'wide' ? '35%' : '100%'}>
+          {overview}
+        </Box>
+        <Box flexDirection="column" width={layout === 'wide' ? '65%' : '100%'}>
+          {work}
+        </Box>
+      </Box>
+      <Panel title="Timeline" focused={pane === 'timeline'}>
+        <Timeline snapshot={snapshot} filter={filter} />
+      </Panel>
+    </>
+  );
+}
+
+export function DashboardApp({
+  initialSnapshot,
+  loadSnapshot,
+  refreshMs = 500,
+  width,
+}: DashboardAppProps): ReactNode {
+  const { exit } = useApp();
+  const { stdout } = useStdout();
+  const [terminalWidth, setTerminalWidth] = useState(width ?? stdout.columns);
+  const [snapshot, setSnapshot] = useState(initialSnapshot);
+  const [paneIndex, setPaneIndex] = useState(0);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [filter, setFilter] = useState('');
+  const [searching, setSearching] = useState(false);
+  const [showHelp, setShowHelp] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+
+  const layout = layoutFor(width ?? terminalWidth);
+  const panes = panesFor(layout);
+  const pane = panes[paneIndex % panes.length] ?? 'tasks';
+  const tasks = useMemo(
+    () => snapshot.tasks.filter((task) => taskMatches(task, filter)),
+    [filter, snapshot.tasks],
+  );
+
+  const refresh = useCallback(() => {
+    try {
+      setSnapshot(loadSnapshot());
+      setError(undefined);
+    } catch (cause: unknown) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    }
+  }, [loadSnapshot]);
+
+  useEffect(() => {
+    const timer = setInterval(refresh, refreshMs);
+    return () => {
+      clearInterval(timer);
+    };
+  }, [refresh, refreshMs]);
+
+  useEffect(() => {
+    if (width !== undefined) {
+      return;
+    }
+    const resize = (): void => {
+      setTerminalWidth(stdout.columns);
+    };
+    stdout.on('resize', resize);
+    return () => {
+      stdout.off('resize', resize);
+    };
+  }, [stdout, width]);
+
+  useEffect(() => {
+    setSelectedIndex((current) => Math.min(current, Math.max(0, tasks.length - 1)));
+  }, [tasks.length]);
+
+  useInput((input, key) => {
+    if (showHelp) {
+      if (input === '?' || input === 'q' || key.escape) {
+        setShowHelp(false);
+      }
+      return;
+    }
+    if (searching) {
+      if (key.escape || key.return) {
+        setSearching(false);
+      } else if (key.backspace || key.delete) {
+        setFilter((current) => current.slice(0, -1));
+      } else if (!key.ctrl && !key.meta && input !== '') {
+        setFilter((current) => current + input);
+      }
+      return;
+    }
+    if (input === 'q' || (key.ctrl && input === 'c')) {
+      exit();
+    } else if (input === '?') {
+      setShowHelp(true);
+    } else if (input === '/') {
+      setSearching(true);
+    } else if (key.escape) {
+      setFilter('');
+    } else if (input === 'r') {
+      refresh();
+    } else if (key.tab) {
+      setPaneIndex((current) => {
+        const direction = key.shift ? -1 : 1;
+        return (current + direction + panes.length) % panes.length;
+      });
+    } else if (key.downArrow || input === 'j') {
+      setSelectedIndex((current) => Math.min(current + 1, Math.max(0, tasks.length - 1)));
+    } else if (key.upArrow || input === 'k') {
+      setSelectedIndex((current) => Math.max(0, current - 1));
+    }
+  });
+
+  return (
+    <Box flexDirection="column">
+      <Box justifyContent="space-between">
+        <Text bold color="cyan">
+          Concord · {snapshot.repoName} · LIVE
+        </Text>
+        <Text dimColor>updated {shortTime(snapshot.generatedAt)}</Text>
+      </Box>
+      {showHelp ? (
+        <Help />
+      ) : (
+        <DashboardBody
+          snapshot={snapshot}
+          layout={layout}
+          pane={pane}
+          tasks={tasks}
+          selectedIndex={selectedIndex}
+          filter={filter}
+        />
+      )}
+      {error === undefined ? null : <Text color="red">Refresh failed: {error}</Text>}
+      <Text color={searching ? 'cyan' : 'gray'}>
+        {searching
+          ? `Filter: ${filter}▌`
+          : filter === ''
+            ? 'q quit · Tab pane · / filter · ? help'
+            : `Filter: ${filter} · Esc clear`}
+      </Text>
+    </Box>
+  );
+}

--- a/src/cli/dashboard/model.ts
+++ b/src/cli/dashboard/model.ts
@@ -1,0 +1,64 @@
+import { basename, dirname } from 'node:path';
+
+import { buildStatus, type StatusView } from '../../artifacts/work-state-view.js';
+import type {
+  EventRecord,
+  HandoffRecord,
+  Repositories,
+  ReviewRecord,
+  TaskRecord,
+  TaskUpdateRecord,
+} from '../../db/index.js';
+
+export interface DashboardTask {
+  task: TaskRecord;
+  touches: string;
+  updates: TaskUpdateRecord[];
+  latestHandoff: HandoffRecord | undefined;
+  latestReview: ReviewRecord | undefined;
+}
+
+export interface DashboardSnapshot {
+  repoName: string;
+  generatedAt: string;
+  status: StatusView;
+  tasks: DashboardTask[];
+  events: EventRecord[];
+}
+
+function touchesOf(task: TaskRecord): string {
+  const values =
+    task.modules.length > 0 ? task.modules : task.expectedFiles.map((file) => dirname(file));
+  const unique = [...new Set(values.filter((value) => value !== '.' && value !== ''))];
+  return unique.length > 0 ? unique.join(', ') : '-';
+}
+
+/** Build the complete read-only projection consumed by the live dashboard. */
+export function buildDashboardSnapshot(
+  repoRoot: string,
+  repos: Repositories,
+  now: number = Date.now(),
+): DashboardSnapshot {
+  const tasks = repos.tasks
+    .list()
+    .map((task) => ({
+      task,
+      touches: touchesOf(task),
+      updates: repos.taskUpdates.listByTask(task.taskId),
+      latestHandoff: repos.handoffs.latestForTask(task.taskId),
+      latestReview: repos.reviews.latestForTask(task.taskId),
+    }))
+    .sort(
+      (a, b) =>
+        b.task.updatedAt.localeCompare(a.task.updatedAt) ||
+        b.task.taskId.localeCompare(a.task.taskId),
+    );
+
+  return {
+    repoName: basename(repoRoot),
+    generatedAt: new Date(now).toISOString(),
+    status: buildStatus(repos, now),
+    tasks,
+    events: repos.events.list().slice(-100).reverse(),
+  };
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,6 +3,7 @@ import { Command } from '@commander-js/extra-typings';
 
 import { VERSION } from '../version.js';
 import { registerCheckCommand } from './commands/check.js';
+import { registerDashboardCommand } from './commands/dashboard.js';
 import { registerDoctorCommand } from './commands/doctor.js';
 import { registerExportCommand } from './commands/export.js';
 import { registerHandoffCommand } from './commands/handoff.js';
@@ -24,6 +25,7 @@ registerStatus(program);
 registerWhoCommand(program);
 registerTasks(program);
 registerCheckCommand(program);
+registerDashboardCommand(program);
 registerWatchCommand(program);
 registerHookCommand(program);
 registerHandoffCommand(program);


### PR DESCRIPTION
## What changed

- add `concord dashboard` as a read-only, interactive TUI
- project agents, tasks, overlaps, stale claims, open questions, task memory, handoffs, reviews, and recent events from the existing SQLite repositories
- refresh every 500ms with manual refresh, filtering, pane navigation, help, and clean exit
- provide wide, stacked, and compact terminal layouts
- reject non-interactive output with guidance to use `concord status`

## Why

Concord coordination becomes much easier to understand in a live visual surface while agents are working, without adding a browser server or cloud dependency.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- interactive PTY smoke test with concurrent real MCP activity

This is dashboard slice 2 of 3 and stays below the 600 LOC PR limit.