### PR TITLE
test: add the live two-agent dashboard demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ setup:
 
 ## The six tools
 
-| Tool               | When                     | What it does                                                                      |
-| ------------------ | ------------------------ | --------------------------------------------------------------------------------- |
-| `register_agent`   | at session start         | registers this instance's identity + summary + status; returns the live roster    |
-| `get_work_state`   | before choosing work     | shows the agent roster, active tasks, overlaps, stale claims, and open questions   |
-| `claim_work`       | before editing           | records the task + expected files/modules; flags overlaps with other active work  |
-| `update_task`      | while working            | appends typed intent, progress, decisions, questions, blockers, and findings      |
-| `get_task_context` | resuming or coordinating | returns the task, ordered updates, handoff, review evidence, and live overlaps    |
-| `handoff`          | done, blocked, or pre-PR | captures evidence; `ready_for_review` also produces the review packet             |
+| Tool               | When                     | What it does                                                                     |
+| ------------------ | ------------------------ | -------------------------------------------------------------------------------- |
+| `register_agent`   | at session start         | registers this instance's identity + summary + status; returns the live roster   |
+| `get_work_state`   | before choosing work     | shows the agent roster, active tasks, overlaps, stale claims, and open questions |
+| `claim_work`       | before editing           | records the task + expected files/modules; flags overlaps with other active work |
+| `update_task`      | while working            | appends typed intent, progress, decisions, questions, blockers, and findings     |
+| `get_task_context` | resuming or coordinating | returns the task, ordered updates, handoff, review evidence, and live overlaps   |
+| `handoff`          | done, blocked, or pre-PR | captures evidence; `ready_for_review` also produces the review packet            |
 
 Every write tool accepts your `register_agent` `agent_id`, which keeps your
 presence live just by working. `get_work_state` shows **who is here** (with
@@ -87,6 +87,7 @@ Agents use the MCP tools; humans use the CLI.
 ```bash
 concord init                 # create the .concord/ workspace
 concord status               # roster, active work, overlaps, stale claims, review-ready
+concord dashboard            # live, keyboard-driven view of agents, tasks, alerts, and activity
 concord who                  # which agents are present and what they are working on
 concord tasks                # list all tracked tasks
 concord handoff <task-id>    # print the latest handoff
@@ -94,6 +95,10 @@ concord review-packet <id>   # print the latest review packet
 concord export markdown      # regenerate .concord/ artifacts
 concord doctor               # workspace checks + per-task tool adoption
 ```
+
+`concord dashboard` is a read-only local TUI. It refreshes from the shared
+SQLite workspace every 500ms. Use `Tab` to change panes, `j`/`k` or the arrow
+keys to select work, `/` to filter, `?` for help, and `q` to quit.
 
 ## Try the demo
 
@@ -103,7 +108,8 @@ pnpm demo
 
 Runs the [two-agent overlap demo](./examples/two-agent-overlap/): two agents
 claim overlapping work, share and read task context, then one hands off and
-marks the task review-ready.
+marks the task review-ready. The example also includes a two-terminal flow for
+watching those real MCP calls appear live in `concord dashboard`.
 
 ## What this is / is not
 

--- a/examples/two-agent-overlap/README.md
+++ b/examples/two-agent-overlap/README.md
@@ -16,14 +16,38 @@ This builds the server and runs [`demo.mjs`](./demo.mjs), which drives the real
 Concord MCP server over stdio inside a throwaway repo (so it never touches this
 project's own `.concord/`).
 
+## Watch it live
+
+Use two terminals to see the same real MCP activity in the dashboard:
+
+```bash
+# Terminal 1
+CONCORD_ROOT=$PWD
+DEMO_DIR=$(mktemp -d)
+git init -q "$DEMO_DIR"
+echo "$DEMO_DIR"
+pnpm build
+(cd "$DEMO_DIR" && node "$CONCORD_ROOT/dist/cli/index.js" dashboard)
+```
+
+```bash
+# Terminal 2 — replace the path with the DEMO_DIR printed in terminal 1
+pnpm demo -- --dir /tmp/your-demo-dir --delay 1000
+```
+
+The one-second delay makes agent registration, claims, task memory, overlap,
+handoff, and review readiness visible as they happen. The data is not mocked:
+both terminals read and write the same local Concord SQLite workspace.
+
 ## What happens
 
-1. **claude-code** claims `TASK-12` (Stripe retry handling, module `billing`).
-2. **codex** claims `TASK-14` (invoice totals, module `billing`) — Concord flags
+1. **claude-code** and **codex** register their live presence.
+2. **claude-code** claims `TASK-12` (Stripe retry handling, module `billing`).
+3. **codex** claims `TASK-14` (invoice totals, module `billing`) — Concord flags
    the overlap on `billing`.
-3. **claude-code** hands off `TASK-12` with what changed, tests run, and
+4. **claude-code** hands off `TASK-12` with what changed, tests run, and
    decisions.
-4. **claude-code** marks `TASK-12` review-ready with plan, guardrails, open
+5. **claude-code** marks `TASK-12` review-ready with plan, guardrails, open
    questions, and provenance.
 
 The script then prints the generated `.concord/` artifacts, including the full

--- a/examples/two-agent-overlap/demo.mjs
+++ b/examples/two-agent-overlap/demo.mjs
@@ -4,7 +4,7 @@
 
 import { mkdirSync, mkdtempSync, readdirSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
@@ -13,9 +13,21 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 const here = dirname(fileURLToPath(import.meta.url));
 const serverEntry = join(here, '..', '..', 'dist', 'index.js');
 
-// Run in a throwaway repo so the demo never touches this project's own .concord/.
-const workdir = mkdtempSync(join(tmpdir(), 'concord-demo-'));
-mkdirSync(join(workdir, '.git'));
+function option(name) {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? undefined : process.argv[index + 1];
+}
+
+const requestedDir = option('--dir');
+const workdir =
+  requestedDir === undefined ? mkdtempSync(join(tmpdir(), 'concord-demo-')) : resolve(requestedDir);
+const delayMs = Number.parseInt(option('--delay') ?? '0', 10);
+if (!Number.isFinite(delayMs) || delayMs < 0) {
+  throw new Error('--delay must be a non-negative number of milliseconds');
+}
+
+// Default to a throwaway repo; --dir lets a second terminal watch the real flow.
+mkdirSync(join(workdir, '.git'), { recursive: true });
 
 const transport = new StdioClientTransport({
   command: process.execPath,
@@ -34,7 +46,33 @@ async function call(name, args) {
   return text(await client.callTool({ name, arguments: args }));
 }
 
+async function pause() {
+  await new Promise((resolvePause) => {
+    setTimeout(resolvePause, delayMs);
+  });
+}
+
 console.log('# Concord — two-agent overlap demo\n');
+console.log(`Workspace: ${workdir}`);
+console.log(`Watch live: (cd ${JSON.stringify(workdir)} && concord dashboard)\n`);
+
+console.log('$ claude-code and codex register their presence');
+console.log(
+  await call('register_agent', {
+    agent_id: 'claude-code:demo',
+    kind: 'claude-code',
+    summary: 'Adding Stripe retry handling',
+  }),
+);
+console.log(
+  await call('register_agent', {
+    agent_id: 'codex:demo',
+    kind: 'codex',
+    summary: 'Fixing invoice totals',
+  }),
+  '\n',
+);
+await pause();
 
 console.log('$ claude-code claims TASK-12');
 console.log(
@@ -42,12 +80,14 @@ console.log(
     task_id: 'TASK-12',
     title: 'Add Stripe retry handling',
     agent: 'claude-code',
+    agent_id: 'claude-code:demo',
     branch: 'feat/billing-retry',
     modules: ['billing', 'stripe'],
     expected_files: ['src/billing/retry.ts'],
   }),
   '\n',
 );
+await pause();
 
 console.log('$ claude-code records task context as it works');
 console.log(
@@ -55,6 +95,7 @@ console.log(
     task_id: 'TASK-12',
     kind: 'intent',
     content: 'Keep checkout responsive when Stripe retries are needed',
+    agent_id: 'claude-code:demo',
   }),
 );
 console.log(
@@ -62,9 +103,11 @@ console.log(
     task_id: 'TASK-12',
     kind: 'decision',
     content: 'Use a queued retry so user-path calls never block checkout',
+    agent_id: 'claude-code:demo',
   }),
   '\n',
 );
+await pause();
 
 console.log('$ codex claims TASK-14 (also touches billing)');
 console.log(
@@ -72,11 +115,13 @@ console.log(
     task_id: 'TASK-14',
     title: 'Fix invoice totals',
     agent: 'codex',
+    agent_id: 'codex:demo',
     modules: ['billing'],
     expected_files: ['src/billing/invoices.ts'],
   }),
   '\n',
 );
+await pause();
 
 console.log('$ codex reads TASK-12 context before coordinating');
 console.log(await call('get_task_context', { task_id: 'TASK-12' }), '\n');
@@ -85,6 +130,7 @@ console.log('$ claude-code hands off TASK-12 and marks it review-ready');
 console.log(
   await call('handoff', {
     task_id: 'TASK-12',
+    agent_id: 'claude-code:demo',
     status: 'done',
     what_changed: 'Queued retries instead of blocking checkout',
     changed_files: ['src/billing/retry.ts'],
@@ -102,6 +148,7 @@ console.log(
   }),
   '\n',
 );
+await pause();
 
 await client.close();
 

--- a/test/cli/dashboard.test.tsx
+++ b/test/cli/dashboard.test.tsx
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { cleanup, render } from 'ink-testing-library';
+
+import { DashboardApp } from '../../src/cli/dashboard/app.js';
+import { buildDashboardSnapshot } from '../../src/cli/dashboard/model.js';
+import { openDatabase } from '../../src/db/connection.js';
+import { createRepositories, type Repositories } from '../../src/db/index.js';
+import { handleClaimWork } from '../../src/tools/claim-work.js';
+import { handleHandoff } from '../../src/tools/handoff.js';
+import { handleRegisterAgent } from '../../src/tools/register-agent.js';
+import { handleReviewReady } from '../../src/tools/review-ready.js';
+import { handleUpdateTask } from '../../src/tools/update-task.js';
+
+describe('dashboard snapshot', () => {
+  let repos: Repositories;
+
+  beforeEach(() => {
+    repos = createRepositories(openDatabase(':memory:'));
+  });
+
+  afterEach(() => {
+    cleanup();
+    repos.db.close();
+  });
+
+  function seedDashboard(): void {
+    handleRegisterAgent(repos, {
+      agent_id: 'claude-code:demo',
+      kind: 'claude-code',
+      summary: 'building retry handling',
+    });
+    handleClaimWork(repos, {
+      task_id: 'TASK-12',
+      title: 'Add Stripe retry handling',
+      agent: 'claude-code',
+      agent_id: 'claude-code:demo',
+      branch: 'feat/retry',
+      modules: ['billing'],
+    });
+    handleUpdateTask(repos, {
+      task_id: 'TASK-12',
+      kind: 'decision',
+      content: 'Use a queued retry',
+      agent: 'claude-code',
+    });
+    handleClaimWork(repos, {
+      task_id: 'TASK-14',
+      title: 'Fix invoice totals',
+      agent: 'codex',
+      modules: ['billing'],
+    });
+  }
+
+  it('combines presence, task memory, overlaps, and newest-first events', () => {
+    seedDashboard();
+    handleHandoff(repos, {
+      task_id: 'TASK-12',
+      status: 'done',
+      what_changed: 'Queued retries',
+    });
+    handleReviewReady(repos, {
+      task_id: 'TASK-12',
+      plan_summary: 'Keep checkout responsive',
+      open_questions: ['When should we notify the owner?'],
+    });
+
+    const snapshot = buildDashboardSnapshot('/work/concord-demo', repos);
+    const task = snapshot.tasks.find((item) => item.task.taskId === 'TASK-12');
+
+    expect(snapshot.repoName).toBe('concord-demo');
+    expect(snapshot.status.presence[0]?.agentId).toBe('claude-code:demo');
+    expect(snapshot.status.overlaps).toHaveLength(0);
+    expect(task?.updates[0]?.content).toBe('Use a queued retry');
+    expect(task?.latestHandoff?.whatChanged).toBe('Queued retries');
+    expect(task?.latestReview?.openQuestions).toEqual(['When should we notify the owner?']);
+    expect(snapshot.events[0]?.tool).toBe('review_ready');
+  });
+
+  it('renders a wide overview and task context', () => {
+    seedDashboard();
+    const snapshot = buildDashboardSnapshot('/work/concord-demo', repos);
+    const view = render(
+      <DashboardApp
+        initialSnapshot={snapshot}
+        loadSnapshot={() => snapshot}
+        refreshMs={60_000}
+        width={120}
+      />,
+    );
+    const frame = view.lastFrame();
+
+    expect(frame).toContain('Concord · concord-demo · LIVE');
+    expect(frame).toContain('Agents');
+    expect(frame).toContain('claude-code:demo');
+    expect(frame).toContain('TASK-12');
+    expect(frame).toContain('TASK-12 ↔ TASK-14');
+    expect(frame).toContain('Timeline');
+
+    view.stdin.write('j');
+    expect(view.lastFrame()).toContain('Use a queued retry');
+  });
+
+  it('uses a compact view below 70 columns', () => {
+    seedDashboard();
+    const snapshot = buildDashboardSnapshot('/work/concord-demo', repos);
+    const view = render(
+      <DashboardApp
+        initialSnapshot={snapshot}
+        loadSnapshot={() => snapshot}
+        refreshMs={60_000}
+        width={60}
+      />,
+    );
+    const frame = view.lastFrame();
+
+    expect(frame).toContain('Compact view');
+    expect(frame).toContain('Tasks');
+    expect(frame).toContain('Alerts');
+    expect(frame).not.toContain('Task context');
+  });
+
+  it('filters tasks and exposes keyboard help', () => {
+    seedDashboard();
+    const snapshot = buildDashboardSnapshot('/work/concord-demo', repos);
+    const view = render(
+      <DashboardApp
+        initialSnapshot={snapshot}
+        loadSnapshot={() => snapshot}
+        refreshMs={60_000}
+        width={120}
+      />,
+    );
+
+    view.stdin.write('/');
+    view.stdin.write('invoice');
+    expect(view.lastFrame()).toContain('TASK-14');
+    expect(view.lastFrame()).not.toContain('TASK-12 — Add Stripe retry handling');
+
+    view.stdin.write('\u001B');
+    view.stdin.write('?');
+    expect(view.lastFrame()).toContain('Keyboard help');
+    expect(view.lastFrame()).toContain('Tab/Shift-Tab');
+  });
+
+  it('refreshes immediately when r is pressed', () => {
+    seedDashboard();
+    const initial = buildDashboardSnapshot('/work/concord-demo', repos);
+    const view = render(
+      <DashboardApp
+        initialSnapshot={initial}
+        loadSnapshot={() => buildDashboardSnapshot('/work/concord-demo', repos)}
+        refreshMs={60_000}
+        width={120}
+      />,
+    );
+
+    handleClaimWork(repos, { task_id: 'TASK-99', title: 'New live work', agent: 'cursor' });
+    expect(view.lastFrame()).not.toContain('TASK-99');
+    view.stdin.write('r');
+    expect(view.lastFrame()).toContain('TASK-99');
+  });
+});


### PR DESCRIPTION
## What changed

- cover dashboard snapshots, wide/compact layouts, filtering, help, selection, and manual refresh
- extend the canonical demo with real registered agent identities
- allow the demo to target a shared repo and add pacing for a visible two-terminal flow
- document `concord dashboard`, its keyboard controls, and the YC-ready live demo

## Why

The visualizer needs deterministic regression coverage and a repeatable presentation that proves the UI is observing real MCP writes rather than mocked activity.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (20 files, 139 tests)
- `pnpm build`
- `pnpm demo`
- real PTY dashboard observed the paced MCP flow and restored the terminal on exit

This is dashboard slice 3 of 3 and stays below the 600 LOC PR limit.