### PR TITLE
Persist versioned task ownership

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -2,6 +2,10 @@ import { openDatabase, type ConcordDatabase } from './connection.js';
 import { createAgentRepository, type AgentRepository } from './repositories/agents.js';
 import { createEventRepository, type EventRepository } from './repositories/events.js';
 import { createHandoffRepository, type HandoffRepository } from './repositories/handoffs.js';
+import {
+  createOwnershipEventRepository,
+  type OwnershipEventRepository,
+} from './repositories/ownership-events.js';
 import { createReviewRepository, type ReviewRepository } from './repositories/reviews.js';
 import {
   createTaskUpdateRepository,
@@ -16,6 +20,10 @@ export type { NewHandoff, HandoffRepository } from './repositories/handoffs.js';
 export type { NewReview, ReviewRepository } from './repositories/reviews.js';
 export type { NewTaskUpdate, TaskUpdateRepository } from './repositories/task-updates.js';
 export type { NewEvent, EventRepository } from './repositories/events.js';
+export type {
+  NewOwnershipEvent,
+  OwnershipEventRepository,
+} from './repositories/ownership-events.js';
 export type { NewAgent, AgentRepository } from './repositories/agents.js';
 export type {
   TaskRecord,
@@ -30,6 +38,8 @@ export type {
   TaskUpdateRecord,
   AgentRecord,
   AgentStatus,
+  OwnershipEventRecord,
+  HandoffDeliveryStatus,
 } from './rows.js';
 
 /** The full set of Concord repositories bound to one database. */
@@ -41,6 +51,7 @@ export interface Repositories {
   taskUpdates: TaskUpdateRepository;
   events: EventRepository;
   agents: AgentRepository;
+  ownershipEvents: OwnershipEventRepository;
 }
 
 /** Bind all repositories to an already-open database. */
@@ -53,6 +64,7 @@ export function createRepositories(db: ConcordDatabase): Repositories {
     taskUpdates: createTaskUpdateRepository(db),
     events: createEventRepository(db),
     agents: createAgentRepository(db),
+    ownershipEvents: createOwnershipEventRepository(db),
   };
 }
 

--- a/src/db/repositories/handoffs.ts
+++ b/src/db/repositories/handoffs.ts
@@ -1,7 +1,12 @@
 import { z } from 'zod';
 
 import type { ConcordDatabase } from '../connection.js';
-import { parseHandoffRow, serializeStringArray, type HandoffRecord } from '../rows.js';
+import {
+  parseHandoffRow,
+  serializeStringArray,
+  type HandoffDeliveryStatus,
+  type HandoffRecord,
+} from '../rows.js';
 
 /** Input for recording a handoff. Array fields default to `[]` at the caller. */
 export interface NewHandoff {
@@ -16,12 +21,24 @@ export interface NewHandoff {
   guardrailsChecked: readonly string[];
   needsReviewFrom: readonly string[];
   nextSteps: readonly string[];
+  fromAgentId?: string | null;
+  toAgentId?: string | null;
+  deliveryStatus?: HandoffDeliveryStatus;
+  expiresAt?: string | null;
+  taskVersion?: number | null;
 }
 
 export interface HandoffRepository {
   create(handoff: NewHandoff): HandoffRecord;
   listByTask(taskId: string): HandoffRecord[];
   latestForTask(taskId: string): HandoffRecord | undefined;
+  get(id: number): HandoffRecord | undefined;
+  pendingForTask(taskId: string): HandoffRecord | undefined;
+  resolve(
+    id: number,
+    status: Exclude<HandoffDeliveryStatus, 'recorded' | 'pending'>,
+    reason: string | null,
+  ): HandoffRecord | undefined;
 }
 
 const rawListSchema = z.array(z.unknown());
@@ -31,11 +48,13 @@ export function createHandoffRepository(db: ConcordDatabase): HandoffRepository 
     INSERT INTO handoffs (
       task_id, status, changed_files, what_changed, tests_run, known_risks,
       assumptions, decisions, guardrails_checked, needs_review_from, next_steps,
-      created_at
+      from_agent_id, to_agent_id, delivery_status, expires_at, resolved_at,
+      task_version, resolution_reason, created_at
     ) VALUES (
       @task_id, @status, @changed_files, @what_changed, @tests_run, @known_risks,
       @assumptions, @decisions, @guardrails_checked, @needs_review_from, @next_steps,
-      @created_at
+      @from_agent_id, @to_agent_id, @delivery_status, @expires_at, @resolved_at,
+      @task_version, @resolution_reason, @created_at
     )
   `);
   const getByIdStmt = db.prepare('SELECT * FROM handoffs WHERE id = ?');
@@ -45,6 +64,23 @@ export function createHandoffRepository(db: ConcordDatabase): HandoffRepository 
   const latestStmt = db.prepare(
     'SELECT * FROM handoffs WHERE task_id = ? ORDER BY created_at DESC, id DESC LIMIT 1',
   );
+  const pendingStmt = db.prepare(
+    `SELECT * FROM handoffs
+     WHERE task_id = ? AND delivery_status = 'pending'
+     ORDER BY id DESC LIMIT 1`,
+  );
+  const resolveStmt = db.prepare(
+    `UPDATE handoffs
+     SET delivery_status = @delivery_status,
+         resolved_at = @resolved_at,
+         resolution_reason = @resolution_reason
+     WHERE id = @id AND delivery_status = 'pending'`,
+  );
+
+  function get(id: number): HandoffRecord | undefined {
+    const raw: unknown = getByIdStmt.get(id);
+    return raw === undefined ? undefined : parseHandoffRow(raw);
+  }
 
   return {
     create(handoff) {
@@ -60,6 +96,13 @@ export function createHandoffRepository(db: ConcordDatabase): HandoffRepository 
         guardrails_checked: serializeStringArray(handoff.guardrailsChecked),
         needs_review_from: serializeStringArray(handoff.needsReviewFrom),
         next_steps: serializeStringArray(handoff.nextSteps),
+        from_agent_id: handoff.fromAgentId ?? null,
+        to_agent_id: handoff.toAgentId ?? null,
+        delivery_status: handoff.deliveryStatus ?? 'recorded',
+        expires_at: handoff.expiresAt ?? null,
+        resolved_at: null,
+        task_version: handoff.taskVersion ?? null,
+        resolution_reason: null,
         created_at: new Date().toISOString(),
       });
       const raw: unknown = getByIdStmt.get(info.lastInsertRowid);
@@ -78,6 +121,20 @@ export function createHandoffRepository(db: ConcordDatabase): HandoffRepository 
         return undefined;
       }
       return parseHandoffRow(raw);
+    },
+    get,
+    pendingForTask(taskId) {
+      const raw: unknown = pendingStmt.get(taskId);
+      return raw === undefined ? undefined : parseHandoffRow(raw);
+    },
+    resolve(id, status, reason) {
+      const info = resolveStmt.run({
+        id,
+        delivery_status: status,
+        resolved_at: new Date().toISOString(),
+        resolution_reason: reason,
+      });
+      return info.changes === 0 ? undefined : get(id);
     },
   };
 }

--- a/src/db/repositories/ownership-events.ts
+++ b/src/db/repositories/ownership-events.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod';
+
+import type { ConcordDatabase } from '../connection.js';
+import { parseOwnershipEventRow, type OwnershipEventRecord, type TaskStatus } from '../rows.js';
+
+export interface NewOwnershipEvent {
+  taskId: string;
+  transition: string;
+  actorAgentId: string;
+  fromAgentId: string | null;
+  toAgentId: string | null;
+  fromStatus: TaskStatus;
+  toStatus: TaskStatus;
+  fromVersion: number;
+  toVersion: number;
+  reason: string | null;
+}
+
+export interface OwnershipEventRepository {
+  record(event: NewOwnershipEvent): OwnershipEventRecord;
+  listByTask(taskId: string): OwnershipEventRecord[];
+}
+
+const rawListSchema = z.array(z.unknown());
+
+export function createOwnershipEventRepository(db: ConcordDatabase): OwnershipEventRepository {
+  const insertStmt = db.prepare(`
+    INSERT INTO task_ownership_events (
+      task_id, transition, actor_agent_id, from_agent_id, to_agent_id,
+      from_status, to_status, from_version, to_version, reason, created_at
+    ) VALUES (
+      @task_id, @transition, @actor_agent_id, @from_agent_id, @to_agent_id,
+      @from_status, @to_status, @from_version, @to_version, @reason, @created_at
+    )
+  `);
+  const getStmt = db.prepare('SELECT * FROM task_ownership_events WHERE id = ?');
+  const listStmt = db.prepare(
+    'SELECT * FROM task_ownership_events WHERE task_id = ? ORDER BY id ASC',
+  );
+
+  return {
+    record(event) {
+      const info = insertStmt.run({
+        task_id: event.taskId,
+        transition: event.transition,
+        actor_agent_id: event.actorAgentId,
+        from_agent_id: event.fromAgentId,
+        to_agent_id: event.toAgentId,
+        from_status: event.fromStatus,
+        to_status: event.toStatus,
+        from_version: event.fromVersion,
+        to_version: event.toVersion,
+        reason: event.reason,
+        created_at: new Date().toISOString(),
+      });
+      const raw: unknown = getStmt.get(info.lastInsertRowid);
+      if (raw === undefined) {
+        throw new Error(`Ownership event ${String(info.lastInsertRowid)} could not be read back`);
+      }
+      return parseOwnershipEventRow(raw);
+    },
+    listByTask(taskId) {
+      const raw: unknown = listStmt.all(taskId);
+      return rawListSchema.parse(raw).map(parseOwnershipEventRow);
+    },
+  };
+}

--- a/src/db/repositories/tasks.ts
+++ b/src/db/repositories/tasks.ts
@@ -18,6 +18,9 @@ export interface NewTask {
   notes: string | null;
   parentTaskId: string | null;
   agentId: string | null;
+  status?: TaskStatus;
+  assignedAgentId?: string | null;
+  leaseExpiresAt?: string | null;
 }
 
 /** The declared surface of a claim, updated when an agent re-claims with an
@@ -35,6 +38,16 @@ export interface TaskRepository {
   list(): TaskRecord[];
   updateStatus(taskId: string, status: TaskStatus): TaskRecord | undefined;
   updateScope(taskId: string, scope: TaskScope): TaskRecord | undefined;
+  transition(input: TaskTransition): TaskRecord | undefined;
+}
+
+export interface TaskTransition {
+  taskId: string;
+  expectedVersion: number;
+  status: TaskStatus;
+  agentId: string | null;
+  assignedAgentId: string | null;
+  leaseExpiresAt: string | null;
 }
 
 const rawListSchema = z.array(z.unknown());
@@ -44,22 +57,37 @@ export function createTaskRepository(db: ConcordDatabase): TaskRepository {
     INSERT INTO tasks (
       task_id, title, owner, agent, branch, worktree,
       expected_files, modules, domains, risk_tags, notes, status,
-      parent_task_id, agent_id, created_at, updated_at
+      parent_task_id, agent_id, version, assigned_agent_id, lease_expires_at,
+      created_at, updated_at
     ) VALUES (
       @task_id, @title, @owner, @agent, @branch, @worktree,
       @expected_files, @modules, @domains, @risk_tags, @notes, @status,
-      @parent_task_id, @agent_id, @created_at, @updated_at
+      @parent_task_id, @agent_id, @version, @assigned_agent_id, @lease_expires_at,
+      @created_at, @updated_at
     )
   `);
   const getStmt = db.prepare('SELECT * FROM tasks WHERE task_id = ?');
   const listStmt = db.prepare('SELECT * FROM tasks ORDER BY created_at ASC, task_id ASC');
   const updateStatusStmt = db.prepare(
-    'UPDATE tasks SET status = @status, updated_at = @updated_at WHERE task_id = @task_id',
+    `UPDATE tasks
+     SET status = @status, version = version + 1, updated_at = @updated_at
+     WHERE task_id = @task_id`,
   );
   const updateScopeStmt = db.prepare(
     `UPDATE tasks SET expected_files = @expected_files, modules = @modules,
-       domains = @domains, risk_tags = @risk_tags, updated_at = @updated_at
+       domains = @domains, risk_tags = @risk_tags,
+       version = version + 1, updated_at = @updated_at
      WHERE task_id = @task_id`,
+  );
+  const transitionStmt = db.prepare(
+    `UPDATE tasks
+     SET status = @status,
+         agent_id = @agent_id,
+         assigned_agent_id = @assigned_agent_id,
+         lease_expires_at = @lease_expires_at,
+         version = version + 1,
+         updated_at = @updated_at
+     WHERE task_id = @task_id AND version = @expected_version`,
   );
 
   function get(taskId: string): TaskRecord | undefined {
@@ -85,9 +113,12 @@ export function createTaskRepository(db: ConcordDatabase): TaskRepository {
         domains: serializeStringArray(task.domains),
         risk_tags: serializeStringArray(task.riskTags),
         notes: task.notes,
-        status: 'active',
+        status: task.status ?? 'active',
         parent_task_id: task.parentTaskId,
         agent_id: task.agentId,
+        version: 1,
+        assigned_agent_id: task.assignedAgentId ?? null,
+        lease_expires_at: task.leaseExpiresAt ?? null,
         created_at: now,
         updated_at: now,
       });
@@ -116,6 +147,18 @@ export function createTaskRepository(db: ConcordDatabase): TaskRepository {
         updated_at: new Date().toISOString(),
       });
       return get(taskId);
+    },
+    transition(input) {
+      const info = transitionStmt.run({
+        task_id: input.taskId,
+        expected_version: input.expectedVersion,
+        status: input.status,
+        agent_id: input.agentId,
+        assigned_agent_id: input.assignedAgentId,
+        lease_expires_at: input.leaseExpiresAt,
+        updated_at: new Date().toISOString(),
+      });
+      return info.changes === 0 ? undefined : get(input.taskId);
     },
   };
 }

--- a/src/db/rows.ts
+++ b/src/db/rows.ts
@@ -7,12 +7,38 @@ import { z } from 'zod';
  */
 
 /** Lifecycle states a task can be in. */
-export const taskStatusValues = ['active', 'handed_off', 'review_ready'] as const;
+export const taskStatusValues = [
+  'proposed',
+  'assigned',
+  'active',
+  'blocked',
+  'handoff_offered',
+  'handed_off',
+  'review_ready',
+  'complete',
+  'closed',
+] as const;
 export type TaskStatus = (typeof taskStatusValues)[number];
 const taskStatusSchema = z.enum(taskStatusValues);
 
 /** Tools that can be recorded as events (used for adoption tracking). */
-export const toolNameValues = ['claim_work', 'update_task', 'handoff', 'review_ready'] as const;
+export const toolNameValues = [
+  'claim_work',
+  'update_task',
+  'handoff',
+  'review_ready',
+  'assign_task',
+  'accept_task',
+  'release_task',
+  'expire_assignment',
+  'reassign_task',
+  'offer_handoff',
+  'accept_handoff',
+  'decline_handoff',
+  'expire_handoff',
+  'close_task',
+  'reopen_task',
+] as const;
 export type ToolName = (typeof toolNameValues)[number];
 const toolNameSchema = z.enum(toolNameValues);
 
@@ -72,6 +98,12 @@ export interface TaskRecord {
    * Distinct from `agent` (the kind string): used to check the claimant's
    * liveness for stale-claim detection. */
   agentId: string | null;
+  /** Monotonic compare-and-swap version for lifecycle transitions. */
+  version: number;
+  /** Agent offered this task but not yet the active owner. */
+  assignedAgentId: string | null;
+  /** Optional assignment/ownership lease deadline. */
+  leaseExpiresAt: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -91,6 +123,9 @@ const taskDbRowSchema = z.object({
   status: taskStatusSchema,
   parent_task_id: z.string().nullable(),
   agent_id: z.string().nullable(),
+  version: z.number().int().positive(),
+  assigned_agent_id: z.string().nullable(),
+  lease_expires_at: z.string().nullable(),
   created_at: z.string(),
   updated_at: z.string(),
 });
@@ -112,6 +147,9 @@ export function parseTaskRow(raw: unknown): TaskRecord {
     status: row.status,
     parentTaskId: row.parent_task_id,
     agentId: row.agent_id,
+    version: row.version,
+    assignedAgentId: row.assigned_agent_id,
+    leaseExpiresAt: row.lease_expires_at,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -177,8 +215,25 @@ export interface HandoffRecord {
   guardrailsChecked: string[];
   needsReviewFrom: string[];
   nextSteps: string[];
+  fromAgentId: string | null;
+  toAgentId: string | null;
+  deliveryStatus: HandoffDeliveryStatus;
+  expiresAt: string | null;
+  resolvedAt: string | null;
+  taskVersion: number | null;
+  resolutionReason: string | null;
   createdAt: string;
 }
+
+export const handoffDeliveryStatusValues = [
+  'recorded',
+  'pending',
+  'accepted',
+  'declined',
+  'expired',
+] as const;
+export type HandoffDeliveryStatus = (typeof handoffDeliveryStatusValues)[number];
+const handoffDeliveryStatusSchema = z.enum(handoffDeliveryStatusValues);
 
 const handoffDbRowSchema = z.object({
   id: z.number().int(),
@@ -193,6 +248,13 @@ const handoffDbRowSchema = z.object({
   guardrails_checked: z.string(),
   needs_review_from: z.string(),
   next_steps: z.string(),
+  from_agent_id: z.string().nullable(),
+  to_agent_id: z.string().nullable(),
+  delivery_status: handoffDeliveryStatusSchema,
+  expires_at: z.string().nullable(),
+  resolved_at: z.string().nullable(),
+  task_version: z.number().int().nullable(),
+  resolution_reason: z.string().nullable(),
   created_at: z.string(),
 });
 
@@ -211,6 +273,63 @@ export function parseHandoffRow(raw: unknown): HandoffRecord {
     guardrailsChecked: parseStringArray(row.guardrails_checked),
     needsReviewFrom: parseStringArray(row.needs_review_from),
     nextSteps: parseStringArray(row.next_steps),
+    fromAgentId: row.from_agent_id,
+    toAgentId: row.to_agent_id,
+    deliveryStatus: row.delivery_status,
+    expiresAt: row.expires_at,
+    resolvedAt: row.resolved_at,
+    taskVersion: row.task_version,
+    resolutionReason: row.resolution_reason,
+    createdAt: row.created_at,
+  };
+}
+
+// --- ownership events -------------------------------------------------------
+
+export interface OwnershipEventRecord {
+  id: number;
+  taskId: string;
+  transition: string;
+  actorAgentId: string;
+  fromAgentId: string | null;
+  toAgentId: string | null;
+  fromStatus: TaskStatus;
+  toStatus: TaskStatus;
+  fromVersion: number;
+  toVersion: number;
+  reason: string | null;
+  createdAt: string;
+}
+
+const ownershipEventDbRowSchema = z.object({
+  id: z.number().int(),
+  task_id: z.string(),
+  transition: z.string(),
+  actor_agent_id: z.string(),
+  from_agent_id: z.string().nullable(),
+  to_agent_id: z.string().nullable(),
+  from_status: taskStatusSchema,
+  to_status: taskStatusSchema,
+  from_version: z.number().int().positive(),
+  to_version: z.number().int().positive(),
+  reason: z.string().nullable(),
+  created_at: z.string(),
+});
+
+export function parseOwnershipEventRow(raw: unknown): OwnershipEventRecord {
+  const row = ownershipEventDbRowSchema.parse(raw);
+  return {
+    id: row.id,
+    taskId: row.task_id,
+    transition: row.transition,
+    actorAgentId: row.actor_agent_id,
+    fromAgentId: row.from_agent_id,
+    toAgentId: row.to_agent_id,
+    fromStatus: row.from_status,
+    toStatus: row.to_status,
+    fromVersion: row.from_version,
+    toVersion: row.to_version,
+    reason: row.reason,
     createdAt: row.created_at,
   };
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -114,4 +114,40 @@ export const migrations: readonly string[] = [
   `
   ALTER TABLE tasks ADD COLUMN agent_id TEXT;
   `,
+  // 007 — versioned ownership lifecycle and acknowledged handoff delivery.
+  // Existing task/handoff rows retain their legacy status and are upgraded with
+  // safe defaults; all ownership changes are recorded append-only.
+  `
+  ALTER TABLE tasks ADD COLUMN version INTEGER NOT NULL DEFAULT 1;
+  ALTER TABLE tasks ADD COLUMN assigned_agent_id TEXT;
+  ALTER TABLE tasks ADD COLUMN lease_expires_at TEXT;
+
+  ALTER TABLE handoffs ADD COLUMN from_agent_id TEXT;
+  ALTER TABLE handoffs ADD COLUMN to_agent_id TEXT;
+  ALTER TABLE handoffs ADD COLUMN delivery_status TEXT NOT NULL DEFAULT 'recorded';
+  ALTER TABLE handoffs ADD COLUMN expires_at TEXT;
+  ALTER TABLE handoffs ADD COLUMN resolved_at TEXT;
+  ALTER TABLE handoffs ADD COLUMN task_version INTEGER;
+  ALTER TABLE handoffs ADD COLUMN resolution_reason TEXT;
+
+  CREATE TABLE task_ownership_events (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id         TEXT NOT NULL REFERENCES tasks(task_id),
+    transition      TEXT NOT NULL,
+    actor_agent_id  TEXT NOT NULL,
+    from_agent_id   TEXT,
+    to_agent_id     TEXT,
+    from_status     TEXT NOT NULL,
+    to_status       TEXT NOT NULL,
+    from_version    INTEGER NOT NULL,
+    to_version      INTEGER NOT NULL,
+    reason          TEXT,
+    created_at      TEXT NOT NULL
+  );
+
+  CREATE INDEX idx_ownership_events_task_id
+    ON task_ownership_events(task_id, id);
+  CREATE INDEX idx_handoffs_pending_recipient
+    ON handoffs(to_agent_id, delivery_status);
+  `,
 ];

--- a/src/workspaces/manager.ts
+++ b/src/workspaces/manager.ts
@@ -154,5 +154,8 @@ export function routedRepositories(manager: WorkspaceManager): Repositories {
     get agents() {
       return manager.current().repos.agents;
     },
+    get ownershipEvents() {
+      return manager.current().repos.ownershipEvents;
+    },
   };
 }

--- a/test/cli/cli-commands.test.ts
+++ b/test/cli/cli-commands.test.ts
@@ -73,7 +73,7 @@ describe('CLI read/export commands', () => {
 
   it('doctor reports schema version and adoption', () => {
     const report = runDoctor(dir);
-    expect(report).toContain('schema v6, expected v6');
+    expect(report).toContain('schema v7, expected v7');
     expect(report).toContain('TASK-12');
     expect(report).toContain('claim_work: yes');
     // The resolved workspace path is surfaced so agents don't have to hunt for it.

--- a/test/db/connection.test.ts
+++ b/test/db/connection.test.ts
@@ -1,14 +1,19 @@
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
+import Database from 'better-sqlite3';
 import { openDatabase } from '../../src/db/connection.js';
 import { parseStringArray, parseTaskRow, serializeStringArray } from '../../src/db/rows.js';
+import { migrations } from '../../src/db/schema.js';
 
 describe('openDatabase', () => {
   it('applies all migrations (user_version at head) and creates tables', () => {
     const db = openDatabase(':memory:');
     const version: unknown = db.pragma('user_version', { simple: true });
-    expect(version).toBe(6);
+    expect(version).toBe(7);
 
     const raw: unknown = db.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all();
     const names = new Set(
@@ -23,6 +28,53 @@ describe('openDatabase', () => {
     expect(names.has('reviews')).toBe(true);
     expect(names.has('task_updates')).toBe(true);
     expect(names.has('agents')).toBe(true);
+    expect(names.has('task_ownership_events')).toBe(true);
+  });
+
+  it('upgrades a version-6 database without losing legacy task ownership', () => {
+    const filename = join(mkdtempSync(join(tmpdir(), 'concord-upgrade-')), 'legacy.db');
+    const legacy = new Database(filename);
+    for (let index = 0; index < 6; index += 1) {
+      legacy.exec(migrations[index] ?? '');
+      legacy.pragma(`user_version = ${String(index + 1)}`);
+    }
+    legacy
+      .prepare(
+        `INSERT INTO tasks (
+          task_id, title, owner, agent, branch, worktree, expected_files,
+          modules, domains, risk_tags, notes, status, parent_task_id, agent_id,
+          created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        'LEGACY',
+        'Legacy task',
+        'alex',
+        'codex',
+        null,
+        null,
+        '[]',
+        '[]',
+        '[]',
+        '[]',
+        null,
+        'handed_off',
+        null,
+        'codex:old',
+        '2026-01-01T00:00:00.000Z',
+        '2026-01-01T00:00:00.000Z',
+      );
+    legacy.close();
+
+    const upgraded = openDatabase(filename);
+    const task = parseTaskRow(
+      upgraded.prepare('SELECT * FROM tasks WHERE task_id = ?').get('LEGACY'),
+    );
+    expect(upgraded.pragma('user_version', { simple: true })).toBe(7);
+    expect(task.status).toBe('handed_off');
+    expect(task.agentId).toBe('codex:old');
+    expect(task.version).toBe(1);
+    expect(task.assignedAgentId).toBeNull();
   });
 });
 
@@ -48,6 +100,9 @@ describe('row parsing', () => {
       status: 'active',
       parent_task_id: null,
       agent_id: null,
+      version: 1,
+      assigned_agent_id: null,
+      lease_expires_at: null,
       created_at: '2026-07-17T00:00:00.000Z',
       updated_at: '2026-07-17T00:00:00.000Z',
     });

--- a/test/db/storage.test.ts
+++ b/test/db/storage.test.ts
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { z } from 'zod';
 
 import { openDatabase } from '../../src/db/connection.js';
-import { createRepositories, type Repositories } from '../../src/db/index.js';
+import { createRepositories, openRepositories, type Repositories } from '../../src/db/index.js';
 
 function newRepos(): Repositories {
   return createRepositories(openDatabase(':memory:'));
@@ -50,12 +53,13 @@ describe('migrations', () => {
     expect(names.has('events')).toBe(true);
     expect(names.has('task_updates')).toBe(true);
     expect(names.has('agents')).toBe(true);
+    expect(names.has('task_ownership_events')).toBe(true);
   });
 
   it('is idempotent when reopening (user_version already at head)', () => {
     const { db } = newRepos();
     const version: unknown = db.pragma('user_version', { simple: true });
-    expect(version).toBe(6);
+    expect(version).toBe(7);
   });
 });
 
@@ -70,6 +74,8 @@ describe('task repository', () => {
     expect(created.taskId).toBe('TASK-12');
     expect(created.modules).toEqual(['billing', 'stripe']);
     expect(created.status).toBe('active');
+    expect(created.version).toBe(1);
+    expect(created.assignedAgentId).toBeNull();
 
     const fetched = repos.tasks.get('TASK-12');
     expect(fetched?.expectedFiles).toEqual(['src/billing/retry.ts']);
@@ -91,6 +97,63 @@ describe('task repository', () => {
     repos.tasks.create(baseTask);
     const updated = repos.tasks.updateStatus('TASK-12', 'review_ready');
     expect(updated?.status).toBe('review_ready');
+    expect(updated?.version).toBe(2);
+  });
+
+  it('transitions ownership with compare-and-swap semantics', () => {
+    repos.tasks.create(baseTask);
+    const accepted = repos.tasks.transition({
+      taskId: 'TASK-12',
+      expectedVersion: 1,
+      status: 'active',
+      agentId: 'codex:one',
+      assignedAgentId: null,
+      leaseExpiresAt: null,
+    });
+    const stale = repos.tasks.transition({
+      taskId: 'TASK-12',
+      expectedVersion: 1,
+      status: 'active',
+      agentId: 'codex:two',
+      assignedAgentId: null,
+      leaseExpiresAt: null,
+    });
+
+    expect(accepted?.agentId).toBe('codex:one');
+    expect(accepted?.version).toBe(2);
+    expect(stale).toBeUndefined();
+    expect(repos.tasks.get('TASK-12')?.agentId).toBe('codex:one');
+  });
+
+  it('allows only one transition across two database connections', () => {
+    const filename = join(mkdtempSync(join(tmpdir(), 'concord-cas-')), 'concord.db');
+    const first = openRepositories(filename);
+    const second = openRepositories(filename);
+    first.tasks.create(baseTask);
+    expect(second.tasks.get('TASK-12')?.version).toBe(1);
+
+    const winner = first.tasks.transition({
+      taskId: 'TASK-12',
+      expectedVersion: 1,
+      status: 'active',
+      agentId: 'codex:first',
+      assignedAgentId: null,
+      leaseExpiresAt: null,
+    });
+    const loser = second.tasks.transition({
+      taskId: 'TASK-12',
+      expectedVersion: 1,
+      status: 'active',
+      agentId: 'codex:second',
+      assignedAgentId: null,
+      leaseExpiresAt: null,
+    });
+
+    expect(winner?.version).toBe(2);
+    expect(loser).toBeUndefined();
+    expect(second.tasks.get('TASK-12')?.agentId).toBe('codex:first');
+    first.db.close();
+    second.db.close();
   });
 
   it('updates scope (files/modules/domains/risk tags)', () => {
@@ -137,6 +200,31 @@ describe('handoff repository', () => {
     });
     expect(handoff.id).toBeGreaterThan(0);
     expect(handoff.assumptions).toEqual(['retries are idempotent']);
+    expect(handoff.deliveryStatus).toBe('recorded');
+  });
+
+  it('records and conditionally resolves a pending handoff delivery', () => {
+    const pending = repos.handoffs.create({
+      taskId: 'TASK-12',
+      status: 'in_progress',
+      changedFiles: [],
+      whatChanged: 'ready for the next agent',
+      testsRun: [],
+      knownRisks: [],
+      assumptions: [],
+      decisions: [],
+      guardrailsChecked: [],
+      needsReviewFrom: [],
+      nextSteps: [],
+      fromAgentId: 'codex:one',
+      toAgentId: 'codex:two',
+      deliveryStatus: 'pending',
+      taskVersion: 2,
+    });
+
+    expect(repos.handoffs.pendingForTask('TASK-12')?.id).toBe(pending.id);
+    expect(repos.handoffs.resolve(pending.id, 'accepted', null)?.deliveryStatus).toBe('accepted');
+    expect(repos.handoffs.resolve(pending.id, 'declined', 'late')).toBeUndefined();
   });
 
   it('returns the latest handoff for a task', () => {
@@ -191,6 +279,28 @@ describe('event repository', () => {
     expect(repos.events.list()).toHaveLength(3);
     const forTask = repos.events.listByTask('TASK-12');
     expect(forTask.map((e) => e.tool)).toEqual(['claim_work', 'handoff']);
+  });
+});
+
+describe('ownership event repository', () => {
+  it('records an append-only ownership transition', () => {
+    const repos = newRepos();
+    repos.tasks.create(baseTask);
+    const event = repos.ownershipEvents.record({
+      taskId: 'TASK-12',
+      transition: 'assign',
+      actorAgentId: 'supervisor:one',
+      fromAgentId: null,
+      toAgentId: 'codex:two',
+      fromStatus: 'active',
+      toStatus: 'assigned',
+      fromVersion: 1,
+      toVersion: 2,
+      reason: 'route to specialist',
+    });
+
+    expect(event.toAgentId).toBe('codex:two');
+    expect(repos.ownershipEvents.listByTask('TASK-12')).toEqual([event]);
   });
 });
 

--- a/test/domain/overlap.test.ts
+++ b/test/domain/overlap.test.ts
@@ -19,6 +19,9 @@ function task(partial: Partial<TaskRecord> & { taskId: string }): TaskRecord {
     status: partial.status ?? 'active',
     parentTaskId: partial.parentTaskId ?? null,
     agentId: null,
+    version: partial.version ?? 1,
+    assignedAgentId: partial.assignedAgentId ?? null,
+    leaseExpiresAt: partial.leaseExpiresAt ?? null,
     createdAt: '2026-07-17T00:00:00.000Z',
     updatedAt: '2026-07-17T00:00:00.000Z',
   };

--- a/test/domain/presence.test.ts
+++ b/test/domain/presence.test.ts
@@ -105,6 +105,9 @@ function task(partial: Partial<TaskRecord> & { taskId: string }): TaskRecord {
     status: partial.status ?? 'active',
     parentTaskId: null,
     agentId: partial.agentId ?? null,
+    version: partial.version ?? 1,
+    assignedAgentId: partial.assignedAgentId ?? null,
+    leaseExpiresAt: partial.leaseExpiresAt ?? null,
     createdAt: '2026-07-24T00:00:00.000Z',
     updatedAt: '2026-07-24T00:00:00.000Z',
   };


### PR DESCRIPTION
## Summary

- migrate Concord storage to schema v7 with monotonic task versions
- persist explicit owner, pending assignee, lease, and terminal lifecycle state
- add append-only ownership events and delivery-aware handoff records
- preserve and test migration compatibility with existing workspaces

Part of #65.

This is the first PR in the #65 stack and depends on the #64 workspace-routing stack (#77).

## Verification

- `pnpm typecheck`
- `pnpm test` — 23 files, 170 tests
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `git diff --check`

## Stack

1. This PR — persistence foundation
2. Explicit assignment lifecycle
3. Terminal task lifecycle
4. Ownership authorization
5. Acknowledged handoff delivery
6. Lifecycle visibility and docs
