### PR TITLE
fix: publish the relay plugin and install it from concord setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-08-06
+
+### Fixed
+
+- The relay plugin is now published. `files` listed only `dist`, so 0.7.0 on
+  npm contained the CLI and server but not `plugin/concord-relay` — the
+  background monitor is the only channel that reaches an idle Claude Code
+  agent, and it was unavailable to anyone who installed from the registry.
+- `concord setup` installs it. Codex hooks were installed automatically while
+  Claude Code's half of the relay was left to be wired up by hand, so a fresh
+  setup gave Codex live delivery and Claude Code none. A monitor can only be
+  declared by a plugin, so this links the packaged plugin into Claude Code's
+  skills directory, where it loads with no marketplace and no install step.
+
 ## [0.7.0] - 2026-08-06
 
 Inter-agent messages are now actually delivered. 0.6.1 shipped the send path but

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "access": "public"
   },
   "files": [
-    "dist"
+    "dist",
+    "plugin"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 
 import { writeArtifacts } from '../../artifacts/index.js';
 import { installClaudeHook } from '../../install/claude-hooks.js';
+import { installClaudeRelayPlugin } from '../../install/claude-plugin.js';
 import { installCodexHooks, installCodexMcpConfig } from '../../install/codex-config.js';
 import { installConcord } from '../../install/index.js';
 import { McpConfigParseError, installMcpConfigs } from '../../install/mcp-config.js';
@@ -52,6 +53,11 @@ export function runSetup(cwd: string, options: SetupOptions = {}): SetupResult {
   if (options.mcp !== false) {
     written.push(...installMcpConfigs(ctx.repoRoot));
     written.push(installCodexMcpConfig(env));
+    // Claude Code's half of the relay. Its background monitor is the only
+    // channel that reaches an agent idle at the prompt, and a monitor can only
+    // be declared by a plugin — settings.json cannot express one.
+    const plugin = installClaudeRelayPlugin(import.meta.url, env);
+    if (plugin !== undefined) written.push(plugin);
     // Codex has no background-monitor equivalent, so hooks are the only way it
     // can receive a message from another agent.
     written.push(installCodexHooks(env));

--- a/src/install/claude-plugin.ts
+++ b/src/install/claude-plugin.ts
@@ -1,0 +1,87 @@
+import { existsSync, lstatSync, mkdirSync, readlinkSync, rmSync, symlinkSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** Directory name the plugin is discovered under, and its invocation name. */
+export const RELAY_PLUGIN_NAME = 'concord-relay';
+
+/**
+ * The relay plugin shipped inside this package.
+ *
+ * Walks up from the calling module rather than counting `..` segments, because
+ * the caller sits at a different depth in `src/` than in `dist/` and a
+ * hard-coded count resolves to a plausible path that simply does not exist.
+ * Returns undefined when no packaged plugin is above the caller.
+ */
+export function packagedPluginPath(moduleUrl: string): string | undefined {
+  let dir = dirname(fileURLToPath(moduleUrl));
+  for (let depth = 0; depth < 6; depth += 1) {
+    const candidate = join(dir, 'plugin', RELAY_PLUGIN_NAME);
+    if (existsSync(join(candidate, '.claude-plugin', 'plugin.json'))) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return undefined;
+}
+
+/**
+ * Where Claude Code discovers plugins with no marketplace and no install step:
+ * any directory under the skills directory holding a `.claude-plugin/`
+ * manifest loads on the next session.
+ */
+export function claudeSkillsPluginPath(env: NodeJS.ProcessEnv = process.env): string {
+  const configDir = env['CLAUDE_CONFIG_DIR'];
+  const base =
+    configDir !== undefined && configDir.trim() !== ''
+      ? configDir
+      : join(env['HOME'] ?? homedir(), '.claude');
+  return join(base, 'skills', RELAY_PLUGIN_NAME);
+}
+
+/**
+ * Link the packaged relay plugin into Claude Code's skills directory.
+ *
+ * A symlink rather than a copy, so upgrading the package upgrades the plugin —
+ * the install path does not change between versions. Returns the link path, or
+ * undefined when the plugin is not present (a source checkout that has not been
+ * packaged, for instance) so setup can carry on rather than fail.
+ *
+ * This writes outside the repository, like the Codex config installer does, and
+ * for the same reason: the plugin has to be visible to every session, not just
+ * sessions started in one project.
+ */
+export function installClaudeRelayPlugin(
+  moduleUrl: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const source = packagedPluginPath(moduleUrl);
+  if (source === undefined) return undefined;
+
+  const target = claudeSkillsPluginPath(env);
+  mkdirSync(dirname(target), { recursive: true });
+
+  if (existsSync(target) || isBrokenLink(target)) {
+    // Re-point a stale link (an older install path) but never clobber a real
+    // directory someone put there by hand.
+    if (!isSymlink(target)) return target;
+    if (readlinkSync(target) === source) return target;
+    rmSync(target);
+  }
+  symlinkSync(source, target);
+  return target;
+}
+
+function isSymlink(path: string): boolean {
+  try {
+    return lstatSync(path).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+/** A symlink whose target is gone: `existsSync` follows links and says false. */
+function isBrokenLink(path: string): boolean {
+  return isSymlink(path) && !existsSync(path);
+}

--- a/test/install/claude-plugin.test.ts
+++ b/test/install/claude-plugin.test.ts
@@ -1,0 +1,101 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  claudeSkillsPluginPath,
+  installClaudeRelayPlugin,
+  packagedPluginPath,
+} from '../../src/install/claude-plugin.js';
+
+/** A stand-in package layout: <root>/plugin/concord-relay + a caller module. */
+function packagedTree(): { moduleUrl: string; source: string } {
+  const root = mkdtempSync(join(tmpdir(), 'concord-pkg-'));
+  const source = join(root, 'plugin', 'concord-relay');
+  mkdirSync(join(source, '.claude-plugin'), { recursive: true });
+  writeFileSync(join(source, '.claude-plugin', 'plugin.json'), '{"name":"concord-relay"}');
+  mkdirSync(join(root, 'dist', 'cli', 'commands'), { recursive: true });
+  // The real caller lives at dist/cli/commands/setup.js — three levels down.
+  return {
+    moduleUrl: pathToFileURL(join(root, 'dist', 'cli', 'commands', 'setup.js')).href,
+    source,
+  };
+}
+
+describe('installClaudeRelayPlugin', () => {
+  let home: string;
+  let env: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'concord-home-'));
+    env = { CLAUDE_CONFIG_DIR: join(home, '.claude') };
+  });
+
+  it('links the packaged plugin where Claude Code discovers it', () => {
+    const { moduleUrl, source } = packagedTree();
+
+    const target = installClaudeRelayPlugin(moduleUrl, env);
+
+    expect(target).toBe(claudeSkillsPluginPath(env));
+    expect(readlinkSync(target ?? '')).toBe(source);
+    expect(existsSync(join(target ?? '', '.claude-plugin', 'plugin.json'))).toBe(true);
+  });
+
+  it('is a no-op when run twice', () => {
+    const { moduleUrl } = packagedTree();
+
+    const first = installClaudeRelayPlugin(moduleUrl, env);
+    const second = installClaudeRelayPlugin(moduleUrl, env);
+
+    expect(second).toBe(first);
+  });
+
+  it('re-points a link left behind by an older install', () => {
+    const { moduleUrl, source } = packagedTree();
+    const target = claudeSkillsPluginPath(env);
+    mkdirSync(join(home, '.claude', 'skills'), { recursive: true });
+    symlinkSync(join(home, 'gone'), target);
+
+    installClaudeRelayPlugin(moduleUrl, env);
+
+    expect(readlinkSync(target)).toBe(source);
+  });
+
+  it('leaves a real directory someone put there alone', () => {
+    const { moduleUrl } = packagedTree();
+    const target = claudeSkillsPluginPath(env);
+    mkdirSync(join(target, '.claude-plugin'), { recursive: true });
+    writeFileSync(join(target, '.claude-plugin', 'plugin.json'), '{"name":"mine"}');
+
+    installClaudeRelayPlugin(moduleUrl, env);
+
+    expect(readFileSync(join(target, '.claude-plugin', 'plugin.json'), 'utf8')).toContain('mine');
+  });
+
+  it('reports nothing to install when the plugin was not packaged', () => {
+    const bare = mkdtempSync(join(tmpdir(), 'concord-bare-'));
+    const moduleUrl = pathToFileURL(join(bare, 'dist', 'cli', 'setup.js')).href;
+
+    expect(installClaudeRelayPlugin(moduleUrl, env)).toBeUndefined();
+  });
+
+  it('finds the plugin from any caller depth, not a fixed number of levels up', () => {
+    const { source } = packagedTree();
+    const root = source.replace('/plugin/concord-relay', '');
+
+    for (const rel of ['dist/cli/setup.js', 'dist/cli/commands/setup.js', 'src/x/y/z/a.ts']) {
+      expect(packagedPluginPath(pathToFileURL(join(root, rel)).href)).toBe(source);
+    }
+  });
+});


### PR DESCRIPTION
Two problems with 0.7.0, both of which leave the headline feature unavailable to anyone who installs from npm.

**The plugin was never published.** `files` listed only `dist`, so the tarball contains the CLI and MCP server but not `plugin/concord-relay`. Its background monitor is the only channel that reaches an idle Claude Code agent, so a registry install had no idle delivery at all.

**`concord setup` never installed it.** Codex hooks were written automatically while Claude Code's half of the relay was left to be wired up by hand — I had symlinked it manually while testing and did not notice setup was not doing it. A fresh setup therefore gave Codex live delivery and Claude Code none.

A monitor can only be declared by a plugin; `settings.json` cannot express one. So setup links the packaged plugin into Claude Code's skills directory, where any folder with a `.claude-plugin/` manifest loads with no marketplace and no install step. A symlink rather than a copy, so upgrading the package upgrades the plugin.

## One thing worth reviewing

The plugin is located by walking up from the calling module rather than counting `..` segments. My first attempt hard-coded two levels and my test agreed with it, because the fixture put the caller at `dist/cli/setup.js` — the real one is `dist/cli/commands/setup.js`, one deeper. It resolved to `dist/plugin/concord-relay`, which does not exist, and the installer would have silently reported "nothing to install" on every real run. The test now exercises three different caller depths, and I verified resolution against the actual built `dist/` rather than only the fixture.

Verified end to end: `concord setup` with `CLAUDE_CONFIG_DIR` pointed at a temp home creates `skills/concord-relay -> <package>/plugin/concord-relay` and reports it under `configured:`.

248 tests, full gate green.