### PR TITLE
Add explicit task assignment lifecycle

### DIFF
--- a/src/domain/schemas.ts
+++ b/src/domain/schemas.ts
@@ -28,6 +28,12 @@ export const workspaceIdField = z
     'Workspace id returned by join_workspace. Omit to use the active/default workspace for this MCP session.',
   );
 
+const taskVersionField = z
+  .number()
+  .int()
+  .positive()
+  .describe('Task version last read by the caller; stale versions are rejected');
+
 export const joinWorkspaceInputShape = {
   root: z
     .string()
@@ -163,6 +169,7 @@ export const handoffInputShape = {
     .optional()
     .describe('Where each claim came from, e.g. { field: "tests", source: "command output" }'),
   agent_id: agentIdField,
+  expected_version: taskVersionField.optional(),
   workspace_id: workspaceIdField,
 } as const;
 
@@ -181,8 +188,59 @@ export const reviewReadyInputShape = {
     .array(z.object({ field: z.string(), source: z.string() }))
     .optional()
     .describe('Where each claim came from, e.g. { field: "tests", source: "command output" }'),
+  agent_id: agentIdField,
+  expected_version: taskVersionField.optional(),
   workspace_id: workspaceIdField,
 } as const;
 
 export const reviewReadyInputSchema = z.object(reviewReadyInputShape);
 export type ReviewReadyInput = z.infer<typeof reviewReadyInputSchema>;
+
+const lifecycleActorField = z
+  .string()
+  .min(1)
+  .describe('Registered agent_id performing this lifecycle transition');
+
+export const assignTaskInputShape = {
+  task_id: z.string().min(1),
+  to_agent_id: z.string().min(1).describe('Registered agent receiving the assignment'),
+  agent_id: lifecycleActorField,
+  expected_version: taskVersionField,
+  lease_seconds: z.number().int().positive().optional(),
+  reason: z.string().min(1).optional(),
+  workspace_id: workspaceIdField,
+} as const;
+export const assignTaskInputSchema = z.object(assignTaskInputShape);
+export type AssignTaskInput = z.infer<typeof assignTaskInputSchema>;
+
+export const acceptTaskInputShape = {
+  task_id: z.string().min(1),
+  agent_id: lifecycleActorField,
+  expected_version: taskVersionField,
+  workspace_id: workspaceIdField,
+} as const;
+export const acceptTaskInputSchema = z.object(acceptTaskInputShape);
+export type AcceptTaskInput = z.infer<typeof acceptTaskInputSchema>;
+
+export const releaseTaskInputShape = {
+  task_id: z.string().min(1),
+  agent_id: lifecycleActorField,
+  expected_version: taskVersionField,
+  reason: z.string().min(1).optional(),
+  workspace_id: workspaceIdField,
+} as const;
+export const releaseTaskInputSchema = z.object(releaseTaskInputShape);
+export type ReleaseTaskInput = z.infer<typeof releaseTaskInputSchema>;
+
+export const reassignTaskInputShape = {
+  task_id: z.string().min(1),
+  to_agent_id: z.string().min(1),
+  agent_id: lifecycleActorField,
+  expected_version: taskVersionField,
+  lease_seconds: z.number().int().positive().optional(),
+  reason: z.string().min(1),
+  force: z.boolean().optional(),
+  workspace_id: workspaceIdField,
+} as const;
+export const reassignTaskInputSchema = z.object(reassignTaskInputShape);
+export type ReassignTaskInput = z.infer<typeof reassignTaskInputSchema>;

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,7 @@ import { registerHandoff } from './tools/handoff.js';
 import { registerJoinWorkspace } from './tools/join-workspace.js';
 import { registerRegisterAgent } from './tools/register-agent.js';
 import { registerUpdateTask } from './tools/update-task.js';
+import { registerTaskLifecycle } from './tools/task-lifecycle.js';
 import { VERSION } from './version.js';
 import {
   routedRepositories,
@@ -50,5 +51,6 @@ export function createServer(repos: Repositories, options: ServerOptions = {}): 
   registerClaimWork(server, selectedRepos, onWrite, selectWorkspace);
   registerUpdateTask(server, selectedRepos, onWrite, selectWorkspace);
   registerHandoff(server, selectedRepos, onWrite, selectWorkspace);
+  registerTaskLifecycle(server, selectedRepos, onWrite, selectWorkspace);
   return server;
 }

--- a/src/tools/task-lifecycle.ts
+++ b/src/tools/task-lifecycle.ts
@@ -1,0 +1,347 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import type {
+  AgentRecord,
+  OwnershipEventRecord,
+  Repositories,
+  TaskRecord,
+  TaskStatus,
+  ToolName,
+} from '../db/index.js';
+import {
+  acceptTaskInputShape,
+  type AcceptTaskInput,
+  assignTaskInputShape,
+  type AssignTaskInput,
+  reassignTaskInputShape,
+  type ReassignTaskInput,
+  releaseTaskInputShape,
+  type ReleaseTaskInput,
+} from '../domain/schemas.js';
+import {
+  selectToolWorkspace,
+  type SelectWorkspace,
+  workspaceStructured,
+  withWorkspaceText,
+} from './workspace-routing.js';
+
+export interface TaskLifecycleResult {
+  task: TaskRecord;
+  ownershipEvent: OwnershipEventRecord;
+}
+
+interface TransitionRequest {
+  task: TaskRecord;
+  transition: string;
+  tool: ToolName;
+  actorAgentId: string;
+  status: TaskStatus;
+  agentId: string | null;
+  assignedAgentId: string | null;
+  leaseExpiresAt: string | null;
+  reason: string | null;
+  eventToAgentId?: string | null;
+}
+
+function registeredAgent(repos: Repositories, agentId: string): AgentRecord {
+  const agent = repos.agents.get(agentId);
+  if (agent === undefined) {
+    throw new Error(`Agent ${agentId} is not registered. Call register_agent first.`);
+  }
+  return agent;
+}
+
+function taskAtVersion(repos: Repositories, taskId: string, expectedVersion: number): TaskRecord {
+  const task = repos.tasks.get(taskId);
+  if (task === undefined) {
+    throw new Error(`Task ${taskId} is not claimed.`);
+  }
+  if (task.version !== expectedVersion) {
+    throw new Error(
+      `Task ${taskId} version conflict: expected ${String(expectedVersion)}, current ${String(task.version)}.`,
+    );
+  }
+  return task;
+}
+
+function isHumanSupervisor(actor: AgentRecord, task: TaskRecord): boolean {
+  return actor.owner !== null && task.owner !== null && actor.owner === task.owner;
+}
+
+function requireOwner(task: TaskRecord, actor: AgentRecord): void {
+  if (task.agentId !== actor.agentId) {
+    throw new Error(
+      `Agent ${actor.agentId} cannot change lifecycle for ${task.taskId}; current owner is ${task.agentId ?? 'unassigned'}.`,
+    );
+  }
+}
+
+function leaseDeadline(leaseSeconds: number | undefined, now: number): string | null {
+  return leaseSeconds === undefined ? null : new Date(now + leaseSeconds * 1000).toISOString();
+}
+
+function applyTransition(repos: Repositories, request: TransitionRequest): TaskLifecycleResult {
+  const transact = repos.db.transaction(() => {
+    const updated = repos.tasks.transition({
+      taskId: request.task.taskId,
+      expectedVersion: request.task.version,
+      status: request.status,
+      agentId: request.agentId,
+      assignedAgentId: request.assignedAgentId,
+      leaseExpiresAt: request.leaseExpiresAt,
+    });
+    if (updated === undefined) {
+      const current = repos.tasks.get(request.task.taskId);
+      throw new Error(
+        `Task ${request.task.taskId} version conflict: expected ${String(request.task.version)}, current ${String(current?.version ?? 'missing')}.`,
+      );
+    }
+    const ownershipEvent = repos.ownershipEvents.record({
+      taskId: request.task.taskId,
+      transition: request.transition,
+      actorAgentId: request.actorAgentId,
+      fromAgentId: request.task.agentId,
+      toAgentId:
+        request.eventToAgentId === undefined
+          ? (updated.agentId ?? updated.assignedAgentId)
+          : request.eventToAgentId,
+      fromStatus: request.task.status,
+      toStatus: updated.status,
+      fromVersion: request.task.version,
+      toVersion: updated.version,
+      reason: request.reason,
+    });
+    repos.events.record({
+      taskId: request.task.taskId,
+      tool: request.tool,
+      status: 'success',
+      detail: `${String(request.task.version)} -> ${String(updated.version)}`,
+    });
+    repos.agents.touch(request.actorAgentId);
+    return { task: updated, ownershipEvent };
+  });
+  return transact();
+}
+
+export function handleAssignTask(
+  repos: Repositories,
+  input: AssignTaskInput,
+  now: number = Date.now(),
+): TaskLifecycleResult {
+  const actor = registeredAgent(repos, input.agent_id);
+  registeredAgent(repos, input.to_agent_id);
+  const task = taskAtVersion(repos, input.task_id, input.expected_version);
+  if (task.status === 'closed' || task.status === 'complete') {
+    throw new Error(`Task ${task.taskId} is ${task.status}; reopen it before assignment.`);
+  }
+  if (task.agentId !== null) {
+    requireOwner(task, actor);
+  }
+  return applyTransition(repos, {
+    task,
+    transition: 'assign',
+    tool: 'assign_task',
+    actorAgentId: actor.agentId,
+    status: 'assigned',
+    agentId: task.agentId,
+    assignedAgentId: input.to_agent_id,
+    leaseExpiresAt: leaseDeadline(input.lease_seconds, now),
+    reason: input.reason ?? null,
+    eventToAgentId: input.to_agent_id,
+  });
+}
+
+export function handleAcceptTask(
+  repos: Repositories,
+  input: AcceptTaskInput,
+  now: number = Date.now(),
+): TaskLifecycleResult {
+  const actor = registeredAgent(repos, input.agent_id);
+  const task = taskAtVersion(repos, input.task_id, input.expected_version);
+  if (task.status !== 'assigned' || task.assignedAgentId !== actor.agentId) {
+    throw new Error(`Task ${task.taskId} is not assigned to ${actor.agentId}.`);
+  }
+  if (task.leaseExpiresAt !== null && Date.parse(task.leaseExpiresAt) <= now) {
+    return applyTransition(repos, {
+      task,
+      transition: 'expire_assignment',
+      tool: 'expire_assignment',
+      actorAgentId: actor.agentId,
+      status: task.agentId === null ? 'proposed' : 'active',
+      agentId: task.agentId,
+      assignedAgentId: null,
+      leaseExpiresAt: null,
+      reason: `assignment expired at ${task.leaseExpiresAt}`,
+    });
+  }
+  return applyTransition(repos, {
+    task,
+    transition: 'accept',
+    tool: 'accept_task',
+    actorAgentId: actor.agentId,
+    status: 'active',
+    agentId: actor.agentId,
+    assignedAgentId: null,
+    leaseExpiresAt: null,
+    reason: null,
+  });
+}
+
+export function handleReleaseTask(
+  repos: Repositories,
+  input: ReleaseTaskInput,
+): TaskLifecycleResult {
+  const actor = registeredAgent(repos, input.agent_id);
+  const task = taskAtVersion(repos, input.task_id, input.expected_version);
+  const decliningAssignment = task.status === 'assigned' && task.assignedAgentId === actor.agentId;
+  if (!decliningAssignment) {
+    requireOwner(task, actor);
+  }
+  return applyTransition(repos, {
+    task,
+    transition: 'release',
+    tool: 'release_task',
+    actorAgentId: actor.agentId,
+    status: decliningAssignment && task.agentId !== null ? 'active' : 'proposed',
+    agentId: decliningAssignment ? task.agentId : null,
+    assignedAgentId: null,
+    leaseExpiresAt: null,
+    reason: input.reason ?? null,
+  });
+}
+
+export function handleReassignTask(
+  repos: Repositories,
+  input: ReassignTaskInput,
+  now: number = Date.now(),
+): TaskLifecycleResult {
+  const actor = registeredAgent(repos, input.agent_id);
+  registeredAgent(repos, input.to_agent_id);
+  const task = taskAtVersion(repos, input.task_id, input.expected_version);
+  if (task.agentId !== actor.agentId) {
+    if (input.force !== true || !isHumanSupervisor(actor, task)) {
+      throw new Error(
+        `Only the current owner or a registered agent for human owner ${task.owner ?? '(none)'} can force-reassign ${task.taskId}.`,
+      );
+    }
+  }
+  return applyTransition(repos, {
+    task,
+    transition: input.force === true ? 'force_reassign' : 'reassign',
+    tool: 'reassign_task',
+    actorAgentId: actor.agentId,
+    status: 'assigned',
+    agentId: task.agentId,
+    assignedAgentId: input.to_agent_id,
+    leaseExpiresAt: leaseDeadline(input.lease_seconds, now),
+    reason: input.reason,
+    eventToAgentId: input.to_agent_id,
+  });
+}
+
+function lifecycleText(action: string, result: TaskLifecycleResult): string {
+  return `${action} ${result.task.taskId}; status ${result.task.status}, version ${String(result.task.version)}.`;
+}
+
+function lifecycleStructured(result: TaskLifecycleResult): Record<string, unknown> {
+  return {
+    task_id: result.task.taskId,
+    status: result.task.status,
+    version: result.task.version,
+    agent_id: result.task.agentId,
+    assigned_agent_id: result.task.assignedAgentId,
+    lease_expires_at: result.task.leaseExpiresAt,
+    ownership_event_id: result.ownershipEvent.id,
+  };
+}
+
+export function registerTaskLifecycle(
+  server: McpServer,
+  repos: Repositories,
+  onWrite?: () => void,
+  selectWorkspace?: SelectWorkspace,
+): void {
+  server.registerTool(
+    'assign_task',
+    {
+      title: 'Assign task',
+      description:
+        'Offer an existing task to a registered agent. Assignment does not mean acceptance or active work.',
+      inputSchema: assignTaskInputShape,
+    },
+    (args) => {
+      const workspace = selectToolWorkspace(selectWorkspace, args.workspace_id);
+      const result = handleAssignTask(repos, args);
+      onWrite?.();
+      return {
+        content: [
+          { type: 'text', text: withWorkspaceText(lifecycleText('Assigned', result), workspace) },
+        ],
+        structuredContent: { ...workspaceStructured(workspace), ...lifecycleStructured(result) },
+      };
+    },
+  );
+  server.registerTool(
+    'accept_task',
+    {
+      title: 'Accept task',
+      description:
+        'Accept a live assignment using its current task version and become active owner.',
+      inputSchema: acceptTaskInputShape,
+    },
+    (args) => {
+      const workspace = selectToolWorkspace(selectWorkspace, args.workspace_id);
+      const result = handleAcceptTask(repos, args);
+      onWrite?.();
+      const action =
+        result.ownershipEvent.transition === 'expire_assignment'
+          ? 'Expired assignment for'
+          : 'Accepted';
+      return {
+        content: [
+          { type: 'text', text: withWorkspaceText(lifecycleText(action, result), workspace) },
+        ],
+        structuredContent: { ...workspaceStructured(workspace), ...lifecycleStructured(result) },
+      };
+    },
+  );
+  server.registerTool(
+    'release_task',
+    {
+      title: 'Release task',
+      description: 'Release a task owned by this registered agent back to proposed/unassigned.',
+      inputSchema: releaseTaskInputShape,
+    },
+    (args) => {
+      const workspace = selectToolWorkspace(selectWorkspace, args.workspace_id);
+      const result = handleReleaseTask(repos, args);
+      onWrite?.();
+      return {
+        content: [
+          { type: 'text', text: withWorkspaceText(lifecycleText('Released', result), workspace) },
+        ],
+        structuredContent: { ...workspaceStructured(workspace), ...lifecycleStructured(result) },
+      };
+    },
+  );
+  server.registerTool(
+    'reassign_task',
+    {
+      title: 'Reassign task',
+      description:
+        'Reassign owned work with an audited reason. Non-owner force requires a registered agent for the same human owner.',
+      inputSchema: reassignTaskInputShape,
+    },
+    (args) => {
+      const workspace = selectToolWorkspace(selectWorkspace, args.workspace_id);
+      const result = handleReassignTask(repos, args);
+      onWrite?.();
+      return {
+        content: [
+          { type: 'text', text: withWorkspaceText(lifecycleText('Reassigned', result), workspace) },
+        ],
+        structuredContent: { ...workspaceStructured(workspace), ...lifecycleStructured(result) },
+      };
+    },
+  );
+}

--- a/test/tools/task-lifecycle.test.ts
+++ b/test/tools/task-lifecycle.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { openDatabase } from '../../src/db/connection.js';
+import { createRepositories, type Repositories } from '../../src/db/index.js';
+import { handleClaimWork } from '../../src/tools/claim-work.js';
+import { handleRegisterAgent } from '../../src/tools/register-agent.js';
+import {
+  handleAcceptTask,
+  handleAssignTask,
+  handleReassignTask,
+  handleReleaseTask,
+} from '../../src/tools/task-lifecycle.js';
+
+describe('versioned task lifecycle', () => {
+  let repos: Repositories;
+
+  beforeEach(() => {
+    repos = createRepositories(openDatabase(':memory:'));
+    handleRegisterAgent(repos, {
+      agent_id: 'codex:owner',
+      kind: 'codex',
+      owner: 'alex',
+    });
+    handleRegisterAgent(repos, {
+      agent_id: 'codex:target',
+      kind: 'codex',
+      owner: 'sam',
+    });
+    handleRegisterAgent(repos, {
+      agent_id: 'codex:supervisor',
+      kind: 'codex',
+      owner: 'alex',
+    });
+    handleClaimWork(repos, {
+      task_id: 'TASK-1',
+      title: 'Lifecycle',
+      owner: 'alex',
+      agent_id: 'codex:owner',
+    });
+  });
+
+  it('separates assignment from acceptance and audits both transitions', () => {
+    const assigned = handleAssignTask(repos, {
+      task_id: 'TASK-1',
+      to_agent_id: 'codex:target',
+      agent_id: 'codex:owner',
+      expected_version: 1,
+    });
+    expect(assigned.task.status).toBe('assigned');
+    expect(assigned.task.agentId).toBe('codex:owner');
+    expect(assigned.task.assignedAgentId).toBe('codex:target');
+    expect(assigned.task.version).toBe(2);
+
+    const accepted = handleAcceptTask(repos, {
+      task_id: 'TASK-1',
+      agent_id: 'codex:target',
+      expected_version: 2,
+    });
+    expect(accepted.task.status).toBe('active');
+    expect(accepted.task.agentId).toBe('codex:target');
+    expect(accepted.task.assignedAgentId).toBeNull();
+    expect(accepted.task.version).toBe(3);
+    expect(repos.ownershipEvents.listByTask('TASK-1').map((event) => event.transition)).toEqual([
+      'assign',
+      'accept',
+    ]);
+  });
+
+  it('allows only one acceptance for an expected version', () => {
+    handleAssignTask(repos, {
+      task_id: 'TASK-1',
+      to_agent_id: 'codex:target',
+      agent_id: 'codex:owner',
+      expected_version: 1,
+    });
+    handleAcceptTask(repos, {
+      task_id: 'TASK-1',
+      agent_id: 'codex:target',
+      expected_version: 2,
+    });
+
+    expect(() =>
+      handleAcceptTask(repos, {
+        task_id: 'TASK-1',
+        agent_id: 'codex:target',
+        expected_version: 2,
+      }),
+    ).toThrow(/version conflict/u);
+  });
+
+  it('rejects unknown targets, the wrong recipient, and expired assignments', () => {
+    expect(() =>
+      handleAssignTask(repos, {
+        task_id: 'TASK-1',
+        to_agent_id: 'ghost:agent',
+        agent_id: 'codex:owner',
+        expected_version: 1,
+      }),
+    ).toThrow(/not registered/u);
+
+    handleAssignTask(
+      repos,
+      {
+        task_id: 'TASK-1',
+        to_agent_id: 'codex:target',
+        agent_id: 'codex:owner',
+        expected_version: 1,
+        lease_seconds: 1,
+      },
+      1_000,
+    );
+    expect(() =>
+      handleAcceptTask(
+        repos,
+        {
+          task_id: 'TASK-1',
+          agent_id: 'codex:owner',
+          expected_version: 2,
+        },
+        1_500,
+      ),
+    ).toThrow(/not assigned/u);
+    const expired = handleAcceptTask(
+      repos,
+      {
+        task_id: 'TASK-1',
+        agent_id: 'codex:target',
+        expected_version: 2,
+      },
+      2_000,
+    );
+    expect(expired.ownershipEvent.transition).toBe('expire_assignment');
+    expect(expired.task.status).toBe('active');
+    expect(expired.task.agentId).toBe('codex:owner');
+    expect(expired.task.assignedAgentId).toBeNull();
+  });
+
+  it('requires ownership, or a same-human supervisor for forced reassignment', () => {
+    expect(() =>
+      handleReassignTask(repos, {
+        task_id: 'TASK-1',
+        to_agent_id: 'codex:target',
+        agent_id: 'codex:target',
+        expected_version: 1,
+        reason: 'take over',
+        force: true,
+      }),
+    ).toThrow(/human owner alex/u);
+
+    const reassigned = handleReassignTask(repos, {
+      task_id: 'TASK-1',
+      to_agent_id: 'codex:target',
+      agent_id: 'codex:supervisor',
+      expected_version: 1,
+      reason: 'owner requested reassignment',
+      force: true,
+    });
+    expect(reassigned.task.status).toBe('assigned');
+    expect(reassigned.ownershipEvent.transition).toBe('force_reassign');
+    expect(reassigned.ownershipEvent.reason).toBe('owner requested reassignment');
+  });
+
+  it('lets an assignee decline without discarding the previous owner', () => {
+    const assigned = handleAssignTask(repos, {
+      task_id: 'TASK-1',
+      to_agent_id: 'codex:target',
+      agent_id: 'codex:owner',
+      expected_version: 1,
+    });
+    const declined = handleReleaseTask(repos, {
+      task_id: 'TASK-1',
+      agent_id: 'codex:target',
+      expected_version: assigned.task.version,
+      reason: 'no capacity',
+    });
+    expect(declined.task.status).toBe('active');
+    expect(declined.task.agentId).toBe('codex:owner');
+  });
+});


### PR DESCRIPTION
## Summary

- add explicit `assign_task`, `accept_task`, `release_task`, and `reassign_task` tools
- keep assignment separate from acceptance
- reject stale concurrent transitions with `expected_version`
- support expiring assignment leases and audited, authorized force reassignment

Part of #65.

Stacked on the persistence foundation. Merge and retarget in order; do not squash.

## Verification

- `pnpm typecheck`
- `pnpm test` — 24 files, 175 tests
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `git diff --check`
