### PR TITLE
feat: route MCP and CLI workspaces explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@
   <a href="./CONTRIBUTING.md">Contributing</a>
 </p>
 
-> ⚠️ Early and under active development. The surface is six focused MCP tools:
-> `register_agent`, `get_work_state`, `claim_work`, `update_task`,
-> `get_task_context`, and `handoff`.
+> ⚠️ Early and under active development. The surface is seven focused MCP
+> tools: `join_workspace`, `register_agent`, `get_work_state`, `claim_work`,
+> `update_task`, `get_task_context`, and `handoff`.
 
 ## One workspace. Every agent.
 
@@ -100,10 +100,11 @@ the workspace is next opened. The interactive `concord` CLI checks npm at most
 once per day and prints an update command when a newer stable release is
 available. Set `CONCORD_NO_UPDATE_CHECK=1` to disable this best-effort check.
 
-## The six tools
+## The seven tools
 
 | Tool               | When                     | What it does                                                                     |
 | ------------------ | ------------------------ | -------------------------------------------------------------------------------- |
+| `join_workspace`   | selecting a repository   | joins an existing repository without restarting MCP and returns its workspace ID |
 | `register_agent`   | at session start         | registers this instance's identity + summary + status; returns the live roster   |
 | `get_work_state`   | before choosing work     | shows the agent roster, active tasks, overlaps, stale claims, and open questions |
 | `claim_work`       | before editing           | records the task + expected files/modules; flags overlaps with other active work |
@@ -116,6 +117,10 @@ presence live just by working. `get_work_state` shows **who is here** (with
 liveness), and flags **stale claims** — an active claim whose owning agent has
 gone away without handing off.
 
+Every operation accepts an optional `workspace_id` returned by `join_workspace`.
+Omit it to use the active/default workspace. Responses report the selected
+workspace ID and repository root so clients can detect a misrouted call.
+
 ## What you get
 
 SQLite is the local source of truth, kept in the `.concord/` at the **root of
@@ -124,6 +129,17 @@ the repo** the work is happening in. The MCP server resolves that root from
 Code sets automatically, even for a user-scoped server), then its working
 directory — so every agent in one repo shares one store. Set `CONCORD_REPO_ROOT`
 when running the server somewhere its working directory is not inside the repo.
+An already-running server can instead call `join_workspace` with any existing
+repository path; no MCP restart is required.
+
+Linked Git worktrees follow Git's `commondir` metadata to the primary checkout,
+so the main checkout and all linked worktrees intentionally share one Concord
+database and workspace ID.
+
+To restrict dynamic joins, set `CONCORD_ALLOWED_ROOTS` to a path-delimited list
+of allowed repository roots. Without an allowlist, explicit roots must still
+exist and be directories; invalid paths are rejected rather than creating an
+accidental workspace.
 
 `concord init` adds `.concord/` to the
 repository's `.gitignore`, so the generated workspace stays local by default.
@@ -154,7 +170,14 @@ concord handoff <task-id>    # print the latest handoff
 concord review-packet <id>   # print the latest review packet
 concord export markdown      # regenerate .concord/ artifacts
 concord doctor               # workspace checks + per-task tool adoption
+
+concord --repo ../project status        # select by repository path from anywhere
+concord --workspace ws_... status       # select an ID returned by join_workspace
 ```
+
+`--repo` and `--workspace` are global, mutually exclusive options. The CLI uses
+the same `CONCORD_REPO_ROOT` → `CLAUDE_PROJECT_DIR` → working-directory priority
+and the same linked-worktree canonicalization as MCP.
 
 `concord dashboard` is a read-only, full-screen local TUI. It refreshes from the
 shared SQLite workspace every second while keeping agents, tasks, alerts,

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -24,6 +24,7 @@ export function buildDoctorReport(ctx: CliContext): string {
     'Concord doctor',
     '',
     'Workspace',
+    `  workspace id ${ctx.workspaceId}`,
     `  .concord/    ${existsSync(ctx.concordPath) ? 'ok' : 'missing'}  ->  ${ctx.concordPath}`,
     `  concord.db   ${existsSync(dbPath) ? 'ok' : 'missing'} (schema v${String(schemaVersion)}, expected v${String(migrations.length)})`,
     `  repo root    ${ctx.repoRoot}`,

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -1,6 +1,6 @@
 import type { Command } from '@commander-js/extra-typings';
 
-import { findRepoRoot } from '../../config/paths.js';
+import { resolveRepoRoot } from '../../config/paths.js';
 import { installClaudeHook } from '../../install/claude-hooks.js';
 import { installConcord } from '../../install/index.js';
 
@@ -13,7 +13,7 @@ export function registerInstallCommand(program: Command): void {
       'also install an opt-in Claude Code PreToolUse overlap hook into .claude/settings.json',
     )
     .action((options) => {
-      const repoRoot = findRepoRoot(process.cwd());
+      const repoRoot = resolveRepoRoot(process.cwd(), process.env);
       const written = installConcord(repoRoot);
       if (options.claudeHooks === true) {
         written.push(installClaudeHook(repoRoot));

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -4,7 +4,11 @@ import { buildStatus, renderStatusText } from '../../artifacts/work-state-view.j
 import { openContext } from '../context.js';
 
 export function runStatus(cwd: string): string {
-  return renderStatusText(buildStatus(openContext(cwd).repos));
+  const context = openContext(cwd);
+  return [
+    `Workspace: ${context.workspaceId} (${context.repoRoot})`,
+    renderStatusText(buildStatus(context.repos)),
+  ].join('\n');
 }
 
 export function registerStatus(program: Command): void {

--- a/src/cli/commands/tasks.ts
+++ b/src/cli/commands/tasks.ts
@@ -19,7 +19,11 @@ export function renderTasks(tasks: readonly TaskRecord[]): string {
 }
 
 export function runTasks(cwd: string): string {
-  return renderTasks(openContext(cwd).repos.tasks.list());
+  const context = openContext(cwd);
+  return [
+    `Workspace: ${context.workspaceId} (${context.repoRoot})`,
+    renderTasks(context.repos.tasks.list()),
+  ].join('\n');
 }
 
 export function registerTasks(program: Command): void {

--- a/src/cli/commands/who.ts
+++ b/src/cli/commands/who.ts
@@ -6,8 +6,13 @@ import { openContext } from '../context.js';
 
 /** Render the presence roster: who is registered and how live they are. */
 export function runWho(cwd: string, now: number = Date.now()): string {
-  const roster = buildRoster(openContext(cwd).repos.agents.list(), now);
-  return ["Who's here", ...renderRosterLines(roster)].join('\n');
+  const context = openContext(cwd);
+  const roster = buildRoster(context.repos.agents.list(), now);
+  return [
+    `Workspace: ${context.workspaceId} (${context.repoRoot})`,
+    "Who's here",
+    ...renderRosterLines(roster),
+  ].join('\n');
 }
 
 export function registerWhoCommand(program: Command): void {

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -1,16 +1,18 @@
-import { concordDir, databasePath, findRepoRoot } from '../config/paths.js';
+import { concordDir, databasePath, resolveRepoRoot, workspaceIdForRoot } from '../config/paths.js';
 import { openRepositories, type Repositories } from '../db/index.js';
 
 export interface CliContext {
+  workspaceId: string;
   repoRoot: string;
   concordPath: string;
   repos: Repositories;
 }
 
-/** Resolve the repo root from `cwd` and open the Concord workspace there. */
-export function openContext(cwd: string): CliContext {
-  const repoRoot = findRepoRoot(cwd);
+/** Resolve the repo root with the same priority as MCP and open that workspace. */
+export function openContext(cwd: string, env: NodeJS.ProcessEnv = process.env): CliContext {
+  const repoRoot = resolveRepoRoot(cwd, env);
   return {
+    workspaceId: workspaceIdForRoot(repoRoot),
     repoRoot,
     concordPath: concordDir(repoRoot),
     repos: openRepositories(databasePath(repoRoot)),

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,16 +19,29 @@ import { registerTasks } from './commands/tasks.js';
 import { registerWatchCommand } from './commands/watch.js';
 import { registerWhoCommand } from './commands/who.js';
 import { notifyIfUpdateAvailable } from './update-notifier.js';
+import { configureCliWorkspace, parseCliWorkspaceOptions } from './workspace-options.js';
 
 const program = new Command();
+let workspaceRoot = resolveRepoRoot(process.cwd(), process.env);
 let activeCommand: { name: string; startedAt: number } | undefined;
 const telemetry = createTelemetryClient({
   surface: 'cli',
-  workspaceRoot: () => resolveRepoRoot(process.cwd(), process.env),
+  workspaceRoot: () => workspaceRoot,
 });
-program.name('concord').description('Shared work-state for coding agents').version(VERSION);
+program
+  .name('concord')
+  .description('Shared work-state for coding agents')
+  .version(VERSION)
+  .option('-C, --repo <path>', 'use the Concord workspace for this repository path')
+  .option('--workspace <id>', 'use a workspace id returned by join_workspace');
 
-program.hook('preAction', (_command, actionCommand) => {
+program.hook('preAction', (command, actionCommand) => {
+  const options = parseCliWorkspaceOptions(command.opts());
+  const selected = configureCliWorkspace(options, process.cwd(), process.env);
+  if (selected !== undefined) {
+    workspaceRoot = selected.repoRoot;
+    process.stderr.write(`Concord workspace: ${selected.workspaceId} (${selected.repoRoot})\n`);
+  }
   activeCommand = { name: actionCommand.name(), startedAt: performance.now() };
 });
 

--- a/src/cli/workspace-options.ts
+++ b/src/cli/workspace-options.ts
@@ -1,0 +1,50 @@
+import { resolve } from 'node:path';
+
+import { z } from 'zod';
+
+import {
+  resolveExplicitRepoRoot,
+  workspaceIdForRoot,
+  workspaceRootFromId,
+} from '../config/paths.js';
+import type { WorkspaceIdentity } from '../workspaces/manager.js';
+
+const cliWorkspaceOptionsSchema = z.object({
+  repo: z.string().optional(),
+  workspace: z.string().optional(),
+});
+
+export type CliWorkspaceOptions = z.infer<typeof cliWorkspaceOptionsSchema>;
+
+export function parseCliWorkspaceOptions(input: unknown): CliWorkspaceOptions {
+  return cliWorkspaceOptionsSchema.parse(input);
+}
+
+/**
+ * Validate a CLI workspace selector and apply it through the same environment
+ * override consumed by every CLI context. Returns undefined when no explicit
+ * selector was supplied.
+ */
+export function configureCliWorkspace(
+  options: CliWorkspaceOptions,
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+): WorkspaceIdentity | undefined {
+  if (options.repo !== undefined && options.workspace !== undefined) {
+    throw new Error('Use either --repo or --workspace, not both.');
+  }
+  if (options.repo === undefined && options.workspace === undefined) {
+    return undefined;
+  }
+
+  let repoRoot: string;
+  if (options.repo !== undefined) {
+    repoRoot = resolveExplicitRepoRoot(resolve(cwd, options.repo));
+  } else if (options.workspace !== undefined) {
+    repoRoot = workspaceRootFromId(options.workspace);
+  } else {
+    throw new Error('Concord workspace selection is missing.');
+  }
+  env['CONCORD_REPO_ROOT'] = repoRoot;
+  return { workspaceId: workspaceIdForRoot(repoRoot), repoRoot };
+}

--- a/src/domain/schemas.ts
+++ b/src/domain/schemas.ts
@@ -19,6 +19,30 @@ const agentIdField = z
       "Supplying it refreshes the agent's presence (liveness) in the roster.",
   );
 
+/** Optional workspace selector shared by every MCP operation. */
+export const workspaceIdField = z
+  .string()
+  .min(1)
+  .optional()
+  .describe(
+    'Workspace id returned by join_workspace. Omit to use the active/default workspace for this MCP session.',
+  );
+
+export const joinWorkspaceInputShape = {
+  root: z
+    .string()
+    .min(1)
+    .describe('Existing repository or directory to join as a Concord workspace'),
+} as const;
+
+export const joinWorkspaceInputSchema = z.object(joinWorkspaceInputShape);
+export type JoinWorkspaceInput = z.infer<typeof joinWorkspaceInputSchema>;
+
+export const getWorkStateInputShape = {
+  workspace_id: workspaceIdField,
+} as const;
+export const getWorkStateInputSchema = z.object(getWorkStateInputShape).default({});
+
 export const registerAgentInputShape = {
   agent_id: z
     .string()
@@ -40,6 +64,7 @@ export const registerAgentInputShape = {
   worktree: z.string().optional().describe('Git worktree path, if used'),
   cwd: z.string().optional().describe('Working directory, for disambiguating instances'),
   pid: z.number().int().optional().describe('Process id, for disambiguating instances'),
+  workspace_id: workspaceIdField,
 } as const;
 
 export const registerAgentInputSchema = z.object(registerAgentInputShape);
@@ -72,6 +97,7 @@ export const claimWorkInputShape = {
   risk_tags: z.array(z.string()).optional().describe('Risk tags, e.g. payment-flow'),
   notes: z.string().optional().describe('Freeform notes'),
   agent_id: agentIdField,
+  workspace_id: workspaceIdField,
 } as const;
 
 export const claimWorkInputSchema = z.object(claimWorkInputShape);
@@ -94,6 +120,7 @@ export const updateTaskInputShape = {
   content: z.string().min(1).describe('Concise context another agent needs'),
   agent: z.string().optional().describe('Agent recording the update; defaults to the claimant'),
   agent_id: agentIdField,
+  workspace_id: workspaceIdField,
 } as const;
 
 export const updateTaskInputSchema = z.object(updateTaskInputShape);
@@ -101,6 +128,7 @@ export type UpdateTaskInput = z.infer<typeof updateTaskInputSchema>;
 
 export const getTaskContextInputShape = {
   task_id: z.string().min(1).describe('Task whose shared context should be read'),
+  workspace_id: workspaceIdField,
 } as const;
 
 export const getTaskContextInputSchema = z.object(getTaskContextInputShape);
@@ -135,6 +163,7 @@ export const handoffInputShape = {
     .optional()
     .describe('Where each claim came from, e.g. { field: "tests", source: "command output" }'),
   agent_id: agentIdField,
+  workspace_id: workspaceIdField,
 } as const;
 
 export const handoffInputSchema = z.object(handoffInputShape);
@@ -152,6 +181,7 @@ export const reviewReadyInputShape = {
     .array(z.object({ field: z.string(), source: z.string() }))
     .optional()
     .describe('Where each claim came from, e.g. { field: "tests", source: "command output" }'),
+  workspace_id: workspaceIdField,
 } as const;
 
 export const reviewReadyInputSchema = z.object(reviewReadyInputShape);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,24 +2,26 @@
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
 import { writeArtifacts } from './artifacts/index.js';
-import { concordDir, databasePath, resolveRepoRoot } from './config/paths.js';
-import { openRepositories } from './db/index.js';
+import { resolveRepoRoot } from './config/paths.js';
 import { createServer } from './server.js';
 import { createTelemetryClient } from './telemetry/client.js';
 import { TelemetryTransport } from './telemetry/transport.js';
+import { WorkspaceManager } from './workspaces/manager.js';
 
 async function main(): Promise<void> {
   const repoRoot = resolveRepoRoot(process.cwd(), process.env);
-  const repos = openRepositories(databasePath(repoRoot));
-  const artifactsDir = concordDir(repoRoot);
-  const server = createServer(repos, {
-    onToolWrite: () => {
-      writeArtifacts(artifactsDir, repos);
+  const workspaceManager = WorkspaceManager.fromEnvironment(repoRoot, process.env);
+  const server = createServer(workspaceManager.current().repos, {
+    workspaceManager,
+    onToolWrite: (workspace) => {
+      if (workspace !== undefined) {
+        writeArtifacts(workspace.concordPath, workspace.repos);
+      }
     },
   });
   const telemetry = createTelemetryClient({
     surface: 'mcp',
-    workspaceRoot: () => repoRoot,
+    workspaceRoot: () => workspaceManager.current().repoRoot,
   });
   const stdio = new StdioServerTransport();
   const transport = telemetry === undefined ? stdio : new TelemetryTransport(stdio, telemetry);

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,16 +5,24 @@ import { registerClaimWork } from './tools/claim-work.js';
 import { registerGetTaskContext } from './tools/get-task-context.js';
 import { registerWorkState } from './tools/get-work-state.js';
 import { registerHandoff } from './tools/handoff.js';
+import { registerJoinWorkspace } from './tools/join-workspace.js';
 import { registerRegisterAgent } from './tools/register-agent.js';
 import { registerUpdateTask } from './tools/update-task.js';
 import { VERSION } from './version.js';
+import {
+  routedRepositories,
+  type WorkspaceContext,
+  type WorkspaceManager,
+} from './workspaces/manager.js';
 
 /** Concord's advertised MCP server version. */
 export const SERVER_VERSION = VERSION;
 
 export interface ServerOptions {
   /** Called after any tool writes to the database (used to regenerate artifacts). */
-  onToolWrite?: () => void;
+  onToolWrite?: (workspace: WorkspaceContext | undefined) => void;
+  /** Enables dynamic workspace joins and per-operation workspace selection. */
+  workspaceManager?: WorkspaceManager;
 }
 
 /**
@@ -23,17 +31,24 @@ export interface ServerOptions {
  */
 export function createServer(repos: Repositories, options: ServerOptions = {}): McpServer {
   const server = new McpServer({ name: 'concord-mcp', version: SERVER_VERSION });
+  const manager = options.workspaceManager;
+  const selectedRepos = manager === undefined ? repos : routedRepositories(manager);
+  const selectWorkspace =
+    manager === undefined ? undefined : (workspaceId?: string) => manager.select(workspaceId);
   // Register the read surface first so we get the change-notifier, then run it
   // (plus the caller's hook) after every write.
-  const notifyWorkStateChanged = registerWorkState(server, repos);
+  const notifyWorkStateChanged = registerWorkState(server, selectedRepos, selectWorkspace);
   const onWrite = (): void => {
-    options.onToolWrite?.();
+    options.onToolWrite?.(manager?.current());
     notifyWorkStateChanged();
   };
-  registerGetTaskContext(server, repos);
-  registerRegisterAgent(server, repos, onWrite);
-  registerClaimWork(server, repos, onWrite);
-  registerUpdateTask(server, repos, onWrite);
-  registerHandoff(server, repos, onWrite);
+  if (manager !== undefined) {
+    registerJoinWorkspace(server, manager, notifyWorkStateChanged);
+  }
+  registerGetTaskContext(server, selectedRepos, selectWorkspace);
+  registerRegisterAgent(server, selectedRepos, onWrite, selectWorkspace);
+  registerClaimWork(server, selectedRepos, onWrite, selectWorkspace);
+  registerUpdateTask(server, selectedRepos, onWrite, selectWorkspace);
+  registerHandoff(server, selectedRepos, onWrite, selectWorkspace);
   return server;
 }

--- a/src/tools/claim-work.ts
+++ b/src/tools/claim-work.ts
@@ -4,6 +4,12 @@ import type { Repositories, TaskRecord } from '../db/index.js';
 import { assessClaimBreadth } from '../domain/decomposition.js';
 import { detectOverlaps, type OverlapWarning } from '../domain/overlap.js';
 import { claimWorkInputShape, type ClaimWorkInput } from '../domain/schemas.js';
+import {
+  selectToolWorkspace,
+  type SelectWorkspace,
+  workspaceStructured,
+  withWorkspaceText,
+} from './workspace-routing.js';
 
 export interface ClaimWorkResult {
   task: TaskRecord;
@@ -194,6 +200,7 @@ export function registerClaimWork(
   server: McpServer,
   repos: Repositories,
   onWrite?: () => void,
+  selectWorkspace?: SelectWorkspace,
 ): void {
   server.registerTool(
     'claim_work',
@@ -206,11 +213,17 @@ export function registerClaimWork(
       inputSchema: claimWorkInputShape,
     },
     (args) => {
+      const workspace = selectToolWorkspace(selectWorkspace, args.workspace_id);
       const result = handleClaimWork(repos, args);
       onWrite?.();
       return {
-        content: [{ type: 'text', text: formatClaimWorkText(result) }],
-        structuredContent: toClaimWorkStructured(result),
+        content: [
+          { type: 'text', text: withWorkspaceText(formatClaimWorkText(result), workspace) },
+        ],
+        structuredContent: {
+          ...workspaceStructured(workspace),
+          ...toClaimWorkStructured(result),
+        },
       };
     },
   );

--- a/src/tools/get-task-context.ts
+++ b/src/tools/get-task-context.ts
@@ -9,6 +9,12 @@ import type {
 } from '../db/index.js';
 import { detectOverlaps, type OverlapWarning } from '../domain/overlap.js';
 import { getTaskContextInputShape, type GetTaskContextInput } from '../domain/schemas.js';
+import {
+  selectToolWorkspace,
+  type SelectWorkspace,
+  workspaceStructured,
+  withWorkspaceText,
+} from './workspace-routing.js';
 
 export interface TaskContextResult {
   task: TaskRecord;
@@ -85,7 +91,11 @@ function formatContext(result: TaskContextResult): string {
   ].join('\n');
 }
 
-export function registerGetTaskContext(server: McpServer, repos: Repositories): void {
+export function registerGetTaskContext(
+  server: McpServer,
+  repos: Repositories,
+  selectWorkspace?: SelectWorkspace,
+): void {
   server.registerTool(
     'get_task_context',
     {
@@ -101,10 +111,12 @@ export function registerGetTaskContext(server: McpServer, repos: Repositories): 
       },
     },
     (input) => {
+      const workspace = selectToolWorkspace(selectWorkspace, input.workspace_id);
       const result = handleGetTaskContext(repos, input);
       return {
-        content: [{ type: 'text', text: formatContext(result) }],
+        content: [{ type: 'text', text: withWorkspaceText(formatContext(result), workspace) }],
         structuredContent: {
+          ...workspaceStructured(workspace),
           task: result.task,
           updates: result.updates,
           latest_handoff: result.latestHandoff ?? null,

--- a/src/tools/get-work-state.ts
+++ b/src/tools/get-work-state.ts
@@ -6,6 +6,13 @@ import {
 
 import { buildStatus, renderStatusText, type StatusView } from '../artifacts/work-state-view.js';
 import type { Repositories } from '../db/index.js';
+import { getWorkStateInputSchema } from '../domain/schemas.js';
+import {
+  selectToolWorkspace,
+  type SelectWorkspace,
+  workspaceStructured,
+  withWorkspaceText,
+} from './workspace-routing.js';
 
 /** Stable URI for the read-only work-state resource. */
 export const WORK_STATE_URI = 'concord://work-state';
@@ -29,7 +36,11 @@ export function handleGetWorkState(repos: Repositories): StatusView {
  * clients are pushed a `resources/updated` for `concord://work-state`. MCP
  * cannot wake an idle client — this is push while a session is connected.
  */
-export function registerWorkState(server: McpServer, repos: Repositories): () => void {
+export function registerWorkState(
+  server: McpServer,
+  repos: Repositories,
+  selectWorkspace?: SelectWorkspace,
+): () => void {
   server.registerTool(
     'get_work_state',
     {
@@ -39,12 +50,15 @@ export function registerWorkState(server: McpServer, repos: Repositories): () =>
         'active claims, overlaps (recomputed live across all active tasks), and review-ready ' +
         'tasks. Read-only — call this before claiming to see who else is here and what they are ' +
         'already working on.',
+      inputSchema: getWorkStateInputSchema,
     },
-    () => {
+    (args) => {
+      const workspace = selectToolWorkspace(selectWorkspace, args.workspace_id);
       const view = handleGetWorkState(repos);
       return {
-        content: [{ type: 'text', text: renderStatusText(view) }],
+        content: [{ type: 'text', text: withWorkspaceText(renderStatusText(view), workspace) }],
         structuredContent: {
+          ...workspaceStructured(workspace),
           presence: view.presence,
           active: view.active,
           overlaps: view.overlaps,
@@ -64,15 +78,22 @@ export function registerWorkState(server: McpServer, repos: Repositories): () =>
       description: 'Active claims, live overlaps, and review-ready tasks as JSON.',
       mimeType: 'application/json',
     },
-    (uri) => ({
-      contents: [
-        {
-          uri: uri.href,
-          mimeType: 'application/json',
-          text: `${JSON.stringify(handleGetWorkState(repos), null, 2)}\n`,
-        },
-      ],
-    }),
+    (uri) => {
+      const workspace = selectToolWorkspace(selectWorkspace, undefined);
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: 'application/json',
+            text: `${JSON.stringify(
+              { ...workspaceStructured(workspace), ...handleGetWorkState(repos) },
+              null,
+              2,
+            )}\n`,
+          },
+        ],
+      };
+    },
   );
 
   // Advertise resource subscriptions and track which URIs clients care about,

--- a/src/tools/handoff.ts
+++ b/src/tools/handoff.ts
@@ -3,6 +3,12 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { HandoffRecord, Repositories } from '../db/index.js';
 import { handoffInputShape, type HandoffInput } from '../domain/schemas.js';
 import { handleReviewReady } from './review-ready.js';
+import {
+  selectToolWorkspace,
+  type SelectWorkspace,
+  workspaceStructured,
+  withWorkspaceText,
+} from './workspace-routing.js';
 
 export interface HandoffResult {
   handoff: HandoffRecord;
@@ -103,6 +109,7 @@ export function registerHandoff(
   server: McpServer,
   repos: Repositories,
   onWrite?: () => void,
+  selectWorkspace?: SelectWorkspace,
 ): void {
   server.registerTool(
     'handoff',
@@ -115,11 +122,13 @@ export function registerHandoff(
       inputSchema: handoffInputShape,
     },
     (args) => {
+      const workspace = selectToolWorkspace(selectWorkspace, args.workspace_id);
       const result = handleHandoff(repos, args);
       onWrite?.();
       return {
-        content: [{ type: 'text', text: formatHandoffText(result) }],
+        content: [{ type: 'text', text: withWorkspaceText(formatHandoffText(result), workspace) }],
         structuredContent: {
+          ...workspaceStructured(workspace),
           task_id: result.handoff.taskId,
           handoff_id: result.handoff.id,
           task_auto_created: result.taskAutoCreated,

--- a/src/tools/join-workspace.ts
+++ b/src/tools/join-workspace.ts
@@ -1,0 +1,40 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import { joinWorkspaceInputShape } from '../domain/schemas.js';
+import type { WorkspaceManager } from '../workspaces/manager.js';
+
+export function registerJoinWorkspace(
+  server: McpServer,
+  manager: WorkspaceManager,
+  onChange?: () => void,
+): void {
+  server.registerTool(
+    'join_workspace',
+    {
+      title: 'Join workspace',
+      description:
+        'Validate and join a repository after this MCP server has started. Returns a workspace_id ' +
+        'that can be supplied to every other Concord operation. Linked Git worktrees resolve to ' +
+        'their shared primary workspace.',
+      inputSchema: joinWorkspaceInputShape,
+    },
+    ({ root }) => {
+      const result = manager.join(root);
+      onChange?.();
+      const verb = result.firstOpen ? 'Joined' : 'Selected';
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `${verb} workspace ${result.workspaceId} at ${result.repoRoot}.`,
+          },
+        ],
+        structuredContent: {
+          workspace_id: result.workspaceId,
+          repo_root: result.repoRoot,
+          first_open: result.firstOpen,
+        },
+      };
+    },
+  );
+}

--- a/src/tools/register-agent.ts
+++ b/src/tools/register-agent.ts
@@ -5,6 +5,12 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { AgentRecord, Repositories } from '../db/index.js';
 import { buildRoster, type PresenceEntry } from '../domain/presence.js';
 import { registerAgentInputShape, type RegisterAgentInput } from '../domain/schemas.js';
+import {
+  selectToolWorkspace,
+  type SelectWorkspace,
+  workspaceStructured,
+  withWorkspaceText,
+} from './workspace-routing.js';
 
 export interface RegisterAgentResult {
   agent: AgentRecord;
@@ -94,6 +100,7 @@ export function registerRegisterAgent(
   server: McpServer,
   repos: Repositories,
   onWrite?: () => void,
+  selectWorkspace?: SelectWorkspace,
 ): void {
   server.registerTool(
     'register_agent',
@@ -107,11 +114,15 @@ export function registerRegisterAgent(
       inputSchema: registerAgentInputShape,
     },
     (args) => {
+      const workspace = selectToolWorkspace(selectWorkspace, args.workspace_id);
       const result = handleRegisterAgent(repos, args);
       onWrite?.();
       return {
-        content: [{ type: 'text', text: formatRegisterAgentText(result) }],
+        content: [
+          { type: 'text', text: withWorkspaceText(formatRegisterAgentText(result), workspace) },
+        ],
         structuredContent: {
+          ...workspaceStructured(workspace),
           agent_id: result.agent.agentId,
           first_registration: result.firstRegistration,
           status: result.agent.status,

--- a/src/tools/update-task.ts
+++ b/src/tools/update-task.ts
@@ -2,6 +2,12 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import type { Repositories, TaskUpdateRecord } from '../db/index.js';
 import { updateTaskInputShape, type UpdateTaskInput } from '../domain/schemas.js';
+import {
+  selectToolWorkspace,
+  type SelectWorkspace,
+  workspaceStructured,
+  withWorkspaceText,
+} from './workspace-routing.js';
 
 export interface UpdateTaskResult {
   update: TaskUpdateRecord;
@@ -41,6 +47,7 @@ export function registerUpdateTask(
   server: McpServer,
   repos: Repositories,
   onWrite?: () => void,
+  selectWorkspace?: SelectWorkspace,
 ): void {
   server.registerTool(
     'update_task',
@@ -52,11 +59,15 @@ export function registerUpdateTask(
       inputSchema: updateTaskInputShape,
     },
     (args) => {
+      const workspace = selectToolWorkspace(selectWorkspace, args.workspace_id);
       const result = handleUpdateTask(repos, args);
       onWrite?.();
       return {
-        content: [{ type: 'text', text: formatUpdateTaskText(result) }],
+        content: [
+          { type: 'text', text: withWorkspaceText(formatUpdateTaskText(result), workspace) },
+        ],
         structuredContent: {
+          ...workspaceStructured(workspace),
           update_id: result.update.id,
           task_id: result.update.taskId,
           kind: result.update.kind,

--- a/src/tools/workspace-routing.ts
+++ b/src/tools/workspace-routing.ts
@@ -1,0 +1,26 @@
+import type { WorkspaceContext, WorkspaceIdentity } from '../workspaces/manager.js';
+
+export type SelectWorkspace = (workspaceId?: string) => WorkspaceContext;
+
+export function selectToolWorkspace(
+  selectWorkspace: SelectWorkspace | undefined,
+  workspaceId: string | undefined,
+): WorkspaceIdentity | undefined {
+  return selectWorkspace?.(workspaceId);
+}
+
+export function workspaceStructured(workspace: WorkspaceIdentity | undefined): {
+  workspace_id?: string;
+  repo_root?: string;
+} {
+  return workspace === undefined
+    ? {}
+    : { workspace_id: workspace.workspaceId, repo_root: workspace.repoRoot };
+}
+
+export function withWorkspaceText(text: string, workspace: WorkspaceIdentity | undefined): string {
+  if (workspace === undefined) {
+    return text;
+  }
+  return `Workspace: ${workspace.workspaceId} (${workspace.repoRoot})\n${text}`;
+}

--- a/test/cli/cli-core.test.ts
+++ b/test/cli/cli-core.test.ts
@@ -1,4 +1,11 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -11,6 +18,8 @@ import { runInit } from '../../src/cli/commands/init.js';
 import { renderTasks } from '../../src/cli/commands/tasks.js';
 import { runWho } from '../../src/cli/commands/who.js';
 import { openContext } from '../../src/cli/context.js';
+import { configureCliWorkspace } from '../../src/cli/workspace-options.js';
+import { workspaceIdForRoot } from '../../src/config/paths.js';
 import { handleClaimWork } from '../../src/tools/claim-work.js';
 import { handleRegisterAgent } from '../../src/tools/register-agent.js';
 import { handleReviewReady } from '../../src/tools/review-ready.js';
@@ -18,7 +27,7 @@ import { handleReviewReady } from '../../src/tools/review-ready.js';
 function repoDir(): string {
   const dir = mkdtempSync(join(tmpdir(), 'concord-cli-'));
   mkdirSync(join(dir, '.git'));
-  return dir;
+  return realpathSync(dir);
 }
 
 describe('runInit', () => {
@@ -212,5 +221,52 @@ describe('runWho', () => {
     const dir = repoDir();
     runInit(dir);
     expect(runWho(dir)).toContain('none');
+  });
+});
+
+describe('CLI workspace selection', () => {
+  it('uses the same CONCORD_REPO_ROOT override as MCP resolution', () => {
+    const selected = repoDir();
+    const elsewhere = repoDir();
+    const context = openContext(elsewhere, { CONCORD_REPO_ROOT: selected });
+
+    expect(context.repoRoot).toBe(selected);
+    expect(context.workspaceId).toBe(workspaceIdForRoot(selected));
+  });
+
+  it('configures an explicit --repo from any launch directory', () => {
+    const selected = repoDir();
+    const elsewhere = repoDir();
+    const env: NodeJS.ProcessEnv = {};
+    const identity = configureCliWorkspace({ repo: selected }, elsewhere, env);
+
+    expect(identity).toEqual({
+      workspaceId: workspaceIdForRoot(selected),
+      repoRoot: selected,
+    });
+    expect(openContext(elsewhere, env).repoRoot).toBe(selected);
+  });
+
+  it('selects the MCP workspace id through --workspace', () => {
+    const selected = repoDir();
+    const elsewhere = repoDir();
+    const env: NodeJS.ProcessEnv = {};
+    const workspaceId = workspaceIdForRoot(selected);
+
+    expect(configureCliWorkspace({ workspace: workspaceId }, elsewhere, env)?.repoRoot).toBe(
+      selected,
+    );
+    expect(openContext(elsewhere, env).workspaceId).toBe(workspaceId);
+  });
+
+  it('rejects conflicting CLI selectors', () => {
+    const selected = repoDir();
+    expect(() =>
+      configureCliWorkspace(
+        { repo: selected, workspace: workspaceIdForRoot(selected) },
+        selected,
+        {},
+      ),
+    ).toThrow(/either --repo or --workspace/u);
   });
 });

--- a/test/tools/get-work-state.test.ts
+++ b/test/tools/get-work-state.test.ts
@@ -1,13 +1,24 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { ResourceUpdatedNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
+import { mkdirSync, mkdtempSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import { workspaceIdForRoot } from '../../src/config/paths.js';
 import { openDatabase } from '../../src/db/connection.js';
 import { createRepositories, type Repositories } from '../../src/db/index.js';
 import { createServer } from '../../src/server.js';
 import { handleClaimWork } from '../../src/tools/claim-work.js';
 import { handleGetWorkState, WORK_STATE_URI } from '../../src/tools/get-work-state.js';
+import { WorkspaceManager } from '../../src/workspaces/manager.js';
+
+function repoDir(label: string): string {
+  const root = mkdtempSync(join(tmpdir(), `concord-mcp-${label}-`));
+  mkdirSync(join(root, '.git'));
+  return realpathSync(root);
+}
 
 describe('handleGetWorkState', () => {
   let repos: Repositories;
@@ -69,6 +80,7 @@ describe('work-state MCP surface (end-to-end via in-memory transport)', () => {
       expect(tools.tools.map((t) => t.name)).toContain('get_work_state');
       expect(tools.tools.map((t) => t.name)).toContain('update_task');
       expect(tools.tools.map((t) => t.name)).toContain('get_task_context');
+      expect(tools.tools.map((t) => t.name)).not.toContain('join_workspace');
 
       const resources = await client.listResources();
       expect(resources.resources.map((r) => r.uri)).toContain(WORK_STATE_URI);
@@ -106,6 +118,91 @@ describe('work-state MCP surface (end-to-end via in-memory transport)', () => {
       await received;
 
       expect(updated).toContain(WORK_STATE_URI);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it('joins and explicitly selects multiple repositories without restarting', async () => {
+    const firstRoot = repoDir('first');
+    const secondRoot = repoDir('second');
+    const manager = new WorkspaceManager(firstRoot);
+    const writtenRoots: string[] = [];
+    const server = createServer(manager.current().repos, {
+      workspaceManager: manager,
+      onToolWrite: (workspace) => {
+        if (workspace !== undefined) {
+          writtenRoots.push(workspace.repoRoot);
+        }
+      },
+    });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: 'test-client', version: '0.0.0' });
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+    try {
+      const tools = await client.listTools();
+      expect(tools.tools.map((tool) => tool.name)).toContain('join_workspace');
+
+      const firstClaim = await client.callTool({
+        name: 'claim_work',
+        arguments: { task_id: 'FIRST', title: 'First task' },
+      });
+      expect(JSON.stringify(firstClaim)).toContain(workspaceIdForRoot(firstRoot));
+
+      const joined = await client.callTool({
+        name: 'join_workspace',
+        arguments: { root: secondRoot },
+      });
+      expect(JSON.stringify(joined)).toContain(workspaceIdForRoot(secondRoot));
+
+      const registered = await client.callTool({
+        name: 'register_agent',
+        arguments: { kind: 'test-agent' },
+      });
+      expect(JSON.stringify(registered)).toContain(workspaceIdForRoot(secondRoot));
+
+      await client.callTool({
+        name: 'claim_work',
+        arguments: { task_id: 'SECOND', title: 'Second task' },
+      });
+
+      const firstState = await client.callTool({
+        name: 'get_work_state',
+        arguments: { workspace_id: workspaceIdForRoot(firstRoot) },
+      });
+      expect(JSON.stringify(firstState)).toContain('FIRST');
+      expect(JSON.stringify(firstState)).not.toContain('SECOND');
+
+      const secondState = await client.callTool({
+        name: 'get_work_state',
+        arguments: { workspace_id: workspaceIdForRoot(secondRoot) },
+      });
+      expect(JSON.stringify(secondState)).toContain('SECOND');
+      expect(JSON.stringify(secondState)).not.toContain('FIRST');
+      expect(writtenRoots).toEqual([firstRoot, secondRoot, secondRoot]);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it('returns an MCP tool error for an invalid join root', async () => {
+    const root = repoDir('invalid-join');
+    const manager = new WorkspaceManager(root);
+    const server = createServer(manager.current().repos, { workspaceManager: manager });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: 'test-client', version: '0.0.0' });
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+    try {
+      const result = await client.callTool({
+        name: 'join_workspace',
+        arguments: { root: join(root, 'missing') },
+      });
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result)).toContain('Workspace root does not exist');
     } finally {
       await client.close();
       await server.close();

--- a/test/workspaces/manager.test.ts
+++ b/test/workspaces/manager.test.ts
@@ -15,6 +15,18 @@ function repoDir(label: string): string {
 }
 
 describe('WorkspaceManager', () => {
+  it('can start outside a repository and explicitly join one later', () => {
+    const launchRoot = mkdtempSync(join(tmpdir(), 'concord-mcp-launch-root-'));
+    const repoRoot = repoDir('joined-after-launch');
+    const manager = new WorkspaceManager(launchRoot);
+
+    const joined = manager.join(repoRoot);
+
+    expect(joined.repoRoot).toBe(repoRoot);
+    expect(joined.workspaceId).toBe(workspaceIdForRoot(repoRoot));
+    expect(manager.current().repoRoot).toBe(repoRoot);
+  });
+
   it('joins and switches between repositories in one process', () => {
     const first = repoDir('first');
     const second = repoDir('second');


### PR DESCRIPTION
## What changed

- adds `join_workspace` so an MCP session can attach to a repository without restarting
- adds optional `workspace_id` routing and workspace identity to every MCP operation
- routes one server process across multiple repository databases
- adds global CLI `--repo` and `--workspace` selectors
- reports the selected workspace in MCP responses and CLI status output
- documents dynamic joins, allowlists, and linked-worktree behavior

## Why

Concord currently binds its MCP server to one startup directory, which can route agent writes to the wrong repository and split state between linked worktrees. This completes explicit workspace selection across MCP and CLI.

Completes #64.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test` — 23 files / 165 tests passed
- `pnpm build`
- changed lines relative to the stack base: 565 (limit: 600)

Acceptance coverage includes outside-repository launch followed by explicit join, multiple repositories in one MCP process, linked worktree canonicalization, invalid roots, allowlists, CLI/MCP ID parity, selected-workspace output, and backward compatibility.

## Stack

Depends on #76. This PR targets `agent/gh-64-workspace-foundation` so its review diff contains only the routing layer. Retarget it to `main` after #76 merges.
