### PR TITLE
Add terminal task lifecycle

### DIFF
--- a/src/domain/schemas.ts
+++ b/src/domain/schemas.ts
@@ -244,3 +244,27 @@ export const reassignTaskInputShape = {
 } as const;
 export const reassignTaskInputSchema = z.object(reassignTaskInputShape);
 export type ReassignTaskInput = z.infer<typeof reassignTaskInputSchema>;
+
+export const closeTaskInputShape = {
+  task_id: z.string().min(1),
+  agent_id: lifecycleActorField,
+  expected_version: taskVersionField,
+  reason: z.string().min(1),
+  outcome: z
+    .enum(['complete', 'closed'])
+    .optional()
+    .describe('Terminal outcome; defaults to closed'),
+  workspace_id: workspaceIdField,
+} as const;
+export const closeTaskInputSchema = z.object(closeTaskInputShape);
+export type CloseTaskInput = z.infer<typeof closeTaskInputSchema>;
+
+export const reopenTaskInputShape = {
+  task_id: z.string().min(1),
+  agent_id: lifecycleActorField,
+  expected_version: taskVersionField,
+  reason: z.string().min(1),
+  workspace_id: workspaceIdField,
+} as const;
+export const reopenTaskInputSchema = z.object(reopenTaskInputShape);
+export type ReopenTaskInput = z.infer<typeof reopenTaskInputSchema>;

--- a/src/tools/task-lifecycle.ts
+++ b/src/tools/task-lifecycle.ts
@@ -13,10 +13,14 @@ import {
   type AcceptTaskInput,
   assignTaskInputShape,
   type AssignTaskInput,
+  closeTaskInputShape,
+  type CloseTaskInput,
   reassignTaskInputShape,
   type ReassignTaskInput,
   releaseTaskInputShape,
   type ReleaseTaskInput,
+  reopenTaskInputShape,
+  type ReopenTaskInput,
 } from '../domain/schemas.js';
 import {
   selectToolWorkspace,
@@ -239,6 +243,45 @@ export function handleReassignTask(
   });
 }
 
+export function handleCloseTask(repos: Repositories, input: CloseTaskInput): TaskLifecycleResult {
+  const actor = registeredAgent(repos, input.agent_id);
+  const task = taskAtVersion(repos, input.task_id, input.expected_version);
+  requireOwner(task, actor);
+  return applyTransition(repos, {
+    task,
+    transition: 'close',
+    tool: 'close_task',
+    actorAgentId: actor.agentId,
+    status: input.outcome ?? 'closed',
+    agentId: task.agentId,
+    assignedAgentId: null,
+    leaseExpiresAt: null,
+    reason: input.reason,
+  });
+}
+
+export function handleReopenTask(repos: Repositories, input: ReopenTaskInput): TaskLifecycleResult {
+  const actor = registeredAgent(repos, input.agent_id);
+  const task = taskAtVersion(repos, input.task_id, input.expected_version);
+  if (!['closed', 'complete', 'handed_off', 'review_ready'].includes(task.status)) {
+    throw new Error(`Task ${task.taskId} is ${task.status}, not a terminal/review state.`);
+  }
+  if (task.agentId !== null && task.agentId !== actor.agentId && !isHumanSupervisor(actor, task)) {
+    throw new Error(`Agent ${actor.agentId} cannot reopen ${task.taskId}.`);
+  }
+  return applyTransition(repos, {
+    task,
+    transition: 'reopen',
+    tool: 'reopen_task',
+    actorAgentId: actor.agentId,
+    status: 'active',
+    agentId: actor.agentId,
+    assignedAgentId: null,
+    leaseExpiresAt: null,
+    reason: input.reason,
+  });
+}
+
 function lifecycleText(action: string, result: TaskLifecycleResult): string {
   return `${action} ${result.task.taskId}; status ${result.task.status}, version ${String(result.task.version)}.`;
 }
@@ -339,6 +382,45 @@ export function registerTaskLifecycle(
       return {
         content: [
           { type: 'text', text: withWorkspaceText(lifecycleText('Reassigned', result), workspace) },
+        ],
+        structuredContent: { ...workspaceStructured(workspace), ...lifecycleStructured(result) },
+      };
+    },
+  );
+  server.registerTool(
+    'close_task',
+    {
+      title: 'Close task',
+      description: 'Close owned work with an audited reason and expected task version.',
+      inputSchema: closeTaskInputShape,
+    },
+    (args) => {
+      const workspace = selectToolWorkspace(selectWorkspace, args.workspace_id);
+      const result = handleCloseTask(repos, args);
+      onWrite?.();
+      return {
+        content: [
+          { type: 'text', text: withWorkspaceText(lifecycleText('Closed', result), workspace) },
+        ],
+        structuredContent: { ...workspaceStructured(workspace), ...lifecycleStructured(result) },
+      };
+    },
+  );
+  server.registerTool(
+    'reopen_task',
+    {
+      title: 'Reopen task',
+      description:
+        'Reopen terminal, legacy handed-off, or review-ready work with an audited reason.',
+      inputSchema: reopenTaskInputShape,
+    },
+    (args) => {
+      const workspace = selectToolWorkspace(selectWorkspace, args.workspace_id);
+      const result = handleReopenTask(repos, args);
+      onWrite?.();
+      return {
+        content: [
+          { type: 'text', text: withWorkspaceText(lifecycleText('Reopened', result), workspace) },
         ],
         structuredContent: { ...workspaceStructured(workspace), ...lifecycleStructured(result) },
       };

--- a/test/tools/task-lifecycle.test.ts
+++ b/test/tools/task-lifecycle.test.ts
@@ -7,8 +7,10 @@ import { handleRegisterAgent } from '../../src/tools/register-agent.js';
 import {
   handleAcceptTask,
   handleAssignTask,
+  handleCloseTask,
   handleReassignTask,
   handleReleaseTask,
+  handleReopenTask,
 } from '../../src/tools/task-lifecycle.js';
 
 describe('versioned task lifecycle', () => {
@@ -137,6 +139,15 @@ describe('versioned task lifecycle', () => {
 
   it('requires ownership, or a same-human supervisor for forced reassignment', () => {
     expect(() =>
+      handleCloseTask(repos, {
+        task_id: 'TASK-1',
+        agent_id: 'codex:supervisor',
+        expected_version: 1,
+        reason: 'not the active owner',
+      }),
+    ).toThrow(/current owner/u);
+
+    expect(() =>
       handleReassignTask(repos, {
         task_id: 'TASK-1',
         to_agent_id: 'codex:target',
@@ -175,5 +186,53 @@ describe('versioned task lifecycle', () => {
     });
     expect(declined.task.status).toBe('active');
     expect(declined.task.agentId).toBe('codex:owner');
+  });
+
+  it('releases, closes, and reopens owned work with version checks', () => {
+    const released = handleReleaseTask(repos, {
+      task_id: 'TASK-1',
+      agent_id: 'codex:owner',
+      expected_version: 1,
+      reason: 'capacity',
+    });
+    expect(released.task.status).toBe('proposed');
+    expect(released.task.agentId).toBeNull();
+
+    const assigned = handleAssignTask(repos, {
+      task_id: 'TASK-1',
+      to_agent_id: 'codex:owner',
+      agent_id: 'codex:owner',
+      expected_version: 2,
+    });
+    const accepted = handleAcceptTask(repos, {
+      task_id: 'TASK-1',
+      agent_id: 'codex:owner',
+      expected_version: assigned.task.version,
+    });
+    const closed = handleCloseTask(repos, {
+      task_id: 'TASK-1',
+      agent_id: 'codex:owner',
+      expected_version: accepted.task.version,
+      reason: 'merged',
+    });
+    const reopened = handleReopenTask(repos, {
+      task_id: 'TASK-1',
+      agent_id: 'codex:owner',
+      expected_version: closed.task.version,
+      reason: 'regression',
+    });
+
+    expect(closed.task.status).toBe('closed');
+    expect(reopened.task.status).toBe('active');
+    expect(reopened.task.version).toBe(6);
+
+    const completed = handleCloseTask(repos, {
+      task_id: 'TASK-1',
+      agent_id: 'codex:owner',
+      expected_version: reopened.task.version,
+      reason: 'verified complete',
+      outcome: 'complete',
+    });
+    expect(completed.task.status).toBe('complete');
   });
 });


### PR DESCRIPTION
## Summary

- add audited `close_task` and `reopen_task` lifecycle tools
- distinguish terminal `complete` and `closed` outcomes
- require current ownership for close and owner/supervisor authority for reopen
- cover release, close, reopen, and version-conflict behavior

Part of #65.

Stacked on the assignment lifecycle PR. Merge and retarget in order; do not squash.

## Verification

- `pnpm typecheck`
- `pnpm test` — 24 files, 176 tests
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `git diff --check`
