### PR TITLE
Enforce ownership on task writes

### DIFF
--- a/src/tools/claim-work.ts
+++ b/src/tools/claim-work.ts
@@ -62,6 +62,19 @@ export function handleClaimWork(repos: Repositories, input: ClaimWorkInput): Cla
 
   const existing = repos.tasks.get(input.task_id);
 
+  if (input.agent_id !== undefined && repos.agents.get(input.agent_id) === undefined) {
+    throw new Error(`Agent ${input.agent_id} is not registered. Call register_agent first.`);
+  }
+  if (
+    existing?.agentId !== null &&
+    existing?.agentId !== undefined &&
+    input.agent_id !== existing.agentId
+  ) {
+    throw new Error(
+      `Task ${input.task_id} is owned by ${existing.agentId}; use offer_handoff or reassign_task.`,
+    );
+  }
+
   // Parent is set at first claim and preserved thereafter (identity is idempotent).
   const parentTaskId = existing ? existing.parentTaskId : (input.parent_task_id ?? null);
 
@@ -174,6 +187,10 @@ export function formatClaimWorkText(result: ClaimWorkResult): string {
  * overlap entries, so the payload is internally consistent. */
 export function toClaimWorkStructured(result: ClaimWorkResult): {
   task_id: string;
+  status: string;
+  version: number;
+  agent_id: string | null;
+  assigned_agent_id: string | null;
   parent_task_id: string | null;
   already_claimed: boolean;
   overlaps: { task_id: string; title: string; reasons: string[] }[];
@@ -183,6 +200,10 @@ export function toClaimWorkStructured(result: ClaimWorkResult): {
 } {
   return {
     task_id: result.task.taskId,
+    status: result.task.status,
+    version: result.task.version,
+    agent_id: result.task.agentId,
+    assigned_agent_id: result.task.assignedAgentId,
     parent_task_id: result.task.parentTaskId,
     already_claimed: result.alreadyClaimed,
     overlaps: result.overlaps.map((overlap) => ({

--- a/src/tools/get-task-context.ts
+++ b/src/tools/get-task-context.ts
@@ -2,6 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import type {
   HandoffRecord,
+  OwnershipEventRecord,
   Repositories,
   ReviewRecord,
   TaskRecord,
@@ -22,6 +23,8 @@ export interface TaskContextResult {
   latestHandoff: HandoffRecord | undefined;
   latestReview: ReviewRecord | undefined;
   overlaps: OverlapWarning[];
+  pendingHandoff: HandoffRecord | undefined;
+  ownershipHistory: OwnershipEventRecord[];
 }
 
 export function handleGetTaskContext(
@@ -58,6 +61,8 @@ export function handleGetTaskContext(
     latestHandoff: repos.handoffs.latestForTask(task.taskId),
     latestReview: repos.reviews.latestForTask(task.taskId),
     overlaps,
+    pendingHandoff: repos.handoffs.pendingForTask(task.taskId),
+    ownershipHistory: repos.ownershipEvents.listByTask(task.taskId),
   };
 }
 
@@ -79,14 +84,18 @@ function formatContext(result: TaskContextResult): string {
 
   return [
     `${result.task.taskId} — ${result.task.title}`,
-    `Status: ${result.task.status}`,
-    `Agent: ${result.task.agent ?? 'unassigned'}`,
+    `Status: ${result.task.status} (version ${String(result.task.version)})`,
+    `Owner agent: ${result.task.agentId ?? 'unassigned'}`,
+    `Assigned agent: ${result.task.assignedAgentId ?? 'none'}`,
+    `Lease expires: ${result.task.leaseExpiresAt ?? 'none'}`,
     `Notes: ${result.task.notes ?? 'not recorded'}`,
     'Updates:',
     updates,
     'Live overlaps:',
     overlaps,
     `Latest handoff: ${result.latestHandoff?.whatChanged ?? 'none'}`,
+    `Pending handoff: ${result.pendingHandoff === undefined ? 'none' : `${String(result.pendingHandoff.id)} to ${result.pendingHandoff.toAgentId ?? 'unknown'}`}`,
+    `Ownership transitions: ${String(result.ownershipHistory.length)}`,
     `Review plan: ${result.latestReview?.planSummary ?? 'not submitted'}`,
   ].join('\n');
 }
@@ -121,6 +130,8 @@ export function registerGetTaskContext(
           updates: result.updates,
           latest_handoff: result.latestHandoff ?? null,
           latest_review: result.latestReview ?? null,
+          pending_handoff: result.pendingHandoff ?? null,
+          ownership_history: result.ownershipHistory,
           overlaps: result.overlaps,
         },
       };

--- a/src/tools/handoff.ts
+++ b/src/tools/handoff.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
-import type { HandoffRecord, Repositories } from '../db/index.js';
+import type { HandoffRecord, Repositories, TaskRecord } from '../db/index.js';
 import { handoffInputShape, type HandoffInput } from '../domain/schemas.js';
 import { handleReviewReady } from './review-ready.js';
 import {
@@ -15,78 +15,86 @@ export interface HandoffResult {
   taskAutoCreated: boolean;
   /** True when `ready_for_review` was set, so a review packet was also produced. */
   reviewReady: boolean;
+  task: TaskRecord;
 }
 
 /**
- * Record a handoff for a task and mark the task handed off. If the task was
- * never claimed, a minimal stub task is created so the handoff is never lost
- * (the adoption tracker will still show that claim_work was skipped).
+ * Record completion/review evidence for an existing task. Ownership transfer
+ * is handled separately by offer_handoff/accept_handoff.
  */
 export function handleHandoff(repos: Repositories, input: HandoffInput): HandoffResult {
   const existing = repos.tasks.get(input.task_id);
-  const taskAutoCreated = existing === undefined;
   if (existing === undefined) {
-    repos.tasks.create({
-      taskId: input.task_id,
-      title: input.task_id,
-      owner: null,
-      agent: null,
-      branch: null,
-      worktree: null,
-      expectedFiles: input.changed_files ?? [],
-      modules: [],
-      domains: [],
-      riskTags: [],
-      notes: null,
-      parentTaskId: null,
-      agentId: input.agent_id ?? null,
-    });
+    throw new Error(`Task ${input.task_id} is not claimed. Call claim_work first.`);
+  }
+  if (input.agent_id !== undefined && repos.agents.get(input.agent_id) === undefined) {
+    throw new Error(`Agent ${input.agent_id} is not registered. Call register_agent first.`);
+  }
+  if (existing.agentId !== null && input.agent_id !== existing.agentId) {
+    throw new Error(
+      `Agent ${input.agent_id ?? '(missing)'} cannot record handoff evidence for ${input.task_id}; current owner is ${existing.agentId}.`,
+    );
+  }
+  if (
+    input.ready_for_review === true &&
+    existing.agentId !== null &&
+    input.expected_version === undefined
+  ) {
+    throw new Error(
+      `expected_version is required to mark owned task ${input.task_id} review-ready.`,
+    );
+  }
+  if (input.expected_version !== undefined && input.expected_version !== existing.version) {
+    throw new Error(
+      `Task ${input.task_id} version conflict: expected ${String(input.expected_version)}, current ${String(existing.version)}.`,
+    );
   }
 
-  const handoff = repos.handoffs.create({
-    taskId: input.task_id,
-    status: input.status,
-    changedFiles: input.changed_files ?? [],
-    whatChanged: input.what_changed,
-    testsRun: input.tests_run ?? [],
-    knownRisks: input.known_risks ?? [],
-    assumptions: input.assumptions ?? [],
-    decisions: input.decisions ?? [],
-    guardrailsChecked: input.guardrails_checked ?? [],
-    needsReviewFrom: input.needs_review_from ?? [],
-    nextSteps: input.next_steps ?? [],
-  });
-
-  repos.events.record({
-    taskId: input.task_id,
-    tool: 'handoff',
-    status: 'success',
-    detail: input.status,
-  });
-  if (input.agent_id !== undefined) {
-    repos.agents.touch(input.agent_id);
-  }
-
-  // Folding review_ready into handoff: when flagged, produce the review packet
-  // (and set status review_ready) via the shared review handler. Otherwise the
-  // task is simply handed off.
   const reviewReady = input.ready_for_review === true;
-  if (reviewReady) {
-    handleReviewReady(repos, {
-      task_id: input.task_id,
-      plan_summary: input.what_changed,
-      tests_run: input.tests_run,
-      diff_size: input.diff_size,
-      guardrails_checked: input.guardrails_checked,
-      assumptions: input.assumptions,
-      open_questions: input.open_questions,
-      provenance: input.provenance,
+  const transact = repos.db.transaction(() => {
+    const handoff = repos.handoffs.create({
+      taskId: input.task_id,
+      status: input.status,
+      changedFiles: input.changed_files ?? [],
+      whatChanged: input.what_changed,
+      testsRun: input.tests_run ?? [],
+      knownRisks: input.known_risks ?? [],
+      assumptions: input.assumptions ?? [],
+      decisions: input.decisions ?? [],
+      guardrailsChecked: input.guardrails_checked ?? [],
+      needsReviewFrom: input.needs_review_from ?? [],
+      nextSteps: input.next_steps ?? [],
     });
-  } else {
-    repos.tasks.updateStatus(input.task_id, 'handed_off');
-  }
-
-  return { handoff, taskAutoCreated, reviewReady };
+    repos.events.record({
+      taskId: input.task_id,
+      tool: 'handoff',
+      status: 'success',
+      detail: input.status,
+    });
+    if (input.agent_id !== undefined) {
+      repos.agents.touch(input.agent_id);
+    }
+    if (reviewReady) {
+      handleReviewReady(repos, {
+        task_id: input.task_id,
+        plan_summary: input.what_changed,
+        tests_run: input.tests_run,
+        diff_size: input.diff_size,
+        guardrails_checked: input.guardrails_checked,
+        assumptions: input.assumptions,
+        open_questions: input.open_questions,
+        provenance: input.provenance,
+        agent_id: input.agent_id,
+        expected_version: input.expected_version,
+      });
+    }
+    const task = repos.tasks.get(input.task_id);
+    if (task === undefined) {
+      throw new Error(`Task ${input.task_id} disappeared while evidence was recorded.`);
+    }
+    return { handoff, taskAutoCreated: false, reviewReady, task };
+  });
+  return transact();
 }
 
 export function formatHandoffText(result: HandoffResult): string {
@@ -116,8 +124,8 @@ export function registerHandoff(
     {
       title: 'Hand off work',
       description:
-        'Record a concise handoff when an agent finishes or is blocked: what changed, ' +
-        'tests run, assumptions, decisions, and guardrails checked. Call this before finishing. ' +
+        'Record completion/review evidence for owned work: what changed, tests, assumptions, ' +
+        'decisions, and guardrails. This does not transfer ownership; use offer_handoff for that. ' +
         'Set ready_for_review before a PR to also produce a review packet.',
       inputSchema: handoffInputShape,
     },
@@ -133,6 +141,9 @@ export function registerHandoff(
           handoff_id: result.handoff.id,
           task_auto_created: result.taskAutoCreated,
           review_ready: result.reviewReady,
+          status: result.task.status,
+          version: result.task.version,
+          agent_id: result.task.agentId,
         },
       };
     },

--- a/src/tools/review-ready.ts
+++ b/src/tools/review-ready.ts
@@ -13,49 +13,53 @@ function toProvenance(entries: ReviewReadyInput['provenance']): ProvenanceEntry[
 /**
  * Record a review packet for a task and mark the task review-ready. Invoked by
  * `handoff` when `ready_for_review` is set (review_ready is no longer a separate
- * tool). Auto-creates a stub task if the work was never claimed.
+ * tool). Authorization is checked by the owning handoff operation.
  */
 export function handleReviewReady(repos: Repositories, input: ReviewReadyInput): ReviewReadyResult {
   const existing = repos.tasks.get(input.task_id);
-  const taskAutoCreated = existing === undefined;
   if (existing === undefined) {
-    repos.tasks.create({
-      taskId: input.task_id,
-      title: input.task_id,
-      owner: null,
-      agent: null,
-      branch: null,
-      worktree: null,
-      expectedFiles: [],
-      modules: [],
-      domains: [],
-      riskTags: [],
-      notes: null,
-      parentTaskId: null,
-      agentId: null,
-    });
+    throw new Error(`Task ${input.task_id} is not claimed. Call claim_work first.`);
   }
 
-  const review = repos.reviews.create({
-    taskId: input.task_id,
-    planSummary: input.plan_summary,
-    testsRun: input.tests_run ?? [],
-    diffSize: input.diff_size ?? null,
-    guardrailsChecked: input.guardrails_checked ?? [],
-    assumptions: input.assumptions ?? [],
-    openQuestions: input.open_questions ?? [],
-    provenance: toProvenance(input.provenance),
+  if (input.expected_version !== undefined && input.expected_version !== existing.version) {
+    throw new Error(
+      `Task ${input.task_id} version conflict: expected ${String(input.expected_version)}, current ${String(existing.version)}.`,
+    );
+  }
+  const transact = repos.db.transaction(() => {
+    const review = repos.reviews.create({
+      taskId: input.task_id,
+      planSummary: input.plan_summary,
+      testsRun: input.tests_run ?? [],
+      diffSize: input.diff_size ?? null,
+      guardrailsChecked: input.guardrails_checked ?? [],
+      assumptions: input.assumptions ?? [],
+      openQuestions: input.open_questions ?? [],
+      provenance: toProvenance(input.provenance),
+    });
+    const updated =
+      input.expected_version === undefined
+        ? repos.tasks.updateStatus(input.task_id, 'review_ready')
+        : repos.tasks.transition({
+            taskId: input.task_id,
+            expectedVersion: input.expected_version,
+            status: 'review_ready',
+            agentId: existing.agentId,
+            assignedAgentId: null,
+            leaseExpiresAt: null,
+          });
+    if (updated === undefined) {
+      throw new Error(`Task ${input.task_id} changed while review evidence was recorded.`);
+    }
+    repos.events.record({
+      taskId: input.task_id,
+      tool: 'review_ready',
+      status: 'success',
+      detail: `${String(review.openQuestions.length)} open question(s)`,
+    });
+    return { review, taskAutoCreated: false };
   });
-
-  repos.tasks.updateStatus(input.task_id, 'review_ready');
-  repos.events.record({
-    taskId: input.task_id,
-    tool: 'review_ready',
-    status: 'success',
-    detail: `${String(review.openQuestions.length)} open question(s)`,
-  });
-
-  return { review, taskAutoCreated };
+  return transact();
 }
 
 export function formatReviewReadyText(result: ReviewReadyResult): string {

--- a/src/tools/update-task.ts
+++ b/src/tools/update-task.ts
@@ -19,12 +19,26 @@ export function handleUpdateTask(repos: Repositories, input: UpdateTaskInput): U
   if (task === undefined) {
     throw new Error(`Task ${input.task_id} is not claimed. Call claim_work first.`);
   }
+  if (input.agent_id !== undefined && repos.agents.get(input.agent_id) === undefined) {
+    throw new Error(`Agent ${input.agent_id} is not registered. Call register_agent first.`);
+  }
+  if (task.agentId !== null) {
+    if (input.agent_id === undefined) {
+      throw new Error(`Task ${input.task_id} is owned by ${task.agentId}; agent_id is required.`);
+    }
+    const collaborative = input.kind === 'question' || input.kind === 'finding';
+    if (!collaborative && input.agent_id !== task.agentId) {
+      throw new Error(
+        `Agent ${input.agent_id} cannot record ${input.kind} for ${input.task_id}; current owner is ${task.agentId}.`,
+      );
+    }
+  }
 
   const update = repos.taskUpdates.create({
     taskId: input.task_id,
     kind: input.kind,
     content: input.content,
-    agent: input.agent ?? task.agent,
+    agent: input.agent ?? input.agent_id ?? task.agent,
   });
   repos.events.record({
     taskId: input.task_id,

--- a/test/tools/claim-work.test.ts
+++ b/test/tools/claim-work.test.ts
@@ -7,6 +7,7 @@ import {
   handleClaimWork,
   toClaimWorkStructured,
 } from '../../src/tools/claim-work.js';
+import { handleRegisterAgent } from '../../src/tools/register-agent.js';
 
 describe('handleClaimWork', () => {
   let repos: Repositories;
@@ -51,6 +52,26 @@ describe('handleClaimWork', () => {
     expect(again.alreadyClaimed).toBe(true);
     expect(again.task.title).toBe('Retry');
     expect(repos.tasks.list()).toHaveLength(1);
+  });
+
+  it('rejects re-claiming scope owned by another registered agent', () => {
+    handleRegisterAgent(repos, { agent_id: 'codex:one', kind: 'codex' });
+    handleRegisterAgent(repos, { agent_id: 'codex:two', kind: 'codex' });
+    handleClaimWork(repos, {
+      task_id: 'TASK-OWNED',
+      title: 'Owned',
+      agent_id: 'codex:one',
+    });
+
+    expect(() =>
+      handleClaimWork(repos, {
+        task_id: 'TASK-OWNED',
+        title: 'Take over',
+        agent_id: 'codex:two',
+        modules: ['new-scope'],
+      }),
+    ).toThrow(/offer_handoff or reassign_task/u);
+    expect(repos.tasks.get('TASK-OWNED')?.modules).toEqual([]);
   });
 
   it('ignores non-active tasks when detecting overlaps', () => {

--- a/test/tools/get-work-state.test.ts
+++ b/test/tools/get-work-state.test.ts
@@ -80,6 +80,9 @@ describe('work-state MCP surface (end-to-end via in-memory transport)', () => {
       expect(tools.tools.map((t) => t.name)).toContain('get_work_state');
       expect(tools.tools.map((t) => t.name)).toContain('update_task');
       expect(tools.tools.map((t) => t.name)).toContain('get_task_context');
+      expect(tools.tools.map((t) => t.name)).toContain('assign_task');
+      expect(tools.tools.map((t) => t.name)).toContain('accept_task');
+      expect(tools.tools.map((t) => t.name)).toContain('close_task');
       expect(tools.tools.map((t) => t.name)).not.toContain('join_workspace');
 
       const resources = await client.listResources();
@@ -157,12 +160,6 @@ describe('work-state MCP surface (end-to-end via in-memory transport)', () => {
       });
       expect(JSON.stringify(joined)).toContain(workspaceIdForRoot(secondRoot));
 
-      const registered = await client.callTool({
-        name: 'register_agent',
-        arguments: { kind: 'test-agent' },
-      });
-      expect(JSON.stringify(registered)).toContain(workspaceIdForRoot(secondRoot));
-
       await client.callTool({
         name: 'claim_work',
         arguments: { task_id: 'SECOND', title: 'Second task' },
@@ -181,7 +178,7 @@ describe('work-state MCP surface (end-to-end via in-memory transport)', () => {
       });
       expect(JSON.stringify(secondState)).toContain('SECOND');
       expect(JSON.stringify(secondState)).not.toContain('FIRST');
-      expect(writtenRoots).toEqual([firstRoot, secondRoot, secondRoot]);
+      expect(writtenRoots).toEqual([firstRoot, secondRoot]);
     } finally {
       await client.close();
       await server.close();

--- a/test/tools/handoff.test.ts
+++ b/test/tools/handoff.test.ts
@@ -4,6 +4,7 @@ import { openDatabase } from '../../src/db/connection.js';
 import { createRepositories, type Repositories } from '../../src/db/index.js';
 import { handleClaimWork } from '../../src/tools/claim-work.js';
 import { formatHandoffText, handleHandoff } from '../../src/tools/handoff.js';
+import { handleRegisterAgent } from '../../src/tools/register-agent.js';
 
 describe('handleHandoff', () => {
   let repos: Repositories;
@@ -11,7 +12,7 @@ describe('handleHandoff', () => {
     repos = createRepositories(openDatabase(':memory:'));
   });
 
-  it('records a handoff for a claimed task and marks it handed off', () => {
+  it('records evidence without transferring ownership or changing task status', () => {
     handleClaimWork(repos, { task_id: 'TASK-12', title: 'Retry', modules: ['billing'] });
     const result = handleHandoff(repos, {
       task_id: 'TASK-12',
@@ -24,7 +25,7 @@ describe('handleHandoff', () => {
 
     expect(result.taskAutoCreated).toBe(false);
     expect(result.handoff.whatChanged).toBe('Queued retries instead of synchronous');
-    expect(repos.tasks.get('TASK-12')?.status).toBe('handed_off');
+    expect(repos.tasks.get('TASK-12')?.status).toBe('active');
     expect(repos.handoffs.latestForTask('TASK-12')?.status).toBe('done');
     expect(repos.events.listByTask('TASK-12').map((e) => e.tool)).toEqual([
       'claim_work',
@@ -32,18 +33,18 @@ describe('handleHandoff', () => {
     ]);
   });
 
-  it('auto-creates a stub task when handing off an unclaimed task', () => {
-    const result = handleHandoff(repos, {
-      task_id: 'TASK-99',
-      status: 'blocked',
-      what_changed: 'Started but blocked on API keys',
-    });
-    expect(result.taskAutoCreated).toBe(true);
-    expect(repos.tasks.get('TASK-99')?.status).toBe('handed_off');
-    expect(formatHandoffText(result)).toContain('created a stub task');
+  it('rejects evidence for an unclaimed task', () => {
+    expect(() =>
+      handleHandoff(repos, {
+        task_id: 'TASK-99',
+        status: 'blocked',
+        what_changed: 'Started but blocked on API keys',
+      }),
+    ).toThrow(/not claimed/u);
   });
 
   it('formats needs-review recipients', () => {
+    handleClaimWork(repos, { task_id: 'TASK-1', title: 'Review recipients' });
     const result = handleHandoff(repos, {
       task_id: 'TASK-1',
       status: 'done',
@@ -85,7 +86,55 @@ describe('handleHandoff', () => {
     handleClaimWork(repos, { task_id: 'TASK-12', title: 'Retry' });
     const result = handleHandoff(repos, { task_id: 'TASK-12', status: 'done', what_changed: 'x' });
     expect(result.reviewReady).toBe(false);
-    expect(repos.tasks.get('TASK-12')?.status).toBe('handed_off');
+    expect(repos.tasks.get('TASK-12')?.status).toBe('active');
     expect(repos.reviews.latestForTask('TASK-12')).toBeUndefined();
+  });
+
+  it('prevents an unrelated agent from recording owner evidence', () => {
+    handleRegisterAgent(repos, { agent_id: 'codex:owner', kind: 'codex' });
+    handleRegisterAgent(repos, { agent_id: 'codex:other', kind: 'codex' });
+    handleClaimWork(repos, {
+      task_id: 'TASK-OWNED',
+      title: 'Owned',
+      agent_id: 'codex:owner',
+    });
+    expect(() =>
+      handleHandoff(repos, {
+        task_id: 'TASK-OWNED',
+        status: 'done',
+        what_changed: 'not mine',
+        agent_id: 'codex:other',
+      }),
+    ).toThrow(/current owner/u);
+  });
+
+  it('requires the current version for an owned review-ready transition', () => {
+    handleRegisterAgent(repos, { agent_id: 'codex:owner', kind: 'codex' });
+    handleClaimWork(repos, {
+      task_id: 'TASK-REVIEW',
+      title: 'Review',
+      agent_id: 'codex:owner',
+    });
+    expect(() =>
+      handleHandoff(repos, {
+        task_id: 'TASK-REVIEW',
+        status: 'done',
+        what_changed: 'ready',
+        agent_id: 'codex:owner',
+        ready_for_review: true,
+      }),
+    ).toThrow(/expected_version is required/u);
+    expect(repos.handoffs.latestForTask('TASK-REVIEW')).toBeUndefined();
+
+    const result = handleHandoff(repos, {
+      task_id: 'TASK-REVIEW',
+      status: 'done',
+      what_changed: 'ready',
+      agent_id: 'codex:owner',
+      expected_version: 1,
+      ready_for_review: true,
+    });
+    expect(result.reviewReady).toBe(true);
+    expect(repos.tasks.get('TASK-REVIEW')?.version).toBe(2);
   });
 });

--- a/test/tools/register-agent.test.ts
+++ b/test/tools/register-agent.test.ts
@@ -98,10 +98,10 @@ describe('presence refresh through write tools', () => {
     expect(repos.agents.list()).toHaveLength(1);
   });
 
-  it('a write with an unregistered agent_id is a safe no-op (no throw, no ghost row)', () => {
+  it('rejects a write with an unregistered agent_id and creates no ghost row', () => {
     expect(() =>
       handleClaimWork(repos, { task_id: 'TASK-2', title: 'Work', agent_id: 'ghost:zzzz' }),
-    ).not.toThrow();
+    ).toThrow(/not registered/u);
     expect(repos.agents.get('ghost:zzzz')).toBeUndefined();
     expect(repos.agents.list()).toHaveLength(1);
   });
@@ -119,8 +119,35 @@ describe('presence refresh through write tools', () => {
       status: 'done',
       what_changed: 'finished',
       agent_id: 'claude-code:7p8v',
+      expected_version: 1,
     });
     expect(repos.agents.get('claude-code:7p8v')).toBeDefined();
     expect(repos.agents.list()).toHaveLength(1);
+  });
+
+  it('allows collaborative findings but protects owner-only task updates', () => {
+    handleRegisterAgent(repos, { agent_id: 'codex:other', kind: 'codex' });
+    handleClaimWork(repos, {
+      task_id: 'TASK-4',
+      title: 'Owned work',
+      agent_id: 'claude-code:7p8v',
+    });
+
+    expect(() =>
+      handleUpdateTask(repos, {
+        task_id: 'TASK-4',
+        kind: 'progress',
+        content: 'pretend progress',
+        agent_id: 'codex:other',
+      }),
+    ).toThrow(/current owner/u);
+    expect(() =>
+      handleUpdateTask(repos, {
+        task_id: 'TASK-4',
+        kind: 'finding',
+        content: 'related API behavior',
+        agent_id: 'codex:other',
+      }),
+    ).not.toThrow();
   });
 });

--- a/test/tools/review-ready.test.ts
+++ b/test/tools/review-ready.test.ts
@@ -40,17 +40,18 @@ describe('handleReviewReady', () => {
     ]);
   });
 
-  it('auto-creates a stub task when marking an unclaimed task review-ready', () => {
-    const result = handleReviewReady(repos, { task_id: 'TASK-77', plan_summary: 'Small fix' });
-    expect(result.taskAutoCreated).toBe(true);
-    expect(repos.tasks.get('TASK-77')?.status).toBe('review_ready');
-    expect(formatReviewReadyText(result)).toContain('review-ready');
+  it('rejects review evidence for an unclaimed task', () => {
+    expect(() =>
+      handleReviewReady(repos, { task_id: 'TASK-77', plan_summary: 'Small fix' }),
+    ).toThrow(/not claimed/u);
   });
 
   it('defaults array and diff fields when omitted', () => {
+    handleClaimWork(repos, { task_id: 'TASK-1', title: 'Defaults' });
     const result = handleReviewReady(repos, { task_id: 'TASK-1', plan_summary: 'x' });
     expect(result.review.testsRun).toEqual([]);
     expect(result.review.provenance).toEqual([]);
     expect(result.review.diffSize).toBeNull();
+    expect(formatReviewReadyText(result)).toContain('review-ready');
   });
 });


### PR DESCRIPTION
## Summary

- enforce registered-agent ownership on existing task write tools
- require current task versions for handoff and review-ready transitions
- expose pending delivery and ownership history in task context
- retain compatibility coverage for claims, registration, handoff, and review packets

Part of #65.

Stacked on the terminal lifecycle PR. Merge and retarget in order; do not squash.

## Verification

- `pnpm typecheck`
- `pnpm test` — 24 files, 180 tests
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `git diff --check`
