### PR TITLE
feat: add canonical workspace manager

### DIFF
--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -1,5 +1,5 @@
-import { existsSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs';
+import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
 
 /** Directory name that holds all Concord state within a repo. */
 export const CONCORD_DIR = '.concord';
@@ -7,20 +7,61 @@ export const CONCORD_DIR = '.concord';
 /** Filename of the SQLite source-of-truth database. */
 export const DB_FILENAME = 'concord.db';
 
+/** Prefix for path-backed workspace ids returned by the MCP surface. */
+export const WORKSPACE_ID_PREFIX = 'ws_';
+
+function canonicalPath(input: string): string {
+  const absolute = resolve(input);
+  return existsSync(absolute) ? realpathSync(absolute) : absolute;
+}
+
+function linkedWorktreePrimaryRoot(checkoutRoot: string): string | undefined {
+  const gitEntry = join(checkoutRoot, '.git');
+  if (!statSync(gitEntry).isFile()) {
+    return undefined;
+  }
+
+  const pointer = /^gitdir:\s*(.+)$/iu.exec(readFileSync(gitEntry, 'utf8').trim());
+  const gitDirValue = pointer?.[1]?.trim();
+  if (gitDirValue === undefined || gitDirValue === '') {
+    return undefined;
+  }
+
+  const gitDir = resolve(checkoutRoot, gitDirValue);
+  const commonDirFile = join(gitDir, 'commondir');
+  if (!existsSync(commonDirFile)) {
+    return undefined;
+  }
+
+  const commonDirValue = readFileSync(commonDirFile, 'utf8').trim();
+  if (commonDirValue === '') {
+    return undefined;
+  }
+
+  const commonDir = resolve(gitDir, commonDirValue);
+  if (basename(commonDir) === '.git') {
+    return canonicalPath(dirname(commonDir));
+  }
+  return undefined;
+}
+
 /**
- * Walk upward from `startDir` looking for a `.git` directory and return the
- * repository root. Falls back to `startDir` when no `.git` is found so Concord
- * still works outside a git repo.
+ * Walk upward from `startDir` looking for a `.git` entry and return the
+ * canonical repository root. Linked worktrees follow their `gitdir` and
+ * `commondir` metadata to the primary checkout so every worktree shares one
+ * `.concord/` store. Falls back to `startDir` when no `.git` is found so
+ * Concord still works outside a git repo.
  */
 export function findRepoRoot(startDir: string): string {
-  let dir = resolve(startDir);
+  const start = canonicalPath(startDir);
+  let dir = start;
   for (;;) {
     if (existsSync(join(dir, '.git'))) {
-      return dir;
+      return linkedWorktreePrimaryRoot(dir) ?? dir;
     }
     const parent = dirname(dir);
     if (parent === dir) {
-      return resolve(startDir);
+      return start;
     }
     dir = parent;
   }
@@ -39,13 +80,54 @@ export function findRepoRoot(startDir: string): string {
 export function resolveRepoRoot(cwd: string, env: NodeJS.ProcessEnv): string {
   const override = env['CONCORD_REPO_ROOT'];
   if (override !== undefined && override.trim() !== '') {
-    return findRepoRoot(override);
+    return resolveExplicitRepoRoot(override);
   }
   const projectDir = env['CLAUDE_PROJECT_DIR'];
   if (projectDir !== undefined && projectDir.trim() !== '') {
-    return findRepoRoot(projectDir);
+    return resolveExplicitRepoRoot(projectDir);
   }
   return findRepoRoot(cwd);
+}
+
+/**
+ * Resolve and validate a root supplied explicitly by a caller. Unlike the
+ * backward-compatible cwd fallback, explicit roots must exist and be
+ * directories so a typo cannot silently create a new Concord workspace.
+ */
+export function resolveExplicitRepoRoot(input: string): string {
+  if (input.trim() === '') {
+    throw new Error('Workspace root must not be blank.');
+  }
+  const candidate = resolve(input);
+  if (!existsSync(candidate)) {
+    throw new Error(`Workspace root does not exist: ${candidate}`);
+  }
+  if (!statSync(candidate).isDirectory()) {
+    throw new Error(`Workspace root is not a directory: ${candidate}`);
+  }
+  return findRepoRoot(candidate);
+}
+
+/** Return the stable, reversible id for a canonical workspace root. */
+export function workspaceIdForRoot(repoRoot: string): string {
+  return `${WORKSPACE_ID_PREFIX}${Buffer.from(canonicalPath(repoRoot), 'utf8').toString('base64url')}`;
+}
+
+/** Decode and validate a workspace id returned by `workspaceIdForRoot`. */
+export function workspaceRootFromId(workspaceId: string): string {
+  if (!workspaceId.startsWith(WORKSPACE_ID_PREFIX)) {
+    throw new Error(`Invalid workspace id: ${workspaceId}`);
+  }
+  const encoded = workspaceId.slice(WORKSPACE_ID_PREFIX.length);
+  const decoded = Buffer.from(encoded, 'base64url').toString('utf8');
+  if (
+    encoded === '' ||
+    !isAbsolute(decoded) ||
+    Buffer.from(decoded, 'utf8').toString('base64url') !== encoded
+  ) {
+    throw new Error(`Invalid workspace id: ${workspaceId}`);
+  }
+  return resolveExplicitRepoRoot(decoded);
 }
 
 /** Absolute path to the `.concord/` directory for a given repo root. */

--- a/src/workspaces/manager.ts
+++ b/src/workspaces/manager.ts
@@ -1,0 +1,158 @@
+import { delimiter } from 'node:path';
+
+import {
+  concordDir,
+  databasePath,
+  resolveExplicitRepoRoot,
+  workspaceIdForRoot,
+  workspaceRootFromId,
+} from '../config/paths.js';
+import { openRepositories, type Repositories } from '../db/index.js';
+
+export interface WorkspaceIdentity {
+  workspaceId: string;
+  repoRoot: string;
+}
+
+export interface WorkspaceContext extends WorkspaceIdentity {
+  concordPath: string;
+  repos: Repositories;
+}
+
+export interface WorkspaceSelection extends WorkspaceIdentity {
+  firstOpen: boolean;
+}
+
+export interface WorkspaceManagerOptions {
+  allowedRoots?: readonly string[];
+  open?: (databaseFilename: string) => Repositories;
+}
+
+/**
+ * Open and route Concord workspaces within one MCP server process.
+ *
+ * Workspace ids are reversible path-backed ids, so a CLI process can select
+ * the same workspace without relying on a separate global registry.
+ */
+export class WorkspaceManager {
+  readonly #contexts = new Map<string, WorkspaceContext>();
+  readonly #allowedRoots: Set<string> | undefined;
+  readonly #open: (databaseFilename: string) => Repositories;
+  #activeWorkspaceId: string;
+
+  constructor(initialRoot: string, options: WorkspaceManagerOptions = {}) {
+    this.#open = options.open ?? openRepositories;
+    this.#allowedRoots =
+      options.allowedRoots === undefined
+        ? undefined
+        : new Set(options.allowedRoots.map((root) => resolveExplicitRepoRoot(root)));
+    const initial = this.join(initialRoot);
+    this.#activeWorkspaceId = initial.workspaceId;
+  }
+
+  /** Build a manager using the optional path-delimited environment allowlist. */
+  static fromEnvironment(
+    initialRoot: string,
+    env: NodeJS.ProcessEnv,
+    options: Omit<WorkspaceManagerOptions, 'allowedRoots'> = {},
+  ): WorkspaceManager {
+    const raw = env['CONCORD_ALLOWED_ROOTS'];
+    const allowedRoots =
+      raw === undefined || raw.trim() === ''
+        ? undefined
+        : raw
+            .split(delimiter)
+            .map((root) => root.trim())
+            .filter((root) => root !== '');
+    return new WorkspaceManager(
+      initialRoot,
+      allowedRoots === undefined ? options : { ...options, allowedRoots },
+    );
+  }
+
+  /** The active/default context used when an operation omits `workspace_id`. */
+  current(): WorkspaceContext {
+    const context = this.#contexts.get(this.#activeWorkspaceId);
+    if (context === undefined) {
+      throw new Error('Concord has no active workspace.');
+    }
+    return context;
+  }
+
+  /** Validate, open (once), and make a repository root active. */
+  join(root: string): WorkspaceSelection {
+    const repoRoot = resolveExplicitRepoRoot(root);
+    this.#assertAllowed(repoRoot);
+    const workspaceId = workspaceIdForRoot(repoRoot);
+    let context = this.#contexts.get(workspaceId);
+    const firstOpen = context === undefined;
+    if (context === undefined) {
+      context = {
+        workspaceId,
+        repoRoot,
+        concordPath: concordDir(repoRoot),
+        repos: this.#open(databasePath(repoRoot)),
+      };
+      this.#contexts.set(workspaceId, context);
+    }
+    this.#activeWorkspaceId = workspaceId;
+    return { workspaceId, repoRoot, firstOpen };
+  }
+
+  /**
+   * Select an already-known or path-decodable workspace. Omitting the id keeps
+   * the current selection for backward-compatible clients.
+   */
+  select(workspaceId?: string): WorkspaceContext {
+    if (workspaceId === undefined) {
+      return this.current();
+    }
+    const cached = this.#contexts.get(workspaceId);
+    if (cached !== undefined) {
+      this.#activeWorkspaceId = workspaceId;
+      return cached;
+    }
+    const root = workspaceRootFromId(workspaceId);
+    this.join(root);
+    return this.current();
+  }
+
+  #assertAllowed(repoRoot: string): void {
+    if (this.#allowedRoots !== undefined && !this.#allowedRoots.has(repoRoot)) {
+      throw new Error(
+        `Workspace root is not allowed: ${repoRoot}. Add it to CONCORD_ALLOWED_ROOTS.`,
+      );
+    }
+  }
+}
+
+/**
+ * A getter-backed repository facade. Existing tool handlers can remain pure
+ * and continue accepting `Repositories`; each property resolves against the
+ * workspace selected immediately before the handler runs.
+ */
+export function routedRepositories(manager: WorkspaceManager): Repositories {
+  return {
+    get db() {
+      return manager.current().repos.db;
+    },
+    get tasks() {
+      return manager.current().repos.tasks;
+    },
+    get handoffs() {
+      return manager.current().repos.handoffs;
+    },
+    get reviews() {
+      return manager.current().repos.reviews;
+    },
+    get taskUpdates() {
+      return manager.current().repos.taskUpdates;
+    },
+    get events() {
+      return manager.current().repos.events;
+    },
+    get agents() {
+      return manager.current().repos.agents;
+    },
+  };
+}

--- a/test/config/paths.test.ts
+++ b/test/config/paths.test.ts
@@ -1,10 +1,18 @@
-import { mkdirSync, mkdtempSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, realpathSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { concordDir, databasePath, findRepoRoot, resolveRepoRoot } from '../../src/config/paths.js';
+import {
+  concordDir,
+  databasePath,
+  findRepoRoot,
+  resolveExplicitRepoRoot,
+  resolveRepoRoot,
+  workspaceIdForRoot,
+  workspaceRootFromId,
+} from '../../src/config/paths.js';
 
 describe('paths', () => {
   it('derives .concord and db paths from a repo root', () => {
@@ -17,12 +25,43 @@ describe('paths', () => {
     mkdirSync(join(root, '.git'));
     const nested = join(root, 'a', 'b');
     mkdirSync(nested, { recursive: true });
-    expect(findRepoRoot(nested)).toBe(root);
+    expect(findRepoRoot(nested)).toBe(realpathSync(root));
   });
 
   it('falls back to the start dir when no .git is found', () => {
     const dir = mkdtempSync(join(tmpdir(), 'concord-nogit-'));
-    expect(findRepoRoot(dir)).toBe(dir);
+    expect(findRepoRoot(dir)).toBe(realpathSync(dir));
+  });
+
+  it('maps a linked worktree to the primary checkout root', () => {
+    const primary = mkdtempSync(join(tmpdir(), 'concord-primary-'));
+    const worktree = mkdtempSync(join(tmpdir(), 'concord-worktree-'));
+    const worktreeGitDir = join(primary, '.git', 'worktrees', 'feature');
+    mkdirSync(worktreeGitDir, { recursive: true });
+    writeFileSync(join(worktreeGitDir, 'commondir'), '../..\n');
+    writeFileSync(join(worktree, '.git'), `gitdir: ${worktreeGitDir}\n`);
+    const nested = join(worktree, 'packages', 'cli');
+    mkdirSync(nested, { recursive: true });
+
+    expect(findRepoRoot(nested)).toBe(realpathSync(primary));
+    expect(databasePath(findRepoRoot(nested))).toBe(databasePath(realpathSync(primary)));
+  });
+
+  it('validates explicit roots rather than silently creating them', () => {
+    const parent = mkdtempSync(join(tmpdir(), 'concord-explicit-'));
+    expect(() => resolveExplicitRepoRoot(join(parent, 'missing'))).toThrow(
+      /Workspace root does not exist/u,
+    );
+  });
+
+  it('round-trips a canonical root through a workspace id', () => {
+    const root = mkdtempSync(join(tmpdir(), 'concord-workspace-id-'));
+    mkdirSync(join(root, '.git'));
+    const workspaceId = workspaceIdForRoot(root);
+
+    expect(workspaceId).toMatch(/^ws_/u);
+    expect(workspaceRootFromId(workspaceId)).toBe(realpathSync(root));
+    expect(() => workspaceRootFromId('ws_not valid')).toThrow(/Invalid workspace id/u);
   });
 });
 
@@ -32,7 +71,7 @@ describe('resolveRepoRoot', () => {
     mkdirSync(join(root, '.git'));
     const nested = join(root, 'pkg');
     mkdirSync(nested);
-    expect(resolveRepoRoot(nested, {})).toBe(root);
+    expect(resolveRepoRoot(nested, {})).toBe(realpathSync(root));
   });
 
   it('prefers CLAUDE_PROJECT_DIR over cwd and normalizes to the git root', () => {
@@ -42,7 +81,7 @@ describe('resolveRepoRoot', () => {
     mkdirSync(nested);
     const elsewhere = mkdtempSync(join(tmpdir(), 'concord-elsewhere-'));
     // cwd is an unrelated directory; the project dir must win.
-    expect(resolveRepoRoot(elsewhere, { CLAUDE_PROJECT_DIR: nested })).toBe(project);
+    expect(resolveRepoRoot(elsewhere, { CLAUDE_PROJECT_DIR: nested })).toBe(realpathSync(project));
   });
 
   it('lets CONCORD_REPO_ROOT override CLAUDE_PROJECT_DIR', () => {
@@ -52,12 +91,21 @@ describe('resolveRepoRoot', () => {
     mkdirSync(join(project, '.git'));
     expect(
       resolveRepoRoot('/nowhere', { CONCORD_REPO_ROOT: forced, CLAUDE_PROJECT_DIR: project }),
-    ).toBe(forced);
+    ).toBe(realpathSync(forced));
   });
 
   it('ignores blank env values', () => {
     const root = mkdtempSync(join(tmpdir(), 'concord-blank-'));
     mkdirSync(join(root, '.git'));
-    expect(resolveRepoRoot(root, { CONCORD_REPO_ROOT: '  ', CLAUDE_PROJECT_DIR: '' })).toBe(root);
+    expect(resolveRepoRoot(root, { CONCORD_REPO_ROOT: '  ', CLAUDE_PROJECT_DIR: '' })).toBe(
+      realpathSync(root),
+    );
+  });
+
+  it('rejects an invalid explicit environment root', () => {
+    const parent = mkdtempSync(join(tmpdir(), 'concord-invalid-env-'));
+    expect(() => resolveRepoRoot(parent, { CONCORD_REPO_ROOT: join(parent, 'missing') })).toThrow(
+      /Workspace root does not exist/u,
+    );
   });
 });

--- a/test/workspaces/manager.test.ts
+++ b/test/workspaces/manager.test.ts
@@ -1,0 +1,70 @@
+import { mkdirSync, mkdtempSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { workspaceIdForRoot } from '../../src/config/paths.js';
+import { openRepositories } from '../../src/db/index.js';
+import { WorkspaceManager, routedRepositories } from '../../src/workspaces/manager.js';
+
+function repoDir(label: string): string {
+  const root = mkdtempSync(join(tmpdir(), `concord-${label}-`));
+  mkdirSync(join(root, '.git'));
+  return realpathSync(root);
+}
+
+describe('WorkspaceManager', () => {
+  it('joins and switches between repositories in one process', () => {
+    const first = repoDir('first');
+    const second = repoDir('second');
+    const manager = new WorkspaceManager(first);
+    const routed = routedRepositories(manager);
+
+    routed.tasks.create({
+      taskId: 'FIRST',
+      title: 'First',
+      owner: null,
+      agent: null,
+      branch: null,
+      worktree: null,
+      expectedFiles: [],
+      modules: [],
+      domains: [],
+      riskTags: [],
+      notes: null,
+      parentTaskId: null,
+      agentId: null,
+    });
+    const joined = manager.join(second);
+    expect(joined.firstOpen).toBe(true);
+    expect(routed.tasks.list()).toEqual([]);
+
+    manager.select(workspaceIdForRoot(first));
+    expect(routed.tasks.list().map((task) => task.taskId)).toEqual(['FIRST']);
+  });
+
+  it('opens a workspace only once when it is selected repeatedly', () => {
+    const first = repoDir('cached');
+    const open = vi.fn(openRepositories);
+    const manager = new WorkspaceManager(first, { open });
+
+    expect(manager.join(first).firstOpen).toBe(false);
+    manager.select(workspaceIdForRoot(first));
+    expect(open).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects roots outside an explicit allowlist', () => {
+    const allowed = repoDir('allowed');
+    const denied = repoDir('denied');
+    const manager = new WorkspaceManager(allowed, { allowedRoots: [allowed] });
+
+    expect(() => manager.join(denied)).toThrow(/Workspace root is not allowed/u);
+  });
+
+  it('rejects malformed workspace ids', () => {
+    const root = repoDir('invalid-id');
+    const manager = new WorkspaceManager(root);
+    expect(() => manager.select('not-a-workspace')).toThrow(/Invalid workspace id/u);
+  });
+});


### PR DESCRIPTION
## What changed

- canonicalizes repository roots, including symlinks and linked Git worktrees
- introduces stable, reversible workspace IDs
- validates explicit roots before opening a workspace
- adds a workspace manager with per-process caching and optional root allowlists

## Why

This is the storage-selection foundation for explicit MCP and CLI workspace routing. It ensures the primary checkout and all linked worktrees resolve to the same `.concord/` database and prevents invalid explicit paths from silently creating state.

Part of #64.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- targeted path/workspace-manager tests: 15 passed
- changed lines: 394 (limit: 600)

## Stack

The follow-up MCP/CLI routing PR is based on this branch and completes issue #64.
