### PR TITLE
Add acknowledged handoff delivery

### DIFF
--- a/src/domain/schemas.ts
+++ b/src/domain/schemas.ts
@@ -268,3 +268,43 @@ export const reopenTaskInputShape = {
 } as const;
 export const reopenTaskInputSchema = z.object(reopenTaskInputShape);
 export type ReopenTaskInput = z.infer<typeof reopenTaskInputSchema>;
+
+export const offerHandoffInputShape = {
+  task_id: z.string().min(1),
+  to_agent_id: z.string().min(1),
+  agent_id: lifecycleActorField,
+  expected_version: taskVersionField,
+  what_changed: z.string().min(1),
+  changed_files: z.array(z.string()).optional(),
+  tests_run: z.array(z.string()).optional(),
+  known_risks: z.array(z.string()).optional(),
+  assumptions: z.array(z.string()).optional(),
+  decisions: z.array(z.string()).optional(),
+  guardrails_checked: z.array(z.string()).optional(),
+  next_steps: z.array(z.string()).optional(),
+  expires_seconds: z.number().int().positive().optional(),
+  workspace_id: workspaceIdField,
+} as const;
+export const offerHandoffInputSchema = z.object(offerHandoffInputShape);
+export type OfferHandoffInput = z.infer<typeof offerHandoffInputSchema>;
+
+export const acceptHandoffInputShape = {
+  task_id: z.string().min(1),
+  handoff_id: z.number().int().positive(),
+  agent_id: lifecycleActorField,
+  expected_version: taskVersionField,
+  workspace_id: workspaceIdField,
+} as const;
+export const acceptHandoffInputSchema = z.object(acceptHandoffInputShape);
+export type AcceptHandoffInput = z.infer<typeof acceptHandoffInputSchema>;
+
+export const declineHandoffInputShape = {
+  task_id: z.string().min(1),
+  handoff_id: z.number().int().positive(),
+  agent_id: lifecycleActorField,
+  expected_version: taskVersionField,
+  reason: z.string().min(1),
+  workspace_id: workspaceIdField,
+} as const;
+export const declineHandoffInputSchema = z.object(declineHandoffInputShape);
+export type DeclineHandoffInput = z.infer<typeof declineHandoffInputSchema>;

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import { registerClaimWork } from './tools/claim-work.js';
 import { registerGetTaskContext } from './tools/get-task-context.js';
 import { registerWorkState } from './tools/get-work-state.js';
 import { registerHandoff } from './tools/handoff.js';
+import { registerHandoffLifecycle } from './tools/handoff-lifecycle.js';
 import { registerJoinWorkspace } from './tools/join-workspace.js';
 import { registerRegisterAgent } from './tools/register-agent.js';
 import { registerUpdateTask } from './tools/update-task.js';
@@ -52,5 +53,6 @@ export function createServer(repos: Repositories, options: ServerOptions = {}): 
   registerUpdateTask(server, selectedRepos, onWrite, selectWorkspace);
   registerHandoff(server, selectedRepos, onWrite, selectWorkspace);
   registerTaskLifecycle(server, selectedRepos, onWrite, selectWorkspace);
+  registerHandoffLifecycle(server, selectedRepos, onWrite, selectWorkspace);
   return server;
 }

--- a/src/tools/handoff-lifecycle.ts
+++ b/src/tools/handoff-lifecycle.ts
@@ -1,0 +1,361 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import type {
+  HandoffDeliveryStatus,
+  HandoffRecord,
+  OwnershipEventRecord,
+  Repositories,
+  TaskRecord,
+} from '../db/index.js';
+import {
+  acceptHandoffInputShape,
+  type AcceptHandoffInput,
+  declineHandoffInputShape,
+  type DeclineHandoffInput,
+  offerHandoffInputShape,
+  type OfferHandoffInput,
+} from '../domain/schemas.js';
+import {
+  selectToolWorkspace,
+  type SelectWorkspace,
+  workspaceStructured,
+  withWorkspaceText,
+} from './workspace-routing.js';
+
+export interface HandoffLifecycleResult {
+  task: TaskRecord;
+  handoff: HandoffRecord;
+  ownershipEvent: OwnershipEventRecord;
+}
+
+function requireRegistered(repos: Repositories, agentId: string): void {
+  if (repos.agents.get(agentId) === undefined) {
+    throw new Error(`Agent ${agentId} is not registered. Call register_agent first.`);
+  }
+}
+
+function taskAtVersion(repos: Repositories, taskId: string, expectedVersion: number): TaskRecord {
+  const task = repos.tasks.get(taskId);
+  if (task === undefined) {
+    throw new Error(`Task ${taskId} is not claimed.`);
+  }
+  if (task.version !== expectedVersion) {
+    throw new Error(
+      `Task ${taskId} version conflict: expected ${String(expectedVersion)}, current ${String(task.version)}.`,
+    );
+  }
+  return task;
+}
+
+function pendingHandoff(repos: Repositories, taskId: string, handoffId: number): HandoffRecord {
+  const handoff = repos.handoffs.get(handoffId);
+  if (handoff?.taskId !== taskId || handoff.deliveryStatus !== 'pending') {
+    throw new Error(`Pending handoff ${String(handoffId)} for ${taskId} was not found.`);
+  }
+  return handoff;
+}
+
+function recordOwnership(
+  repos: Repositories,
+  before: TaskRecord,
+  after: TaskRecord,
+  transition: string,
+  actorAgentId: string,
+  toAgentId: string | null,
+  reason: string | null,
+): OwnershipEventRecord {
+  return repos.ownershipEvents.record({
+    taskId: before.taskId,
+    transition,
+    actorAgentId,
+    fromAgentId: before.agentId,
+    toAgentId,
+    fromStatus: before.status,
+    toStatus: after.status,
+    fromVersion: before.version,
+    toVersion: after.version,
+    reason,
+  });
+}
+
+export function handleOfferHandoff(
+  repos: Repositories,
+  input: OfferHandoffInput,
+  now: number = Date.now(),
+): HandoffLifecycleResult {
+  requireRegistered(repos, input.agent_id);
+  requireRegistered(repos, input.to_agent_id);
+  const task = taskAtVersion(repos, input.task_id, input.expected_version);
+  if (task.agentId !== input.agent_id) {
+    throw new Error(
+      `Agent ${input.agent_id} cannot offer ${task.taskId}; current owner is ${task.agentId ?? 'unassigned'}.`,
+    );
+  }
+  if (task.status !== 'active' && task.status !== 'blocked') {
+    throw new Error(
+      `Task ${task.taskId} is ${task.status}; only active or blocked work can be offered.`,
+    );
+  }
+  if (repos.handoffs.pendingForTask(task.taskId) !== undefined) {
+    throw new Error(`Task ${task.taskId} already has a pending handoff.`);
+  }
+  const expiresAt =
+    input.expires_seconds === undefined
+      ? null
+      : new Date(now + input.expires_seconds * 1000).toISOString();
+
+  const transact = repos.db.transaction(() => {
+    const updated = repos.tasks.transition({
+      taskId: task.taskId,
+      expectedVersion: task.version,
+      status: 'handoff_offered',
+      agentId: task.agentId,
+      assignedAgentId: input.to_agent_id,
+      leaseExpiresAt: expiresAt,
+    });
+    if (updated === undefined) {
+      throw new Error(`Task ${task.taskId} changed while the handoff was being offered.`);
+    }
+    const handoff = repos.handoffs.create({
+      taskId: task.taskId,
+      status: 'in_progress',
+      changedFiles: input.changed_files ?? [],
+      whatChanged: input.what_changed,
+      testsRun: input.tests_run ?? [],
+      knownRisks: input.known_risks ?? [],
+      assumptions: input.assumptions ?? [],
+      decisions: input.decisions ?? [],
+      guardrailsChecked: input.guardrails_checked ?? [],
+      needsReviewFrom: [],
+      nextSteps: input.next_steps ?? [],
+      fromAgentId: input.agent_id,
+      toAgentId: input.to_agent_id,
+      deliveryStatus: 'pending',
+      expiresAt,
+      taskVersion: updated.version,
+    });
+    const ownershipEvent = recordOwnership(
+      repos,
+      task,
+      updated,
+      'offer_handoff',
+      input.agent_id,
+      input.to_agent_id,
+      null,
+    );
+    repos.events.record({
+      taskId: task.taskId,
+      tool: 'offer_handoff',
+      status: 'success',
+      detail: `handoff ${String(handoff.id)} to ${input.to_agent_id}`,
+    });
+    repos.agents.touch(input.agent_id);
+    return { task: updated, handoff, ownershipEvent };
+  });
+  return transact();
+}
+
+function resolveHandoff(
+  repos: Repositories,
+  task: TaskRecord,
+  handoff: HandoffRecord,
+  actorAgentId: string,
+  deliveryStatus: Exclude<HandoffDeliveryStatus, 'recorded' | 'pending'>,
+  newOwner: string,
+  transition: 'accept_handoff' | 'decline_handoff' | 'expire_handoff',
+  reason: string | null,
+): HandoffLifecycleResult {
+  const transact = repos.db.transaction(() => {
+    const updated = repos.tasks.transition({
+      taskId: task.taskId,
+      expectedVersion: task.version,
+      status: 'active',
+      agentId: newOwner,
+      assignedAgentId: null,
+      leaseExpiresAt: null,
+    });
+    if (updated === undefined) {
+      throw new Error(`Task ${task.taskId} changed while handoff ${String(handoff.id)} resolved.`);
+    }
+    const resolved = repos.handoffs.resolve(handoff.id, deliveryStatus, reason);
+    if (resolved === undefined) {
+      throw new Error(`Handoff ${String(handoff.id)} was already resolved.`);
+    }
+    const ownershipEvent = recordOwnership(
+      repos,
+      task,
+      updated,
+      transition,
+      actorAgentId,
+      newOwner,
+      reason,
+    );
+    repos.events.record({
+      taskId: task.taskId,
+      tool: transition,
+      status: 'success',
+      detail: `handoff ${String(handoff.id)} ${deliveryStatus}`,
+    });
+    repos.agents.touch(actorAgentId);
+    return { task: updated, handoff: resolved, ownershipEvent };
+  });
+  return transact();
+}
+
+function expireHandoff(
+  repos: Repositories,
+  task: TaskRecord,
+  handoff: HandoffRecord,
+  actorAgentId: string,
+): HandoffLifecycleResult {
+  return resolveHandoff(
+    repos,
+    task,
+    handoff,
+    actorAgentId,
+    'expired',
+    handoff.fromAgentId ?? task.agentId ?? '',
+    'expire_handoff',
+    'handoff expired',
+  );
+}
+
+export function handleAcceptHandoff(
+  repos: Repositories,
+  input: AcceptHandoffInput,
+  now: number = Date.now(),
+): HandoffLifecycleResult {
+  requireRegistered(repos, input.agent_id);
+  const task = taskAtVersion(repos, input.task_id, input.expected_version);
+  const handoff = pendingHandoff(repos, input.task_id, input.handoff_id);
+  if (handoff.toAgentId !== input.agent_id) {
+    throw new Error(`Handoff ${String(handoff.id)} is not addressed to ${input.agent_id}.`);
+  }
+  if (handoff.expiresAt !== null && Date.parse(handoff.expiresAt) <= now) {
+    return expireHandoff(repos, task, handoff, input.agent_id);
+  }
+  return resolveHandoff(
+    repos,
+    task,
+    handoff,
+    input.agent_id,
+    'accepted',
+    input.agent_id,
+    'accept_handoff',
+    null,
+  );
+}
+
+export function handleDeclineHandoff(
+  repos: Repositories,
+  input: DeclineHandoffInput,
+): HandoffLifecycleResult {
+  requireRegistered(repos, input.agent_id);
+  const task = taskAtVersion(repos, input.task_id, input.expected_version);
+  const handoff = pendingHandoff(repos, input.task_id, input.handoff_id);
+  if (handoff.toAgentId !== input.agent_id) {
+    throw new Error(`Handoff ${String(handoff.id)} is not addressed to ${input.agent_id}.`);
+  }
+  if (handoff.fromAgentId === null) {
+    throw new Error(`Handoff ${String(handoff.id)} has no recorded sender.`);
+  }
+  return resolveHandoff(
+    repos,
+    task,
+    handoff,
+    input.agent_id,
+    'declined',
+    handoff.fromAgentId,
+    'decline_handoff',
+    input.reason,
+  );
+}
+
+function handoffText(action: string, result: HandoffLifecycleResult): string {
+  return `${action} handoff ${String(result.handoff.id)} for ${result.task.taskId}; status ${result.task.status}, version ${String(result.task.version)}.`;
+}
+
+function handoffStructured(result: HandoffLifecycleResult): Record<string, unknown> {
+  return {
+    task_id: result.task.taskId,
+    task_status: result.task.status,
+    version: result.task.version,
+    agent_id: result.task.agentId,
+    assigned_agent_id: result.task.assignedAgentId,
+    handoff_id: result.handoff.id,
+    delivery_status: result.handoff.deliveryStatus,
+    from_agent_id: result.handoff.fromAgentId,
+    to_agent_id: result.handoff.toAgentId,
+    expires_at: result.handoff.expiresAt,
+    ownership_event_id: result.ownershipEvent.id,
+  };
+}
+
+export function registerHandoffLifecycle(
+  server: McpServer,
+  repos: Repositories,
+  onWrite?: () => void,
+  selectWorkspace?: SelectWorkspace,
+): void {
+  server.registerTool(
+    'offer_handoff',
+    {
+      title: 'Offer handoff',
+      description:
+        'Offer owned active/blocked work to a registered recipient with evidence. Ownership stays with the sender until acceptance.',
+      inputSchema: offerHandoffInputShape,
+    },
+    (args) => {
+      const workspace = selectToolWorkspace(selectWorkspace, args.workspace_id);
+      const result = handleOfferHandoff(repos, args);
+      onWrite?.();
+      return {
+        content: [
+          { type: 'text', text: withWorkspaceText(handoffText('Offered', result), workspace) },
+        ],
+        structuredContent: { ...workspaceStructured(workspace), ...handoffStructured(result) },
+      };
+    },
+  );
+  server.registerTool(
+    'accept_handoff',
+    {
+      title: 'Accept handoff',
+      description:
+        'Accept a pending handoff addressed to this registered agent and atomically become owner.',
+      inputSchema: acceptHandoffInputShape,
+    },
+    (args) => {
+      const workspace = selectToolWorkspace(selectWorkspace, args.workspace_id);
+      const result = handleAcceptHandoff(repos, args);
+      onWrite?.();
+      const action = result.handoff.deliveryStatus === 'expired' ? 'Expired' : 'Accepted';
+      return {
+        content: [
+          { type: 'text', text: withWorkspaceText(handoffText(action, result), workspace) },
+        ],
+        structuredContent: { ...workspaceStructured(workspace), ...handoffStructured(result) },
+      };
+    },
+  );
+  server.registerTool(
+    'decline_handoff',
+    {
+      title: 'Decline handoff',
+      description:
+        'Decline a pending handoff addressed to this registered agent and return it to the sender.',
+      inputSchema: declineHandoffInputShape,
+    },
+    (args) => {
+      const workspace = selectToolWorkspace(selectWorkspace, args.workspace_id);
+      const result = handleDeclineHandoff(repos, args);
+      onWrite?.();
+      return {
+        content: [
+          { type: 'text', text: withWorkspaceText(handoffText('Declined', result), workspace) },
+        ],
+        structuredContent: { ...workspaceStructured(workspace), ...handoffStructured(result) },
+      };
+    },
+  );
+}

--- a/test/tools/get-work-state.test.ts
+++ b/test/tools/get-work-state.test.ts
@@ -82,6 +82,8 @@ describe('work-state MCP surface (end-to-end via in-memory transport)', () => {
       expect(tools.tools.map((t) => t.name)).toContain('get_task_context');
       expect(tools.tools.map((t) => t.name)).toContain('assign_task');
       expect(tools.tools.map((t) => t.name)).toContain('accept_task');
+      expect(tools.tools.map((t) => t.name)).toContain('offer_handoff');
+      expect(tools.tools.map((t) => t.name)).toContain('accept_handoff');
       expect(tools.tools.map((t) => t.name)).toContain('close_task');
       expect(tools.tools.map((t) => t.name)).not.toContain('join_workspace');
 

--- a/test/tools/handoff-lifecycle.test.ts
+++ b/test/tools/handoff-lifecycle.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { openDatabase } from '../../src/db/connection.js';
+import { createRepositories, type Repositories } from '../../src/db/index.js';
+import { handleClaimWork } from '../../src/tools/claim-work.js';
+import {
+  handleAcceptHandoff,
+  handleDeclineHandoff,
+  handleOfferHandoff,
+} from '../../src/tools/handoff-lifecycle.js';
+import { handleRegisterAgent } from '../../src/tools/register-agent.js';
+
+describe('acknowledged handoff lifecycle', () => {
+  let repos: Repositories;
+
+  beforeEach(() => {
+    repos = createRepositories(openDatabase(':memory:'));
+    for (const agentId of ['codex:from', 'codex:to', 'codex:other']) {
+      handleRegisterAgent(repos, { agent_id: agentId, kind: 'codex' });
+    }
+    handleClaimWork(repos, {
+      task_id: 'TASK-1',
+      title: 'Transfer work',
+      agent_id: 'codex:from',
+    });
+  });
+
+  it('keeps ownership with the sender until the named recipient accepts', () => {
+    const offered = handleOfferHandoff(repos, {
+      task_id: 'TASK-1',
+      to_agent_id: 'codex:to',
+      agent_id: 'codex:from',
+      expected_version: 1,
+      what_changed: 'implemented parser',
+      tests_run: ['pnpm test parser'],
+    });
+    expect(offered.task.status).toBe('handoff_offered');
+    expect(offered.task.agentId).toBe('codex:from');
+    expect(offered.task.assignedAgentId).toBe('codex:to');
+    expect(offered.handoff.deliveryStatus).toBe('pending');
+
+    const accepted = handleAcceptHandoff(repos, {
+      task_id: 'TASK-1',
+      handoff_id: offered.handoff.id,
+      agent_id: 'codex:to',
+      expected_version: 2,
+    });
+    expect(accepted.handoff.deliveryStatus).toBe('accepted');
+    expect(accepted.task.status).toBe('active');
+    expect(accepted.task.agentId).toBe('codex:to');
+    expect(accepted.task.version).toBe(3);
+    expect(repos.ownershipEvents.listByTask('TASK-1').map((event) => event.transition)).toEqual([
+      'offer_handoff',
+      'accept_handoff',
+    ]);
+  });
+
+  it('rejects offers by non-owners and acceptance by the wrong recipient', () => {
+    expect(() =>
+      handleOfferHandoff(repos, {
+        task_id: 'TASK-1',
+        to_agent_id: 'codex:to',
+        agent_id: 'codex:other',
+        expected_version: 1,
+        what_changed: 'not mine',
+      }),
+    ).toThrow(/current owner/u);
+
+    const offered = handleOfferHandoff(repos, {
+      task_id: 'TASK-1',
+      to_agent_id: 'codex:to',
+      agent_id: 'codex:from',
+      expected_version: 1,
+      what_changed: 'ready',
+    });
+    expect(() =>
+      handleAcceptHandoff(repos, {
+        task_id: 'TASK-1',
+        handoff_id: offered.handoff.id,
+        agent_id: 'codex:other',
+        expected_version: 2,
+      }),
+    ).toThrow(/not addressed/u);
+  });
+
+  it('declines back to the sender and prevents a later acceptance', () => {
+    const offered = handleOfferHandoff(repos, {
+      task_id: 'TASK-1',
+      to_agent_id: 'codex:to',
+      agent_id: 'codex:from',
+      expected_version: 1,
+      what_changed: 'ready',
+    });
+    const declined = handleDeclineHandoff(repos, {
+      task_id: 'TASK-1',
+      handoff_id: offered.handoff.id,
+      agent_id: 'codex:to',
+      expected_version: 2,
+      reason: 'no capacity',
+    });
+    expect(declined.handoff.deliveryStatus).toBe('declined');
+    expect(declined.task.agentId).toBe('codex:from');
+    expect(declined.ownershipEvent.reason).toBe('no capacity');
+
+    expect(() =>
+      handleAcceptHandoff(repos, {
+        task_id: 'TASK-1',
+        handoff_id: offered.handoff.id,
+        agent_id: 'codex:to',
+        expected_version: 3,
+      }),
+    ).toThrow(/Pending handoff/u);
+  });
+
+  it('expires a pending offer and restores the sender', () => {
+    const offered = handleOfferHandoff(
+      repos,
+      {
+        task_id: 'TASK-1',
+        to_agent_id: 'codex:to',
+        agent_id: 'codex:from',
+        expected_version: 1,
+        what_changed: 'ready briefly',
+        expires_seconds: 1,
+      },
+      1_000,
+    );
+    const expired = handleAcceptHandoff(
+      repos,
+      {
+        task_id: 'TASK-1',
+        handoff_id: offered.handoff.id,
+        agent_id: 'codex:to',
+        expected_version: 2,
+      },
+      2_000,
+    );
+
+    expect(expired.handoff.deliveryStatus).toBe('expired');
+    expect(expired.task.status).toBe('active');
+    expect(expired.task.agentId).toBe('codex:from');
+    expect(expired.ownershipEvent.transition).toBe('expire_handoff');
+  });
+
+  it('allows only one resolution for a pending handoff version', () => {
+    const offered = handleOfferHandoff(repos, {
+      task_id: 'TASK-1',
+      to_agent_id: 'codex:to',
+      agent_id: 'codex:from',
+      expected_version: 1,
+      what_changed: 'ready',
+    });
+    handleAcceptHandoff(repos, {
+      task_id: 'TASK-1',
+      handoff_id: offered.handoff.id,
+      agent_id: 'codex:to',
+      expected_version: 2,
+    });
+
+    expect(() =>
+      handleDeclineHandoff(repos, {
+        task_id: 'TASK-1',
+        handoff_id: offered.handoff.id,
+        agent_id: 'codex:to',
+        expected_version: 2,
+        reason: 'too late',
+      }),
+    ).toThrow(/version conflict/u);
+  });
+});


### PR DESCRIPTION
## Summary

- add `offer_handoff`, `accept_handoff`, and `decline_handoff`
- keep ownership with the sender until the named recipient accepts
- support audited decline and lease expiry without silently losing ownership
- reject wrong recipients and stale task versions

Part of #65.

Stacked on the ownership-authorization PR. Merge and retarget in order; do not squash.

## Verification

- `pnpm typecheck`
- `pnpm test` — 25 files, 185 tests
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `git diff --check`
