### PR TITLE
feat: add anonymous telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-28
+
+### Added
+
+- Transparent, default-on anonymous telemetry for MCP tool and CLI command
+  adoption, outcomes, and duration, with stable pseudonymous installation and
+  workspace identities.
+- `CONCORD_TELEMETRY_DISABLED=1` and `DO_NOT_TRACK=1` opt-outs.
+
+### Security
+
+- Telemetry excludes code, paths, repository remotes, usernames, task and agent
+  identifiers, command arguments, tool inputs/outputs, and task content.
+
 ## [0.4.1] - 2026-07-26
 
 ### Added
@@ -78,7 +92,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `concord install` writes usage instructions for Claude Code, Codex, and Cursor.
 - Two-agent overlap demo (`pnpm demo`).
 
-[Unreleased]: https://github.com/Get-Concord-AI/concord-mcp/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/Get-Concord-AI/concord-mcp/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/Get-Concord-AI/concord-mcp/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/Get-Concord-AI/concord-mcp/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/Get-Concord-AI/concord-mcp/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/Get-Concord-AI/concord-mcp/compare/v0.2.0...v0.3.0

--- a/README.md
+++ b/README.md
@@ -58,6 +58,19 @@ the workspace is next opened. The interactive `concord` CLI checks npm at most
 once per day and prints an update command when a newer stable release is
 available. Set `CONCORD_NO_UPDATE_CHECK=1` to disable this best-effort check.
 
+## Anonymous telemetry
+
+Concord sends anonymous product-usage metadata to `getconcord.ai` so we can
+measure active installations, feature adoption, errors, and performance. Events
+contain random installation/session identifiers, an irreversible per-install
+workspace pseudonym, Concord/Node/platform versions, normalized MCP client
+metadata, and MCP tool or CLI command names, outcomes, and durations.
+
+Concord never sends code, raw file or repository paths, remotes, usernames,
+task or agent identifiers, command arguments, tool inputs/outputs, or task
+content. Set `CONCORD_TELEMETRY_DISABLED=1` (or `DO_NOT_TRACK=1`) to disable
+telemetry. Delivery is best effort and can never make a Concord operation fail.
+
 ## The six tools
 
 | Tool               | When                     | What it does                                                                     |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,6 +18,9 @@ reports within a few business days and will keep you updated on remediation.
 
 ## Scope
 
-Concord is local-first: the open-source server stores data in a local SQLite
-database and does not transmit code, file paths, or task content anywhere. Please
-report anything that contradicts that behavior.
+Concord is local-first: the open-source server stores work data in a local SQLite
+database and never transmits code, raw file paths, repository remotes, tool
+inputs/outputs, task identifiers, or task content. It sends the anonymous,
+metadata-only usage events documented in the README to `getconcord.ai` by
+default; set `CONCORD_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1` to disable them.
+Please report anything that contradicts that behavior.

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ import { writeArtifacts } from './artifacts/index.js';
 import { concordDir, databasePath, resolveRepoRoot } from './config/paths.js';
 import { openRepositories } from './db/index.js';
 import { createServer } from './server.js';
+import { createTelemetryClient } from './telemetry/client.js';
+import { TelemetryTransport } from './telemetry/transport.js';
 
 async function main(): Promise<void> {
   const repoRoot = resolveRepoRoot(process.cwd(), process.env);
@@ -15,7 +17,15 @@ async function main(): Promise<void> {
       writeArtifacts(artifactsDir, repos);
     },
   });
-  const transport = new StdioServerTransport();
+  const telemetry = createTelemetryClient({
+    surface: 'mcp',
+    workspaceRoot: () => repoRoot,
+  });
+  const stdio = new StdioServerTransport();
+  const transport = telemetry === undefined ? stdio : new TelemetryTransport(stdio, telemetry);
+  process.once('beforeExit', () => {
+    void telemetry?.close();
+  });
   await server.connect(transport);
 }
 

--- a/src/telemetry/client.ts
+++ b/src/telemetry/client.ts
@@ -1,0 +1,216 @@
+import { randomUUID } from 'node:crypto';
+import { arch, platform, release } from 'node:os';
+
+import { VERSION } from '../version.js';
+import {
+  loadTelemetryIdentity,
+  markTelemetryNoticeShown,
+  telemetryConfigFile,
+  workspacePseudonym,
+} from './identity.js';
+
+export const DEFAULT_TELEMETRY_URL = 'https://getconcord.ai/api/telemetry/v1';
+const FLUSH_DELAY_MS = 5_000;
+const FETCH_TIMEOUT_MS = 1_500;
+const MAX_BATCH_SIZE = 50;
+const MAX_QUEUE_SIZE = 200;
+
+export type TelemetrySurface = 'mcp' | 'cli';
+export type TelemetryOutcome = 'success' | 'error';
+
+interface QueuedEvent {
+  event_id: string;
+  sequence: number;
+  occurred_at: string;
+  event_type: 'session_started' | 'operation_completed';
+  operation: string | null;
+  outcome: TelemetryOutcome | null;
+  duration_ms: number | null;
+  workspace_id: string | null;
+}
+
+interface TelemetryClientOptions {
+  surface: TelemetrySurface;
+  workspaceRoot: () => string | undefined;
+  env?: NodeJS.ProcessEnv;
+  fetcher?: typeof fetch;
+  stderr?: { write(message: string): unknown };
+}
+
+interface ClientInfo {
+  name: string;
+  version: string | null;
+}
+
+export class TelemetryClient {
+  readonly #installationId: string;
+  readonly #sessionId = randomUUID();
+  readonly #workspaceKey: string;
+  readonly #surface: TelemetrySurface;
+  readonly #workspaceRoot: () => string | undefined;
+  readonly #endpoint: string;
+  readonly #fetcher: typeof fetch;
+  readonly #ci: boolean;
+  readonly #events: QueuedEvent[] = [];
+  #clientInfo: ClientInfo | undefined;
+  #sequence = 0;
+  #timer: NodeJS.Timeout | undefined;
+  #flushing = false;
+
+  constructor(installationId: string, workspaceKey: string, options: TelemetryClientOptions) {
+    this.#installationId = installationId;
+    this.#workspaceKey = workspaceKey;
+    this.#surface = options.surface;
+    this.#workspaceRoot = options.workspaceRoot;
+    this.#endpoint = options.env?.['CONCORD_TELEMETRY_URL'] ?? DEFAULT_TELEMETRY_URL;
+    this.#fetcher = options.fetcher ?? fetch;
+    this.#ci = (options.env ?? process.env)['CI'] !== undefined;
+    this.#record('session_started', null, null, null);
+  }
+
+  setClientInfo(name: string, version: string): void {
+    const normalizedName = /codex/iu.test(name)
+      ? 'codex'
+      : /claude/iu.test(name)
+        ? 'claude'
+        : /cursor/iu.test(name)
+          ? 'cursor'
+          : /gemini|google/iu.test(name)
+            ? 'gemini'
+            : /visual studio|vscode/iu.test(name)
+              ? 'vscode'
+              : 'other';
+    this.#clientInfo = {
+      name: normalizedName,
+      version: /^[0-9A-Za-z.+_-]{1,40}$/u.test(version) ? version : null,
+    };
+  }
+
+  recordOperation(operation: string, outcome: TelemetryOutcome, durationMs: number): void {
+    this.#record('operation_completed', operation.slice(0, 80), outcome, durationMs);
+  }
+
+  async flush(): Promise<void> {
+    if (this.#flushing || this.#events.length === 0) {
+      return;
+    }
+    this.#flushing = true;
+    if (this.#timer !== undefined) {
+      clearTimeout(this.#timer);
+      this.#timer = undefined;
+    }
+    const events = this.#events.splice(0, MAX_BATCH_SIZE);
+    try {
+      await this.#fetcher(this.#endpoint, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          schema_version: 1,
+          installation_id: this.#installationId,
+          session_id: this.#sessionId,
+          sent_at: new Date().toISOString(),
+          source: {
+            surface: this.#surface,
+            concord_version: VERSION,
+            node_version: process.versions.node,
+            platform: platform(),
+            platform_release: release(),
+            arch: arch(),
+            ci: this.#ci,
+            client_name: this.#clientInfo?.name ?? null,
+            client_version: this.#clientInfo?.version ?? null,
+          },
+          events,
+        }),
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+    } catch {
+      // Usage data is best effort and must never affect the product.
+    } finally {
+      this.#flushing = false;
+      if (this.#events.length > 0) {
+        this.#scheduleFlush();
+      }
+    }
+  }
+
+  close(): Promise<void> {
+    return this.flush();
+  }
+
+  #record(
+    eventType: QueuedEvent['event_type'],
+    operation: string | null,
+    outcome: TelemetryOutcome | null,
+    durationMs: number | null,
+  ): void {
+    if (this.#events.length >= MAX_QUEUE_SIZE) {
+      this.#events.shift();
+    }
+    const root = this.#workspaceRoot();
+    this.#events.push({
+      event_id: randomUUID(),
+      sequence: this.#sequence,
+      occurred_at: new Date().toISOString(),
+      event_type: eventType,
+      operation,
+      outcome,
+      duration_ms:
+        durationMs === null ? null : Math.min(86_400_000, Math.max(0, Math.round(durationMs))),
+      workspace_id:
+        root === undefined
+          ? null
+          : workspacePseudonym(
+              {
+                installationId: this.#installationId,
+                workspaceKey: this.#workspaceKey,
+                noticeShown: true,
+              },
+              root,
+            ),
+    });
+    this.#sequence += 1;
+    if (this.#events.length >= MAX_BATCH_SIZE) {
+      void this.flush();
+    } else {
+      this.#scheduleFlush();
+    }
+  }
+
+  #scheduleFlush(): void {
+    if (this.#timer !== undefined) {
+      return;
+    }
+    this.#timer = setTimeout(() => {
+      this.#timer = undefined;
+      void this.flush();
+    }, FLUSH_DELAY_MS);
+    this.#timer.unref();
+  }
+}
+
+export function createTelemetryClient(
+  options: TelemetryClientOptions,
+): TelemetryClient | undefined {
+  const env = options.env ?? process.env;
+  if (
+    env['CONCORD_TELEMETRY_DISABLED'] === '1' ||
+    env['DO_NOT_TRACK'] === '1' ||
+    (env['NODE_ENV'] === 'test' && options.fetcher === undefined)
+  ) {
+    return undefined;
+  }
+  const configFile = telemetryConfigFile(env);
+  const identity = loadTelemetryIdentity(configFile);
+  if (identity === undefined) {
+    return undefined;
+  }
+  if (!identity.noticeShown) {
+    (options.stderr ?? process.stderr).write(
+      'Concord sends anonymous usage telemetry (no code, paths, or task content). ' +
+        'Disable with CONCORD_TELEMETRY_DISABLED=1.\n',
+    );
+    markTelemetryNoticeShown(configFile, identity);
+  }
+  return new TelemetryClient(identity.installationId, identity.workspaceKey, options);
+}

--- a/src/telemetry/identity.ts
+++ b/src/telemetry/identity.ts
@@ -1,0 +1,74 @@
+import { createHmac, randomBytes, randomUUID } from 'node:crypto';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { z } from 'zod';
+
+const identitySchema = z.object({
+  installation_id: z.string().uuid(),
+  workspace_key: z.string().regex(/^[0-9a-f]{64}$/u),
+  notice_shown: z.boolean(),
+});
+
+export interface TelemetryIdentity {
+  installationId: string;
+  workspaceKey: string;
+  noticeShown: boolean;
+}
+
+export function telemetryConfigFile(env: NodeJS.ProcessEnv = process.env): string {
+  const base =
+    env['XDG_CONFIG_HOME'] ??
+    (process.platform === 'win32' ? env['APPDATA'] : undefined) ??
+    join(homedir(), '.config');
+  return join(base, 'concord', 'telemetry.json');
+}
+
+function persistIdentity(path: string, identity: TelemetryIdentity): boolean {
+  try {
+    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+    writeFileSync(
+      path,
+      `${JSON.stringify({
+        installation_id: identity.installationId,
+        workspace_key: identity.workspaceKey,
+        notice_shown: identity.noticeShown,
+      })}\n`,
+      { encoding: 'utf8', mode: 0o600 },
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Load or create the anonymous identity. Failure disables telemetry. */
+export function loadTelemetryIdentity(path: string): TelemetryIdentity | undefined {
+  try {
+    const parsed = identitySchema.parse(JSON.parse(readFileSync(path, 'utf8')));
+    return {
+      installationId: parsed.installation_id,
+      workspaceKey: parsed.workspace_key,
+      noticeShown: parsed.notice_shown,
+    };
+  } catch {
+    const identity: TelemetryIdentity = {
+      installationId: randomUUID(),
+      workspaceKey: randomBytes(32).toString('hex'),
+      noticeShown: false,
+    };
+    return persistIdentity(path, identity) ? identity : undefined;
+  }
+}
+
+export function markTelemetryNoticeShown(path: string, identity: TelemetryIdentity): void {
+  if (!identity.noticeShown && persistIdentity(path, { ...identity, noticeShown: true })) {
+    identity.noticeShown = true;
+  }
+}
+
+/** Stable only for this installation; the canonical path and key never leave the machine. */
+export function workspacePseudonym(identity: TelemetryIdentity, repoRoot: string): string {
+  return createHmac('sha256', identity.workspaceKey).update(repoRoot).digest('hex');
+}

--- a/src/telemetry/transport.ts
+++ b/src/telemetry/transport.ts
@@ -1,0 +1,110 @@
+import type {
+  Transport,
+  TransportSendOptions,
+} from '@modelcontextprotocol/sdk/shared/transport.js';
+import { InitializeRequestSchema, type JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
+import { performance } from 'node:perf_hooks';
+import { z } from 'zod';
+
+import type { TelemetryClient } from './client.js';
+
+const responseSchema = z
+  .object({
+    id: z.union([z.string(), z.number()]),
+    result: z.object({ isError: z.boolean().optional() }).passthrough().optional(),
+    error: z.object({ code: z.number() }).passthrough().optional(),
+  })
+  .passthrough();
+const callRequestSchema = z
+  .object({
+    id: z.union([z.string(), z.number()]),
+    method: z.literal('tools/call'),
+    params: z.object({ name: z.string() }).passthrough(),
+  })
+  .passthrough();
+
+interface PendingCall {
+  operation: string;
+  startedAt: number;
+}
+
+/** Observes MCP envelopes without retaining tool arguments or response bodies. */
+export class TelemetryTransport implements Transport {
+  readonly #inner: Transport;
+  readonly #telemetry: TelemetryClient;
+  readonly #pending = new Map<string, PendingCall>();
+
+  onclose: NonNullable<Transport['onclose']> = () => undefined;
+  onerror: NonNullable<Transport['onerror']> = () => undefined;
+  onmessage: NonNullable<Transport['onmessage']> = () => undefined;
+
+  constructor(inner: Transport, telemetry: TelemetryClient) {
+    this.#inner = inner;
+    this.#telemetry = telemetry;
+  }
+
+  setProtocolVersion(version: string): void {
+    this.#inner.setProtocolVersion?.(version);
+  }
+
+  async start(): Promise<void> {
+    this.#inner.onclose = () => {
+      void this.#telemetry.close();
+      this.onclose();
+    };
+    this.#inner.onerror = (error) => {
+      this.onerror(error);
+    };
+    this.#inner.onmessage = (message, extra) => {
+      this.#observeIncoming(message);
+      this.onmessage(message, extra);
+    };
+    await this.#inner.start();
+  }
+
+  async send(message: JSONRPCMessage, options?: TransportSendOptions): Promise<void> {
+    this.#observeOutgoing(message);
+    await this.#inner.send(message, options);
+  }
+
+  async close(): Promise<void> {
+    await this.#telemetry.close();
+    await this.#inner.close();
+  }
+
+  #observeIncoming(message: JSONRPCMessage): void {
+    const initialization = InitializeRequestSchema.safeParse(message);
+    if (initialization.success) {
+      this.#telemetry.setClientInfo(
+        initialization.data.params.clientInfo.name,
+        initialization.data.params.clientInfo.version,
+      );
+      return;
+    }
+    const call = callRequestSchema.safeParse(message);
+    if (call.success) {
+      this.#pending.set(String(call.data.id), {
+        operation: call.data.params.name,
+        startedAt: performance.now(),
+      });
+    }
+  }
+
+  #observeOutgoing(message: JSONRPCMessage): void {
+    const response = responseSchema.safeParse(message);
+    if (!response.success) {
+      return;
+    }
+    const pending = this.#pending.get(String(response.data.id));
+    if (pending === undefined) {
+      return;
+    }
+    this.#pending.delete(String(response.data.id));
+    const failed = response.data.error !== undefined || response.data.result?.isError === true;
+    this.#telemetry.recordOperation(
+      pending.operation,
+      failed ? 'error' : 'success',
+      performance.now() - pending.startedAt,
+    );
+  }
+}

--- a/test/telemetry/telemetry.test.ts
+++ b/test/telemetry/telemetry.test.ts
@@ -1,0 +1,144 @@
+import { randomUUID } from 'node:crypto';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { z } from 'zod';
+import { describe, expect, it } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+import { openDatabase } from '../../src/db/connection.js';
+import { createRepositories } from '../../src/db/index.js';
+import { createServer } from '../../src/server.js';
+import { createTelemetryClient, TelemetryClient } from '../../src/telemetry/client.js';
+import { loadTelemetryIdentity, workspacePseudonym } from '../../src/telemetry/identity.js';
+import { TelemetryTransport } from '../../src/telemetry/transport.js';
+
+const payloadSchema = z.object({
+  installation_id: z.string(),
+  session_id: z.string(),
+  source: z.object({
+    client_name: z.string().nullable(),
+    client_version: z.string().nullable(),
+  }),
+  events: z.array(
+    z.object({
+      event_type: z.string(),
+      operation: z.string().nullable(),
+      workspace_id: z.string().nullable(),
+    }),
+  ),
+});
+
+function configRoot(): string {
+  return mkdtempSync(join(tmpdir(), 'concord-telemetry-'));
+}
+
+describe('telemetry identity', () => {
+  it('persists a random installation identity and derives opaque workspace ids', () => {
+    const path = join(configRoot(), 'telemetry.json');
+    const first = loadTelemetryIdentity(path);
+    const second = loadTelemetryIdentity(path);
+    expect(first).toBeDefined();
+    expect(second).toEqual(first);
+    if (first === undefined) {
+      throw new Error('identity was not created');
+    }
+    const root = '/Users/private-user/Secret Client/repository';
+    const pseudonym = workspacePseudonym(first, root);
+    expect(pseudonym).toMatch(/^[0-9a-f]{64}$/u);
+    expect(pseudonym).not.toContain('private-user');
+    expect(readFileSync(path, 'utf8')).not.toContain(root);
+  });
+});
+
+describe('telemetry client', () => {
+  it('honours Concord and standard do-not-track opt-outs', () => {
+    for (const env of [
+      { CONCORD_TELEMETRY_DISABLED: '1' },
+      { DO_NOT_TRACK: '1' },
+      { NODE_ENV: 'test' },
+    ]) {
+      expect(
+        createTelemetryClient({
+          surface: 'cli',
+          workspaceRoot: () => '/repo',
+          env,
+        }),
+      ).toBeUndefined();
+    }
+  });
+
+  it('sends only the narrow metadata contract and normalizes client identity', async () => {
+    const bodies: string[] = [];
+    const fetcher: typeof fetch = (_input, init) => {
+      if (typeof init?.body === 'string') {
+        bodies.push(init.body);
+      }
+      return Promise.resolve(new Response(null, { status: 202 }));
+    };
+    const sensitiveRoot = '/Users/alex/Very Secret Customer/repo';
+    const telemetry = new TelemetryClient(randomUUID(), 'a'.repeat(64), {
+      surface: 'mcp',
+      workspaceRoot: () => sensitiveRoot,
+      env: {},
+      fetcher,
+    });
+    telemetry.setClientInfo('Internal Secret Client', 'secret version value');
+    telemetry.recordOperation('claim_work', 'success', 12.4);
+    await telemetry.close();
+
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]).not.toContain(sensitiveRoot);
+    expect(bodies[0]).not.toContain('Internal Secret Client');
+    expect(bodies[0]).not.toContain('secret version value');
+    const payload = payloadSchema.parse(JSON.parse(bodies[0] ?? ''));
+    expect(payload.source).toEqual({ client_name: 'other', client_version: null });
+    expect(payload.events.map((event) => event.event_type)).toEqual([
+      'session_started',
+      'operation_completed',
+    ]);
+    expect(payload.events[1]?.operation).toBe('claim_work');
+    expect(payload.events[0]?.workspace_id).toMatch(/^[0-9a-f]{64}$/u);
+  });
+
+  it('observes MCP outcomes without changing transport behaviour', async () => {
+    const bodies: string[] = [];
+    const fetcher: typeof fetch = (_input, init) => {
+      if (typeof init?.body === 'string') {
+        bodies.push(init.body);
+      }
+      return Promise.resolve(new Response(null, { status: 202 }));
+    };
+    const telemetry = new TelemetryClient(randomUUID(), 'b'.repeat(64), {
+      surface: 'mcp',
+      workspaceRoot: () => '/repo',
+      env: {},
+      fetcher,
+    });
+    const server = createServer(createRepositories(openDatabase(':memory:')));
+    const [clientTransport, rawServerTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: 'codex', version: '1.2.3' });
+    await Promise.all([
+      client.connect(clientTransport),
+      server.connect(new TelemetryTransport(rawServerTransport, telemetry)),
+    ]);
+    try {
+      await client.callTool({ name: 'get_work_state' });
+      await client.callTool({ name: 'missing_tool' });
+    } finally {
+      await telemetry.close();
+      await client.close();
+      await server.close();
+    }
+
+    const payload = payloadSchema.parse(JSON.parse(bodies[0] ?? ''));
+    expect(payload.source).toEqual({ client_name: 'codex', client_version: '1.2.3' });
+    expect(payload.events.map((event) => event.operation)).toEqual([
+      null,
+      'get_work_state',
+      'missing_tool',
+    ]);
+  });
+});


### PR DESCRIPTION
## What changed

- add a transparent, default-on anonymous telemetry client
- derive stable installation and irreversible per-install workspace pseudonyms
- observe MCP tool names, outcomes, and durations without retaining arguments or outputs
- batch delivery to https://getconcord.ai/api/telemetry/v1 with short, non-blocking timeouts
- document exactly what is and is not collected plus opt-outs
- prepare the 0.5.0 changelog

## Privacy

No code, raw paths, repository remotes, usernames, task/agent identifiers, arguments, tool inputs/outputs, or task content are transmitted. CONCORD_TELEMETRY_DISABLED=1 and DO_NOT_TRACK=1 disable collection.

## Validation

- pnpm lint
- pnpm format:check
- pnpm typecheck
- pnpm test (150 tests)
- pnpm build

PR size: 595 changed lines.