### PR TITLE
feat: register the MCP server from concord install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `concord install` now registers the MCP server itself, writing `.mcp.json`
+  (Claude Code), `.cursor/mcp.json` (Cursor), and `[mcp_servers.concord]` in
+  Codex's `~/.codex/config.toml` (honoring `CODEX_HOME`). Previously it wrote
+  only the agent instructions, leaving registration as a manual step that was
+  easy to miss — the instructions landed but the tools were never connected.
+  Existing servers, unrelated keys, and TOML comments are preserved, and
+  re-running is a no-op. Pass `--no-mcp` to skip registration. A config file
+  that cannot be parsed is reported and left untouched rather than overwritten.
+
 ## [0.5.0] - 2026-07-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -71,10 +71,13 @@ npm install -g @concord-ai/concord-mcp
 concord install
 ```
 
-`concord install` writes Concord's tool instructions into your client configs
-(`CLAUDE.md`, `AGENTS.md`, `.codex/`, `.cursor/rules/`). Then register the MCP
-server with your client and let your agent use the tools through MCP. Per-client
-setup:
+`concord install` does both halves of the setup: it registers the MCP server
+(`.mcp.json`, `.cursor/mcp.json`, and Codex's `~/.codex/config.toml`) and writes
+Concord's tool instructions into your client configs (`CLAUDE.md`, `AGENTS.md`,
+`.codex/`, `.cursor/rules/`). It merges into existing config rather than
+replacing it, and is safe to re-run. Pass `--no-mcp` to write only the
+instructions and manage MCP registration yourself. Restart your client
+afterwards so it picks up the new server. Per-client setup:
 
 - [Claude Code](./docs/claude-code.md)
 - [Codex](./docs/codex.md)

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -6,9 +6,13 @@
 npm install -g @concord-ai/concord-mcp
 ```
 
-## 2. Register the MCP server
+## 2. Set up your repo
 
-Add Concord to your project's `.mcp.json`:
+```bash
+concord install
+```
+
+This does two things. It registers the MCP server in your project's `.mcp.json`:
 
 ```json
 {
@@ -20,23 +24,19 @@ Add Concord to your project's `.mcp.json`:
 }
 ```
 
-Or use the Claude Code CLI:
+And it writes a Concord block into `CLAUDE.md` telling the agent when to claim
+work, share task context, and hand off. Both merge into whatever is already
+there — other MCP servers and existing instructions are preserved — so it is
+safe to re-run. Restart Claude Code afterwards so it picks up the server.
+
+To manage `.mcp.json` yourself, pass `--no-mcp` and register Concord by hand
+with the JSON above or:
 
 ```bash
 claude mcp add concord -- concord-mcp
 ```
 
-## 3. Install the agent instructions
-
-```bash
-concord install
-```
-
-This writes a Concord block into `CLAUDE.md` telling the agent when to claim
-work, share task context, and hand off. It preserves any existing content and is
-safe to re-run.
-
-## 4. Use it
+## 3. Use it
 
 Ask Claude to start a task. It should call `claim_work` before editing,
 `update_task` while working, and `get_task_context` when resuming or

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -6,27 +6,31 @@
 npm install -g @concord-ai/concord-mcp
 ```
 
-## 2. Register the MCP server
+## 2. Set up your repo
 
-Add Concord to your Codex config (`~/.codex/config.toml`):
+```bash
+concord install
+```
+
+This registers the MCP server in your Codex config (`~/.codex/config.toml`, or
+`$CODEX_HOME/config.toml` when that is set):
 
 ```toml
 [mcp_servers.concord]
 command = "concord-mcp"
 ```
 
-Refer to the current Codex MCP documentation if the config format has changed.
+and writes a Concord block into `AGENTS.md` (and `.codex/concord.md`) describing
+when to claim work, share task context, and hand off. The rest of your config —
+other tables, and the comments around them — is left as-is, and re-running is a
+no-op. Pass `--no-mcp` to write only the instructions and add the table above
+yourself.
 
-## 3. Install the agent instructions
+Note this is the one file `concord install` writes outside the repo, since Codex
+keeps MCP servers in user-global config rather than per-project. Refer to the
+current Codex MCP documentation if the config format has changed.
 
-```bash
-concord install
-```
-
-This writes a Concord block into `AGENTS.md` (and `.codex/concord.md`) describing
-when to claim work, share task context, and hand off. It is idempotent.
-
-## 4. Use it
+## 3. Use it
 
 Codex should call `claim_work` before editing, `update_task` while working, and
 `get_task_context` when resuming or coordinating. An assigned task must be

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -6,9 +6,13 @@
 npm install -g @concord-ai/concord-mcp
 ```
 
-## 2. Register the MCP server
+## 2. Set up your repo
 
-Add Concord to `.cursor/mcp.json`:
+```bash
+concord install
+```
+
+This registers the MCP server in `.cursor/mcp.json`:
 
 ```json
 {
@@ -20,16 +24,16 @@ Add Concord to `.cursor/mcp.json`:
 }
 ```
 
-## 3. Install the agent instructions
+and writes `.cursor/rules/concord.mdc` (with `alwaysApply: true`) so the agent
+knows when to claim work, share task context, and hand off. Existing servers and
+rules are preserved and it is idempotent. Restart Cursor afterwards so it picks
+up the server. Pass `--no-mcp` to write only the rule and register Concord
+yourself with the JSON above.
 
-```bash
-concord install
-```
+The one-click deeplink in the README registers Concord through `npx` instead,
+for trying it without a global install.
 
-This writes `.cursor/rules/concord.mdc` (with `alwaysApply: true`) so the agent
-knows when to claim work, share task context, and hand off. It is idempotent.
-
-## 4. Use it
+## 3. Use it
 
 Track progress and artifacts from the terminal:
 

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -2,30 +2,51 @@ import type { Command } from '@commander-js/extra-typings';
 
 import { resolveRepoRoot } from '../../config/paths.js';
 import { installClaudeHook } from '../../install/claude-hooks.js';
+import { installCodexMcpConfig } from '../../install/codex-config.js';
 import { installConcord } from '../../install/index.js';
+import { McpConfigParseError, installMcpConfigs } from '../../install/mcp-config.js';
 
 export function registerInstallCommand(program: Command): void {
   program
     .command('install')
-    .description('Write Concord usage instructions into supported client configs')
+    .description('Write Concord usage instructions and MCP registration into client configs')
     .option(
       '--claude-hooks',
       'also install an opt-in Claude Code PreToolUse overlap hook into .claude/settings.json',
     )
+    .option('--no-mcp', 'skip registering the MCP server; only write the usage instructions')
     .action((options) => {
       const repoRoot = resolveRepoRoot(process.cwd(), process.env);
       const written = installConcord(repoRoot);
       if (options.claudeHooks === true) {
         written.push(installClaudeHook(repoRoot));
       }
+
+      let mcpError: McpConfigParseError | undefined;
+      if (options.mcp) {
+        try {
+          written.push(...installMcpConfigs(repoRoot));
+          written.push(installCodexMcpConfig(process.env));
+        } catch (error) {
+          if (!(error instanceof McpConfigParseError)) {
+            throw error;
+          }
+          mcpError = error;
+        }
+      }
+
       process.stdout.write(`Installed Concord instructions:\n`);
-      for (const relPath of written) {
-        process.stdout.write(`  ${relPath}\n`);
+      for (const path of written) {
+        process.stdout.write(`  ${path}\n`);
       }
       if (options.claudeHooks === true) {
         process.stdout.write(
           'PreToolUse hook installed. Set CONCORD_TASK=<your task id> so it excludes your own claim.\n',
         );
+      }
+      if (mcpError !== undefined) {
+        process.stderr.write(`${mcpError.message}\n`);
+        process.exitCode = 1;
       }
     });
 }

--- a/src/install/codex-config.ts
+++ b/src/install/codex-config.ts
@@ -1,0 +1,77 @@
+import { mkdirSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { CONCORD_SERVER_COMMAND } from './mcp-config.js';
+
+/** The TOML table Codex reads Concord's server definition from. */
+export const CODEX_SECTION_HEADER = '[mcp_servers.concord]';
+
+/** Matches any TOML table header, which terminates the preceding table. */
+const TABLE_HEADER = /^\s*\[/u;
+
+/**
+ * Absolute path to Codex's user-global config. Unlike everything else `install`
+ * writes this lives outside the repo, so `CODEX_HOME` is honored — both because
+ * Codex itself respects it and because it lets tests target a temp directory.
+ */
+export function codexConfigFile(env: NodeJS.ProcessEnv = process.env): string {
+  const home = env['CODEX_HOME'];
+  const base = home !== undefined && home.trim() !== '' ? home : join(homedir(), '.codex');
+  return join(base, 'config.toml');
+}
+
+/** Normalize preceding content so exactly one blank line precedes our table. */
+function withTrailingBlankLine(lines: readonly string[]): string {
+  if (lines.length === 0) {
+    return '';
+  }
+  return `${lines.join('\n').replace(/\n*$/u, '')}\n\n`;
+}
+
+/**
+ * Idempotently add Concord's `[mcp_servers.concord]` table to a Codex TOML
+ * config. This splices the table by line range rather than parsing and
+ * re-serializing, so unrelated tables — and the comments and formatting around
+ * them, which a round-trip through a parser would discard — survive verbatim.
+ */
+export function upsertCodexMcpServer(existing: string | undefined): string {
+  const section = `${CODEX_SECTION_HEADER}\ncommand = "${CONCORD_SERVER_COMMAND}"\n`;
+  const source = existing ?? '';
+  if (source.trim() === '') {
+    return section;
+  }
+
+  const lines = source.split('\n');
+  const found = lines.findIndex((line) => line.trim() === CODEX_SECTION_HEADER);
+  const start = found === -1 ? lines.length : found;
+
+  // Our table runs until the next table header; a nested `[mcp_servers.concord.env]`
+  // is such a header, so any subtable the user added is preserved as trailing content.
+  let end = lines.length;
+  if (found !== -1) {
+    for (let index = found + 1; index < lines.length; index += 1) {
+      if (TABLE_HEADER.test(lines[index] ?? '')) {
+        end = index;
+        break;
+      }
+    }
+  }
+
+  const head = withTrailingBlankLine(lines.slice(0, start));
+  const tail = lines.slice(end).join('\n');
+  return tail === '' ? `${head}${section}` : `${head}${section}\n${tail}`;
+}
+
+/**
+ * Register Concord in Codex's user-global `config.toml` (created if absent),
+ * preserving the rest of the file. Returns the absolute path written, since it
+ * lies outside the repo and callers surface that to the user.
+ */
+export function installCodexMcpConfig(env: NodeJS.ProcessEnv = process.env): string {
+  const fullPath = codexConfigFile(env);
+  const existing = existsSync(fullPath) ? readFileSync(fullPath, 'utf8') : undefined;
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, upsertCodexMcpServer(existing));
+  return fullPath;
+}

--- a/src/install/mcp-config.ts
+++ b/src/install/mcp-config.ts
@@ -1,0 +1,68 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { z } from 'zod';
+
+/** The key Concord registers itself under in an `mcpServers` map. */
+export const CONCORD_SERVER_KEY = 'concord';
+/** The binary clients spawn to run the stdio MCP server. */
+export const CONCORD_SERVER_COMMAND = 'concord-mcp';
+
+/** Repo-relative config paths that share the `mcpServers` JSON shape. */
+const JSON_TARGETS: readonly string[] = ['.mcp.json', join('.cursor', 'mcp.json')];
+
+const mcpConfigSchema = z.object({ mcpServers: z.record(z.unknown()).optional() }).passthrough();
+
+/**
+ * Thrown when an existing config file cannot be parsed. The caller reports this
+ * and leaves the file untouched rather than overwriting hand-written config.
+ */
+export class McpConfigParseError extends Error {
+  constructor(readonly relPath: string) {
+    super(`${relPath} is not valid JSON — fix or remove it, then re-run.`);
+    this.name = 'McpConfigParseError';
+  }
+}
+
+/**
+ * Idempotently add Concord's server entry to an `mcpServers` config string.
+ * Every other server and every unrelated top-level key is preserved, and
+ * passing the previous output back in is a no-op.
+ */
+export function upsertMcpServer(existing: string | undefined): string {
+  const source: unknown =
+    existing === undefined || existing.trim() === '' ? {} : JSON.parse(existing);
+  const config = mcpConfigSchema.parse(source);
+  const servers = config.mcpServers ?? {};
+
+  const next = {
+    ...config,
+    mcpServers: { ...servers, [CONCORD_SERVER_KEY]: { command: CONCORD_SERVER_COMMAND } },
+  };
+  return `${JSON.stringify(next, null, 2)}\n`;
+}
+
+function writeMcpConfig(repoRoot: string, relPath: string): string {
+  const fullPath = join(repoRoot, relPath);
+  const existing = existsSync(fullPath) ? readFileSync(fullPath, 'utf8') : undefined;
+
+  let updated: string;
+  try {
+    updated = upsertMcpServer(existing);
+  } catch {
+    throw new McpConfigParseError(relPath);
+  }
+
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, updated);
+  return relPath;
+}
+
+/**
+ * Register Concord in every JSON-shaped client config under `repoRoot`
+ * (Claude Code's `.mcp.json` and Cursor's `.cursor/mcp.json`), creating each
+ * file if absent. Returns the relative paths written.
+ */
+export function installMcpConfigs(repoRoot: string): string[] {
+  return JSON_TARGETS.map((relPath) => writeMcpConfig(repoRoot, relPath));
+}

--- a/test/install/codex-config.test.ts
+++ b/test/install/codex-config.test.ts
@@ -1,0 +1,105 @@
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  CODEX_SECTION_HEADER,
+  codexConfigFile,
+  installCodexMcpConfig,
+  upsertCodexMcpServer,
+} from '../../src/install/codex-config.js';
+import { CONCORD_SERVER_COMMAND } from '../../src/install/mcp-config.js';
+
+describe('codexConfigFile', () => {
+  it('honors CODEX_HOME', () => {
+    const home = join(tmpdir(), 'codex-home');
+    expect(codexConfigFile({ CODEX_HOME: home })).toBe(join(home, 'config.toml'));
+  });
+
+  it('falls back to ~/.codex when CODEX_HOME is unset or blank', () => {
+    const expected = join(homedir(), '.codex', 'config.toml');
+    expect(codexConfigFile({})).toBe(expected);
+    expect(codexConfigFile({ CODEX_HOME: '  ' })).toBe(expected);
+  });
+});
+
+describe('upsertCodexMcpServer', () => {
+  it('writes the table into an empty config', () => {
+    const out = upsertCodexMcpServer(undefined);
+    expect(out).toContain(CODEX_SECTION_HEADER);
+    expect(out).toContain(`command = "${CONCORD_SERVER_COMMAND}"`);
+  });
+
+  it('is idempotent: re-running produces identical output', () => {
+    const once = upsertCodexMcpServer(undefined);
+    expect(upsertCodexMcpServer(once)).toBe(once);
+  });
+
+  it('preserves unrelated tables and their comments', () => {
+    const existing = [
+      '# my codex config',
+      'model = "gpt-5"',
+      '',
+      '[mcp_servers.other]',
+      'command = "other-server"',
+      '',
+    ].join('\n');
+    const out = upsertCodexMcpServer(existing);
+
+    expect(out).toContain('# my codex config');
+    expect(out).toContain('model = "gpt-5"');
+    expect(out).toContain('[mcp_servers.other]');
+    expect(out).toContain('other-server');
+    expect(out).toContain(CODEX_SECTION_HEADER);
+    expect(upsertCodexMcpServer(out)).toBe(out);
+  });
+
+  it('replaces a stale concord table in place without duplicating it', () => {
+    const existing = [
+      '[mcp_servers.concord]',
+      'command = "old-binary"',
+      '',
+      '[other]',
+      'key = 1',
+      '',
+    ].join('\n');
+    const out = upsertCodexMcpServer(existing);
+
+    expect(out).not.toContain('old-binary');
+    expect(out).toContain(`command = "${CONCORD_SERVER_COMMAND}"`);
+    expect(out.split(CODEX_SECTION_HEADER).length - 1).toBe(1);
+    expect(out).toContain('[other]');
+    expect(out).toContain('key = 1');
+  });
+
+  it('keeps a nested concord subtable, which is a table in its own right', () => {
+    const existing = [
+      '[mcp_servers.concord]',
+      'command = "old-binary"',
+      '',
+      '[mcp_servers.concord.env]',
+      'CONCORD_REPO_ROOT = "/tmp/repo"',
+      '',
+    ].join('\n');
+    const out = upsertCodexMcpServer(existing);
+
+    expect(out).not.toContain('old-binary');
+    expect(out).toContain('[mcp_servers.concord.env]');
+    expect(out).toContain('CONCORD_REPO_ROOT = "/tmp/repo"');
+  });
+});
+
+describe('installCodexMcpConfig', () => {
+  it('writes config.toml under CODEX_HOME and is idempotent', () => {
+    const home = mkdtempSync(join(tmpdir(), 'concord-codex-'));
+    const path = installCodexMcpConfig({ CODEX_HOME: home });
+
+    expect(path).toBe(join(home, 'config.toml'));
+    const first = readFileSync(path, 'utf8');
+    expect(first).toContain(CONCORD_SERVER_COMMAND);
+
+    installCodexMcpConfig({ CODEX_HOME: home });
+    expect(readFileSync(path, 'utf8')).toBe(first);
+  });
+});

--- a/test/install/mcp-config.test.ts
+++ b/test/install/mcp-config.test.ts
@@ -1,0 +1,88 @@
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  CONCORD_SERVER_COMMAND,
+  CONCORD_SERVER_KEY,
+  McpConfigParseError,
+  installMcpConfigs,
+  upsertMcpServer,
+} from '../../src/install/mcp-config.js';
+
+describe('upsertMcpServer', () => {
+  it('registers the concord server in an empty config', () => {
+    const out = upsertMcpServer(undefined);
+    expect(out).toContain('mcpServers');
+    expect(out).toContain(CONCORD_SERVER_KEY);
+    expect(out).toContain(CONCORD_SERVER_COMMAND);
+    expect(out.endsWith('\n')).toBe(true);
+  });
+
+  it('is idempotent: re-running produces identical output', () => {
+    const once = upsertMcpServer(undefined);
+    const twice = upsertMcpServer(once);
+    expect(twice).toBe(once);
+  });
+
+  it('preserves other servers and unrelated top-level keys', () => {
+    const existing = JSON.stringify({
+      $schema: 'https://example.test/schema.json',
+      mcpServers: { other: { command: 'other-server', args: ['--flag'] } },
+    });
+    const out = upsertMcpServer(existing);
+    expect(out).toContain('"$schema"');
+    expect(out).toContain('other-server');
+    expect(out).toContain('--flag');
+    expect(out).toContain(CONCORD_SERVER_COMMAND);
+  });
+
+  it('does not duplicate the server when it is already present', () => {
+    const twice = upsertMcpServer(upsertMcpServer(undefined));
+    expect(twice.split(CONCORD_SERVER_COMMAND).length - 1).toBe(1);
+  });
+
+  it('throws on malformed JSON rather than discarding it', () => {
+    expect(() => upsertMcpServer('{ not json')).toThrow();
+  });
+});
+
+describe('installMcpConfigs', () => {
+  it('writes both JSON client targets', () => {
+    const root = mkdtempSync(join(tmpdir(), 'concord-mcp-config-'));
+    const written = installMcpConfigs(root);
+
+    expect(written).toEqual(['.mcp.json', join('.cursor', 'mcp.json')]);
+    for (const relPath of written) {
+      expect(existsSync(join(root, relPath))).toBe(true);
+      expect(readFileSync(join(root, relPath), 'utf8')).toContain(CONCORD_SERVER_COMMAND);
+    }
+  });
+
+  it('is idempotent and preserves an existing server', () => {
+    const root = mkdtempSync(join(tmpdir(), 'concord-mcp-config-'));
+    writeFileSync(
+      join(root, '.mcp.json'),
+      `${JSON.stringify({ mcpServers: { other: { command: 'other-server' } } }, null, 2)}\n`,
+    );
+
+    installMcpConfigs(root);
+    const first = readFileSync(join(root, '.mcp.json'), 'utf8');
+    installMcpConfigs(root);
+    const second = readFileSync(join(root, '.mcp.json'), 'utf8');
+
+    expect(first).toContain('other-server');
+    expect(first).toContain(CONCORD_SERVER_COMMAND);
+    expect(second).toBe(first);
+  });
+
+  it('reports the offending path and leaves malformed config untouched', () => {
+    const root = mkdtempSync(join(tmpdir(), 'concord-mcp-config-'));
+    const broken = '{ this is not json\n';
+    writeFileSync(join(root, '.mcp.json'), broken);
+
+    expect(() => installMcpConfigs(root)).toThrow(McpConfigParseError);
+    expect(readFileSync(join(root, '.mcp.json'), 'utf8')).toBe(broken);
+  });
+});


### PR DESCRIPTION
## Problem

`concord install` wrote only instruction markdown (`CLAUDE.md`, `AGENTS.md`, `.codex/concord.md`, `.cursor/rules/concord.mdc`) and never registered the MCP server — `grep` for `mcpServers` across `src/` returned zero hits. The result is an install that writes documentation telling agents to call `claim_work` / `handoff` while those tools are not connected to anything.

Registration was documented as a manual prerequisite (`docs/claude-code.md` step 2, *before* `concord install` at step 3), so this wasn't strictly a bug — but `install` is the natural home for "make Concord work here," and the step users skip is exactly the one it didn't own. This hit us in this very repo: the instruction files landed, no `.concord/` was created, and no `mcp__concord__*` tools were available.

## What changed

`concord install` now also registers the server in:

| Client | File |
|---|---|
| Claude Code | `.mcp.json` |
| Cursor | `.cursor/mcp.json` |
| Codex | `~/.codex/config.toml` (honors `CODEX_HOME`) |

Generated output matches the previously documented snippets byte-for-byte, using the bare `concord-mcp` bin. That's deliberate: anyone running `concord install` already has the global bin — the command couldn't execute otherwise — and `.claude/settings.json` hooks already invoke a bare `concord`. Emitting an `npx @latest` config instead would point at a *different* copy of the package than the CLI and hooks use, and with 7 append-only migrations gated on `PRAGMA user_version`, two version sources against one SQLite file invites schema skew. The README's one-click Cursor deeplink keeps using `npx`, which is correct for that entry point since it can't assume a global install.

### Implementation notes

- **JSON targets** mirror `src/install/claude-hooks.ts` exactly — a pure `string → string` upsert (unit-tested without disk) plus a thin filesystem wrapper. Merging uses zod `.passthrough()` + object spread, so other MCP servers and unrelated top-level keys survive untouched.
- **Codex TOML** is spliced by line range rather than parsed and re-serialized — a round-trip through a parser would discard the user's comments and formatting. A nested `[mcp_servers.concord.env]` is itself a table header, so any subtable the user added is preserved as trailing content.
- **Malformed config** is reported (`.mcp.json is not valid JSON — fix or remove it, then re-run.`) with a non-zero exit and the file left **untouched**. This is a deliberate divergence from `claude-hooks.ts`, which lets a raw `JSON.parse` stack trace escape.
- **`--no-mcp`** skips registration for anyone hand-managing these files.

Everything is idempotent; `installConcord`'s existing return contract is unchanged, so the new writers are wired in from the CLI action the same way `installClaudeHook` is.

## Verification

`pnpm lint && pnpm typecheck && pnpm test && pnpm build` all pass — 27 files, 201 tests, 14 of them new.

Manually verified in throwaway repos: all three files generated correctly; re-running leaves them byte-identical (checksummed); `--no-mcp` writes only the four markdown targets and no Codex config; a hand-broken `.mcp.json` produces the clear error, exit 1, and is left intact; and an existing `mcpServers` entry plus an unrelated `$schema` key are both preserved.

One cosmetic note: zod `.passthrough()` emits known keys before passthrough keys, so an existing file may have unrelated top-level keys reordered on first write. Output is stable across subsequent runs.

~467 LOC, under the 600 limit.