### PR TITLE
chore: ignore local agent state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,10 +8,11 @@ dist/
 # Test coverage
 coverage/
 
-# Concord local source-of-truth DB (machine-specific, never committed)
-.concord/concord.db
-.concord/concord.db-shm
-.concord/concord.db-wal
+# Local agent and Concord state (machine-specific, never committed)
+.codex/
+.concord/
+.cursor/
+AGENTS.md
 
 # Logs
 *.log


### PR DESCRIPTION
## What changed

- ignores `.codex/`, `.concord/`, `.cursor/`, and `AGENTS.md`
- replaces the narrower Concord database-only ignore entries with a whole-directory rule

## Why

These paths contain machine-local agent instructions, runtime state, generated review artifacts, and event history. Keeping them out of Git prevents accidental publication and keeps the repository worktree focused on source changes.

## Validation

- `git diff --check`
- `git check-ignore -v .codex/concord.md .concord/events.jsonl .cursor/rules/concord.mdc AGENTS.md`
