### PR TITLE
chore: gitignore .claude/ local agent state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist/
 coverage/
 
 # Local agent and Concord state (machine-specific, never committed)
+.claude/
 .codex/
 .concord/
 .cursor/


### PR DESCRIPTION
## What

Adds `.claude/` to the existing "Local agent and Concord state" block in `.gitignore`, alongside `.codex/`, `.concord/` and `.cursor/`.

## Why

That block covers Codex and Cursor but omitted Claude Code — an inconsistency rather than a decision, as far as I can tell.

It matters most for **git worktrees**. Claude Code creates them under `.claude/worktrees/`, and while that path is unignored:

- `git status` shows `?? .claude/`
- `git add -A` stages the worktree as an **embedded gitlink** — git only warns, it does not refuse. That commits a gitlink resolving on no other machine.

With concurrent agents in this repo, an unattended `git add -A && git commit` is an easy way to hit that.

## Notes

- Nothing under `.claude/` is currently tracked, so no `git rm --cached` is needed and no history is affected.
- This ignores **all** of `.claude/`, including `.claude/settings.json`. If shared hooks/permissions should be committed for the team later, that needs a `!.claude/settings.json` negation — flagging it as a deliberate tradeoff, not an oversight.

## Verification

`git check-ignore` confirms coverage of `.claude/worktrees/`, `settings.local.json` and `settings.json`; `git add -A` with a worktree present now stages only `.gitignore`.