### PR TITLE
feat: notify users when a Concord update is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Interactive CLI commands now show a cached, best-effort notice when a newer
+  stable Concord release is available on npm.
+
 ## [0.4.0] - 2026-07-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ concord --version
 
 Concord does not auto-update. Upgrading preserves each repository's local
 `.concord/` workspace; any required database migrations run automatically when
-the workspace is next opened.
+the workspace is next opened. The interactive `concord` CLI checks npm at most
+once per day and prints an update command when a newer stable release is
+available. Set `CONCORD_NO_UPDATE_CHECK=1` to disable this best-effort check.
 
 ## The six tools
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,6 +15,7 @@ import { registerStatus } from './commands/status.js';
 import { registerTasks } from './commands/tasks.js';
 import { registerWatchCommand } from './commands/watch.js';
 import { registerWhoCommand } from './commands/who.js';
+import { notifyIfUpdateAvailable } from './update-notifier.js';
 
 const program = new Command();
 program.name('concord').description('Shared work-state for coding agents').version(VERSION);
@@ -33,4 +34,5 @@ registerReviewPacketCommand(program);
 registerExportCommand(program);
 registerDoctorCommand(program);
 
+await notifyIfUpdateAvailable(VERSION);
 program.parse();

--- a/src/cli/update-notifier.ts
+++ b/src/cli/update-notifier.ts
@@ -1,0 +1,160 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { z } from 'zod';
+
+const REGISTRY_URL = 'https://registry.npmjs.org/@concord-ai%2fconcord-mcp/latest';
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 400;
+
+const registryResponseSchema = z.object({ version: z.string() });
+const updateCacheSchema = z.object({
+  checkedAt: z.number(),
+  latestVersion: z.string().nullable(),
+});
+
+interface VersionParts {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string | null;
+}
+
+interface UpdateCache {
+  checkedAt: number;
+  latestVersion: string | null;
+}
+
+export interface UpdateCheckOptions {
+  currentVersion: string;
+  cacheFile: string;
+  now?: number;
+  ttlMs?: number;
+  fetchLatest?: () => Promise<string | null>;
+}
+
+function parseVersion(version: string): VersionParts | undefined {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/.exec(version);
+  const major = match?.[1];
+  const minor = match?.[2];
+  const patch = match?.[3];
+  if (major === undefined || minor === undefined || patch === undefined) {
+    return undefined;
+  }
+  return {
+    major: Number(major),
+    minor: Number(minor),
+    patch: Number(patch),
+    prerelease: match?.[4] ?? null,
+  };
+}
+
+/** SemVer comparison for the stable x.y.z versions published under npm latest. */
+export function isNewerVersion(currentVersion: string, latestVersion: string): boolean {
+  const current = parseVersion(currentVersion);
+  const latest = parseVersion(latestVersion);
+  if (current === undefined || latest === undefined) {
+    return false;
+  }
+  for (const key of ['major', 'minor', 'patch'] as const) {
+    if (latest[key] !== current[key]) {
+      return latest[key] > current[key];
+    }
+  }
+  return current.prerelease !== null && latest.prerelease === null;
+}
+
+function readCache(cacheFile: string): UpdateCache | undefined {
+  try {
+    const raw: unknown = JSON.parse(readFileSync(cacheFile, 'utf8'));
+    return updateCacheSchema.parse(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+function writeCache(cacheFile: string, cache: UpdateCache): void {
+  try {
+    mkdirSync(dirname(cacheFile), { recursive: true });
+    writeFileSync(cacheFile, `${JSON.stringify(cache)}\n`, 'utf8');
+  } catch {
+    // A read-only home directory must never make a Concord command fail.
+  }
+}
+
+async function fetchLatestVersion(): Promise<string | null> {
+  try {
+    const response = await fetch(REGISTRY_URL, {
+      headers: { accept: 'application/vnd.npm.install-v1+json' },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      return null;
+    }
+    const raw: unknown = await response.json();
+    return registryResponseSchema.parse(raw).version;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Return the newer published version, if any. Registry results (including a
+ * failed best-effort check) are cached so normal commands do not perform
+ * network I/O more than once per day.
+ */
+export async function checkForUpdate(options: UpdateCheckOptions): Promise<string | undefined> {
+  const now = options.now ?? Date.now();
+  const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+  const cached = readCache(options.cacheFile);
+  if (cached !== undefined && now - cached.checkedAt >= 0 && now - cached.checkedAt < ttlMs) {
+    return cached.latestVersion !== null &&
+      isNewerVersion(options.currentVersion, cached.latestVersion)
+      ? cached.latestVersion
+      : undefined;
+  }
+
+  const latestVersion = await (options.fetchLatest ?? fetchLatestVersion)();
+  writeCache(options.cacheFile, { checkedAt: now, latestVersion });
+  return latestVersion !== null && isNewerVersion(options.currentVersion, latestVersion)
+    ? latestVersion
+    : undefined;
+}
+
+export function updateCacheFile(env: NodeJS.ProcessEnv = process.env): string {
+  const base =
+    env['XDG_CACHE_HOME'] ??
+    (process.platform === 'win32' ? env['LOCALAPPDATA'] : undefined) ??
+    join(homedir(), '.cache');
+  return join(base, 'concord', 'update-check.json');
+}
+
+export function formatUpdateNotice(currentVersion: string, latestVersion: string): string {
+  return [
+    `Update available: Concord ${currentVersion} → ${latestVersion}`,
+    'Run: npm install -g @concord-ai/concord-mcp@latest',
+  ].join('\n');
+}
+
+/** Best-effort interactive notice. Never throws or writes to normal stdout. */
+export async function notifyIfUpdateAvailable(
+  currentVersion: string,
+  stderr: NodeJS.WriteStream = process.stderr,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  if (!stderr.isTTY || env['CI'] !== undefined || env['CONCORD_NO_UPDATE_CHECK'] === '1') {
+    return;
+  }
+  try {
+    const latestVersion = await checkForUpdate({
+      currentVersion,
+      cacheFile: updateCacheFile(env),
+    });
+    if (latestVersion !== undefined) {
+      stderr.write(`${formatUpdateNotice(currentVersion, latestVersion)}\n\n`);
+    }
+  } catch {
+    // Version awareness is useful, but no update check may break the CLI.
+  }
+}

--- a/test/cli/update-notifier.test.ts
+++ b/test/cli/update-notifier.test.ts
@@ -1,0 +1,113 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  checkForUpdate,
+  formatUpdateNotice,
+  isNewerVersion,
+} from '../../src/cli/update-notifier.js';
+
+function cacheFile(): string {
+  return join(mkdtempSync(join(tmpdir(), 'concord-update-')), 'cache.json');
+}
+
+describe('isNewerVersion', () => {
+  it('compares stable semantic versions', () => {
+    expect(isNewerVersion('0.4.0', '0.4.1')).toBe(true);
+    expect(isNewerVersion('0.4.9', '0.5.0')).toBe(true);
+    expect(isNewerVersion('1.0.0', '2.0.0')).toBe(true);
+    expect(isNewerVersion('0.4.0', '0.4.0')).toBe(false);
+    expect(isNewerVersion('0.5.0', '0.4.9')).toBe(false);
+  });
+
+  it('treats a stable release as newer than its prerelease', () => {
+    expect(isNewerVersion('0.5.0-beta.1', '0.5.0')).toBe(true);
+    expect(isNewerVersion('0.5.0', '0.5.0-beta.1')).toBe(false);
+    expect(isNewerVersion('not-semver', '0.5.0')).toBe(false);
+  });
+});
+
+describe('checkForUpdate', () => {
+  it('returns a newer registry version and caches it', async () => {
+    const path = cacheFile();
+    let calls = 0;
+    const fetchLatest = (): Promise<string> => {
+      calls += 1;
+      return Promise.resolve('0.5.0');
+    };
+
+    await expect(
+      checkForUpdate({
+        currentVersion: '0.4.0',
+        cacheFile: path,
+        now: 1_000,
+        fetchLatest,
+      }),
+    ).resolves.toBe('0.5.0');
+    await expect(
+      checkForUpdate({
+        currentVersion: '0.4.0',
+        cacheFile: path,
+        now: 2_000,
+        fetchLatest,
+      }),
+    ).resolves.toBe('0.5.0');
+    expect(calls).toBe(1);
+  });
+
+  it('does not notify when the installed version is current', async () => {
+    await expect(
+      checkForUpdate({
+        currentVersion: '0.4.0',
+        cacheFile: cacheFile(),
+        fetchLatest: () => Promise.resolve('0.4.0'),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('caches a failed best-effort check to avoid repeated network delays', async () => {
+    const path = cacheFile();
+    let calls = 0;
+    const fetchLatest = (): Promise<null> => {
+      calls += 1;
+      return Promise.resolve(null);
+    };
+
+    await checkForUpdate({
+      currentVersion: '0.4.0',
+      cacheFile: path,
+      now: 1_000,
+      fetchLatest,
+    });
+    await checkForUpdate({
+      currentVersion: '0.4.0',
+      cacheFile: path,
+      now: 2_000,
+      fetchLatest,
+    });
+    expect(calls).toBe(1);
+  });
+
+  it('recovers from an invalid cache file', async () => {
+    const path = cacheFile();
+    writeFileSync(path, 'not-json');
+    await expect(
+      checkForUpdate({
+        currentVersion: '0.4.0',
+        cacheFile: path,
+        fetchLatest: () => Promise.resolve('0.4.1'),
+      }),
+    ).resolves.toBe('0.4.1');
+  });
+});
+
+describe('formatUpdateNotice', () => {
+  it('includes the versions and global npm update command', () => {
+    const notice = formatUpdateNotice('0.4.0', '0.4.1');
+    expect(notice).toContain('Concord 0.4.0 → 0.4.1');
+    expect(notice).toContain('npm install -g @concord-ai/concord-mcp@latest');
+  });
+});


### PR DESCRIPTION
## What changed

- check npm for a newer stable Concord release on interactive CLI startup
- cache successful and failed checks for 24 hours
- print the global npm upgrade command to stderr whenever the cached version is newer
- skip CI and non-TTY processes, with `CONCORD_NO_UPDATE_CHECK=1` as an explicit opt-out
- document the behavior and cover SemVer, caching, failures, and notice formatting

## Why

Globally installed CLI users otherwise have no indication that new Concord capabilities or fixes are available.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (21 files, 146 tests)
- `pnpm build`
- tracked files pass Prettier

The check is best-effort, bounded to 400ms once per day, and cannot fail a Concord command.