### PR TITLE
fix: keep the dashboard inside a full-screen viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Interactive CLI commands now show a cached, best-effort notice when a newer
   stable Concord release is available on npm.
 
+### Fixed
+
+- `concord dashboard` now uses a bounded full-screen viewport and alternate
+  screen buffer, preventing refresh frames from accumulating in terminal
+  scrollback.
+
 ## [0.4.0] - 2026-07-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -112,9 +112,11 @@ concord export markdown      # regenerate .concord/ artifacts
 concord doctor               # workspace checks + per-task tool adoption
 ```
 
-`concord dashboard` is a read-only local TUI. It refreshes from the shared
-SQLite workspace every 500ms. Use `Tab` to change panes, `j`/`k` or the arrow
-keys to select work, `/` to filter, `?` for help, and `q` to quit.
+`concord dashboard` is a read-only, full-screen local TUI. It refreshes from the
+shared SQLite workspace every second while keeping agents, tasks, alerts,
+context, and timeline inside a fixed terminal viewport. Use `Tab` to change
+panes, `j`/`k` or the arrow keys to select work, `/` to filter, `?` for help,
+and `q` to quit.
 
 ## Try the demo
 

--- a/src/cli/commands/dashboard.tsx
+++ b/src/cli/commands/dashboard.tsx
@@ -7,6 +7,8 @@ import { openContext } from '../context.js';
 
 export const DASHBOARD_TTY_ERROR =
   'concord dashboard needs an interactive terminal. Use `concord status` for plain-text output.';
+export const ENTER_ALTERNATE_SCREEN = '\u001B[?1049h\u001B[2J\u001B[H';
+export const EXIT_ALTERNATE_SCREEN = '\u001B[?1049l';
 
 export async function runDashboard(
   cwd: string,
@@ -21,6 +23,7 @@ export async function runDashboard(
   const loadSnapshot = (): ReturnType<typeof buildDashboardSnapshot> =>
     buildDashboardSnapshot(context.repoRoot, context.repos);
 
+  stdout.write(ENTER_ALTERNATE_SCREEN);
   try {
     const app = render(
       <DashboardApp initialSnapshot={loadSnapshot()} loadSnapshot={loadSnapshot} />,
@@ -28,12 +31,13 @@ export async function runDashboard(
         stdin,
         stdout,
         exitOnCtrlC: true,
-        incrementalRendering: true,
+        incrementalRendering: false,
       },
     );
     await app.waitUntilExit();
   } finally {
     context.repos.db.close();
+    stdout.write(EXIT_ALTERNATE_SCREEN);
   }
 }
 

--- a/src/cli/dashboard/app.tsx
+++ b/src/cli/dashboard/app.tsx
@@ -12,20 +12,24 @@ export interface DashboardAppProps {
   loadSnapshot: () => DashboardSnapshot;
   refreshMs?: number;
   width?: number;
+  height?: number;
 }
 
 interface PanelProps {
   title: string;
   focused: boolean;
   children: ReactNode;
+  height?: number | string;
 }
 
-function Panel({ title, focused, children }: PanelProps): ReactNode {
+function Panel({ title, focused, children, height }: PanelProps): ReactNode {
   return (
     <Box
       borderStyle="round"
       borderColor={focused ? 'cyan' : 'gray'}
       flexDirection="column"
+      height={height}
+      overflow="hidden"
       paddingX={1}
     >
       <Text bold color={focused ? 'cyan' : 'gray'}>
@@ -244,6 +248,7 @@ function DashboardBody({
   tasks,
   selectedIndex,
   filter,
+  height,
 }: {
   snapshot: DashboardSnapshot;
   layout: Layout;
@@ -251,74 +256,96 @@ function DashboardBody({
   tasks: DashboardTask[];
   selectedIndex: number;
   filter: string;
+  height: number;
 }): ReactNode {
   const selected = tasks[selectedIndex];
   if (layout === 'compact') {
     return (
-      <>
-        <Panel title="Tasks" focused={pane === 'tasks'}>
+      <Box flexDirection="column" height={height} overflow="hidden">
+        <Panel title="Tasks" focused={pane === 'tasks'} height="35%">
           <Tasks tasks={tasks} selectedIndex={selectedIndex} />
         </Panel>
-        <Panel title="Alerts" focused={pane === 'alerts'}>
+        <Panel title="Alerts" focused={pane === 'alerts'} height="25%">
           <Alerts snapshot={snapshot} />
         </Panel>
-        <Panel title="Timeline" focused={pane === 'timeline'}>
+        <Panel title="Timeline" focused={pane === 'timeline'} height="40%">
           <Timeline snapshot={snapshot} filter={filter} />
         </Panel>
-        <Text dimColor>
-          Compact view — widen terminal to 70+ columns for agent and task context.
-        </Text>
-      </>
+      </Box>
     );
   }
 
   const overview = (
-    <>
-      <Panel title="Agents" focused={pane === 'agents'}>
+    <Box flexDirection="column" height="100%" overflow="hidden">
+      <Panel title="Agents" focused={pane === 'agents'} height="65%">
         <Agents snapshot={snapshot} />
       </Panel>
-      <Panel title="Alerts" focused={pane === 'alerts'}>
+      <Panel title="Alerts" focused={pane === 'alerts'} height="35%">
         <Alerts snapshot={snapshot} />
       </Panel>
-    </>
+    </Box>
   );
   const work = (
-    <>
-      <Panel title="Tasks" focused={pane === 'tasks'}>
+    <Box flexDirection="column" height="100%" overflow="hidden">
+      <Panel title="Tasks" focused={pane === 'tasks'} height="40%">
         <Tasks tasks={tasks} selectedIndex={selectedIndex} />
       </Panel>
-      <Panel title="Task context" focused={pane === 'context'}>
+      <Panel title="Task context" focused={pane === 'context'} height="60%">
         <Context item={selected} />
       </Panel>
-    </>
+    </Box>
   );
 
+  if (layout === 'stacked') {
+    return (
+      <Box flexDirection="column" height={height} overflow="hidden">
+        <Panel title="Agents" focused={pane === 'agents'} height="18%">
+          <Agents snapshot={snapshot} />
+        </Panel>
+        <Panel title="Tasks" focused={pane === 'tasks'} height="20%">
+          <Tasks tasks={tasks} selectedIndex={selectedIndex} />
+        </Panel>
+        <Panel title="Alerts" focused={pane === 'alerts'} height="18%">
+          <Alerts snapshot={snapshot} />
+        </Panel>
+        <Panel title="Task context" focused={pane === 'context'} height="24%">
+          <Context item={selected} />
+        </Panel>
+        <Panel title="Timeline" focused={pane === 'timeline'} height="20%">
+          <Timeline snapshot={snapshot} filter={filter} />
+        </Panel>
+      </Box>
+    );
+  }
+
   return (
-    <>
-      <Box flexDirection={layout === 'wide' ? 'row' : 'column'}>
-        <Box flexDirection="column" width={layout === 'wide' ? '35%' : '100%'}>
+    <Box flexDirection="column" height={height} overflow="hidden">
+      <Box flexDirection="row" height="68%" overflow="hidden">
+        <Box flexDirection="column" width="35%" overflow="hidden">
           {overview}
         </Box>
-        <Box flexDirection="column" width={layout === 'wide' ? '65%' : '100%'}>
+        <Box flexDirection="column" width="65%" overflow="hidden">
           {work}
         </Box>
       </Box>
-      <Panel title="Timeline" focused={pane === 'timeline'}>
+      <Panel title="Timeline" focused={pane === 'timeline'} height="32%">
         <Timeline snapshot={snapshot} filter={filter} />
       </Panel>
-    </>
+    </Box>
   );
 }
 
 export function DashboardApp({
   initialSnapshot,
   loadSnapshot,
-  refreshMs = 500,
+  refreshMs = 1_000,
   width,
+  height,
 }: DashboardAppProps): ReactNode {
   const { exit } = useApp();
   const { stdout } = useStdout();
   const [terminalWidth, setTerminalWidth] = useState(width ?? stdout.columns);
+  const [terminalHeight, setTerminalHeight] = useState(height ?? Math.max(8, stdout.rows));
   const [snapshot, setSnapshot] = useState(initialSnapshot);
   const [paneIndex, setPaneIndex] = useState(0);
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -328,6 +355,7 @@ export function DashboardApp({
   const [error, setError] = useState<string | undefined>();
 
   const layout = layoutFor(width ?? terminalWidth);
+  const viewportHeight = height ?? terminalHeight;
   const panes = panesFor(layout);
   const pane = panes[paneIndex % panes.length] ?? 'tasks';
   const tasks = useMemo(
@@ -352,17 +380,22 @@ export function DashboardApp({
   }, [refresh, refreshMs]);
 
   useEffect(() => {
-    if (width !== undefined) {
+    if (width !== undefined && height !== undefined) {
       return;
     }
     const resize = (): void => {
-      setTerminalWidth(stdout.columns);
+      if (width === undefined) {
+        setTerminalWidth(stdout.columns);
+      }
+      if (height === undefined) {
+        setTerminalHeight(Math.max(8, stdout.rows));
+      }
     };
     stdout.on('resize', resize);
     return () => {
       stdout.off('resize', resize);
     };
-  }, [stdout, width]);
+  }, [height, stdout, width]);
 
   useEffect(() => {
     setSelectedIndex((current) => Math.min(current, Math.max(0, tasks.length - 1)));
@@ -408,15 +441,17 @@ export function DashboardApp({
   });
 
   return (
-    <Box flexDirection="column">
-      <Box justifyContent="space-between">
+    <Box flexDirection="column" height={viewportHeight} overflow="hidden">
+      <Box justifyContent="space-between" height={1}>
         <Text bold color="cyan">
           Concord · {snapshot.repoName} · LIVE
         </Text>
         <Text dimColor>updated {shortTime(snapshot.generatedAt)}</Text>
       </Box>
       {showHelp ? (
-        <Help />
+        <Box height={Math.max(1, viewportHeight - 2)} overflow="hidden">
+          <Help />
+        </Box>
       ) : (
         <DashboardBody
           snapshot={snapshot}
@@ -425,16 +460,24 @@ export function DashboardApp({
           tasks={tasks}
           selectedIndex={selectedIndex}
           filter={filter}
+          height={Math.max(1, viewportHeight - 2)}
         />
       )}
-      {error === undefined ? null : <Text color="red">Refresh failed: {error}</Text>}
-      <Text color={searching ? 'cyan' : 'gray'}>
-        {searching
-          ? `Filter: ${filter}▌`
-          : filter === ''
-            ? 'q quit · Tab pane · / filter · ? help'
-            : `Filter: ${filter} · Esc clear`}
-      </Text>
+      <Box height={1} overflow="hidden">
+        {error === undefined ? (
+          <Text color={searching ? 'cyan' : 'gray'}>
+            {searching
+              ? `Filter: ${filter}▌`
+              : filter === ''
+                ? layout === 'compact'
+                  ? 'q quit · / filter · ? help · widen for agent context'
+                  : 'q quit · Tab pane · / filter · ? help'
+                : `Filter: ${filter} · Esc clear`}
+          </Text>
+        ) : (
+          <Text color="red">Refresh failed: {error}</Text>
+        )}
+      </Box>
     </Box>
   );
 }

--- a/test/cli/dashboard.test.tsx
+++ b/test/cli/dashboard.test.tsx
@@ -85,6 +85,7 @@ describe('dashboard snapshot', () => {
         loadSnapshot={() => snapshot}
         refreshMs={60_000}
         width={120}
+        height={30}
       />,
     );
     const frame = view.lastFrame();
@@ -109,11 +110,12 @@ describe('dashboard snapshot', () => {
         loadSnapshot={() => snapshot}
         refreshMs={60_000}
         width={60}
+        height={24}
       />,
     );
     const frame = view.lastFrame();
 
-    expect(frame).toContain('Compact view');
+    expect(frame).toContain('widen for agent context');
     expect(frame).toContain('Tasks');
     expect(frame).toContain('Alerts');
     expect(frame).not.toContain('Task context');
@@ -128,6 +130,7 @@ describe('dashboard snapshot', () => {
         loadSnapshot={() => snapshot}
         refreshMs={60_000}
         width={120}
+        height={30}
       />,
     );
 
@@ -151,6 +154,7 @@ describe('dashboard snapshot', () => {
         loadSnapshot={() => buildDashboardSnapshot('/work/concord-demo', repos)}
         refreshMs={60_000}
         width={120}
+        height={30}
       />,
     );
 
@@ -158,5 +162,36 @@ describe('dashboard snapshot', () => {
     expect(view.lastFrame()).not.toContain('TASK-99');
     view.stdin.write('r');
     expect(view.lastFrame()).toContain('TASK-99');
+  });
+
+  it('keeps a fixed viewport as the roster grows', () => {
+    seedDashboard();
+    const initial = buildDashboardSnapshot('/work/concord-demo', repos);
+    const view = render(
+      <DashboardApp
+        initialSnapshot={initial}
+        loadSnapshot={() => buildDashboardSnapshot('/work/concord-demo', repos)}
+        refreshMs={60_000}
+        width={120}
+        height={24}
+      />,
+    );
+    const initialFrame = view.lastFrame();
+    if (initialFrame === undefined) {
+      throw new Error('Dashboard did not render an initial frame');
+    }
+    const initialHeight = initialFrame.split('\n').length;
+
+    for (let index = 0; index < 20; index += 1) {
+      handleRegisterAgent(repos, {
+        agent_id: `codex:${String(index)}`,
+        kind: 'codex',
+        summary: 'Present in the repository',
+      });
+    }
+    view.stdin.write('r');
+
+    expect(view.lastFrame()?.split('\n')).toHaveLength(initialHeight);
+    expect(initialHeight).toBe(24);
   });
 });


### PR DESCRIPTION
## What changed

- enter an alternate terminal screen for `concord dashboard` and restore it on exit
- disable incremental rendering, which left stale rows in some modern terminal hosts
- bind the root layout to terminal rows and update it on resize
- give every pane a bounded percentage height with clipped overflow
- retain fixed header/footer rows and refresh once per second
- add a regression test proving twenty new agents do not increase frame height

## Why

The original dashboard rendered an unbounded Ink tree into normal scrollback. Frequent age refreshes could therefore accumulate old frames, as shown in the reported screenshot. This adopts the same full-screen/fixed-header/flexible-content pattern used by `../avios-cli`.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (21 files, 146 tests)
- `pnpm build`
- real PTY smoke test: alternate screen, repeated refresh, bounded frame, `q` restoration

Diff: +133 / -43, below the 600 LOC limit.