### PR TITLE
Maintain task-level activity timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Task-scoped activity now refreshes the task's `updated_at` timestamp, so
+  current-state views reflect reclaims, progress updates, task-scoped messages,
+  handoffs, reviews, and lifecycle work independently of agent heartbeat.
+  Activity refreshes do not increment the optimistic-concurrency version.
+
 ## [0.7.1] - 2026-08-06
 
 ### Fixed

--- a/src/artifacts/work-state-json.ts
+++ b/src/artifacts/work-state-json.ts
@@ -9,6 +9,7 @@ interface WorkStateTask {
   agent_id: string | null;
   assigned_agent_id: string | null;
   version: number;
+  updated_at: string;
   lease_expires_at: string | null;
   owner: string | null;
   branch: string | null;
@@ -44,6 +45,7 @@ function toWorkStateTask(task: TaskRecord): WorkStateTask {
     agent_id: task.agentId,
     assigned_agent_id: task.assignedAgentId,
     version: task.version,
+    updated_at: task.updatedAt,
     lease_expires_at: task.leaseExpiresAt,
     owner: task.owner,
     branch: task.branch,

--- a/src/artifacts/work-state-view.ts
+++ b/src/artifacts/work-state-view.ts
@@ -17,6 +17,7 @@ interface ActiveEntry {
   assignedAgentId: string | null;
   status: string;
   version: number;
+  updatedAt: string;
   branch: string;
   touches: string;
   parentTaskId: string | null;
@@ -124,6 +125,7 @@ export function buildStatus(repos: Repositories, now: number = Date.now()): Stat
       assignedAgentId: task.assignedAgentId,
       status: task.status,
       version: task.version,
+      updatedAt: task.updatedAt,
       branch: task.branch ?? '-',
       touches: touchesOf(task),
       parentTaskId: task.parentTaskId,
@@ -179,7 +181,7 @@ export function renderStatusText(view: StatusView): string {
     for (const entry of view.active) {
       const parent = entry.parentTaskId === null ? '' : `  (child of ${entry.parentTaskId})`;
       lines.push(
-        `  ${entry.taskId.padEnd(10)} ${entry.status.padEnd(16)} v${String(entry.version).padEnd(4)} ${(entry.agentId ?? entry.assignedAgentId ?? entry.agent).padEnd(18)} ${entry.branch.padEnd(20)} touches: ${entry.touches}${parent}`,
+        `  ${entry.taskId.padEnd(10)} ${entry.status.padEnd(16)} v${String(entry.version).padEnd(4)} ${(entry.agentId ?? entry.assignedAgentId ?? entry.agent).padEnd(18)} ${entry.branch.padEnd(20)} activity: ${entry.updatedAt}  touches: ${entry.touches}${parent}`,
       );
     }
   }

--- a/src/cli/commands/tasks.ts
+++ b/src/cli/commands/tasks.ts
@@ -13,7 +13,7 @@ export function renderTasks(tasks: readonly TaskRecord[]): string {
       const id = task.taskId.padEnd(10);
       const status = task.status.padEnd(13);
       const agent = (task.agentId ?? task.assignedAgentId ?? task.agent ?? '-').padEnd(18);
-      return `${id} ${status} v${String(task.version).padEnd(4)} ${agent} ${task.title}`;
+      return `${id} ${status} v${String(task.version).padEnd(4)} ${agent} ${task.updatedAt} ${task.title}`;
     })
     .join('\n');
 }

--- a/src/cli/dashboard/app.tsx
+++ b/src/cli/dashboard/app.tsx
@@ -177,7 +177,7 @@ function Context({ item }: { item: DashboardTask | undefined }): ReactNode {
       <Text wrap="truncate-end">
         owner {item.task.owner ?? '-'} · agent{' '}
         {item.task.agentId ?? item.task.assignedAgentId ?? '-'} · branch {item.task.branch ?? '-'} ·
-        touches {item.touches}
+        activity {item.task.updatedAt} · touches {item.touches}
       </Text>
       {item.updates.slice(-5).map((update) => (
         <Text key={`update-${String(update.id)}`} wrap="truncate-end">

--- a/src/db/repositories/tasks.ts
+++ b/src/db/repositories/tasks.ts
@@ -36,6 +36,7 @@ export interface TaskRepository {
   create(task: NewTask): TaskRecord;
   get(taskId: string): TaskRecord | undefined;
   list(): TaskRecord[];
+  touchActivity(taskId: string): TaskRecord | undefined;
   updateStatus(taskId: string, status: TaskStatus): TaskRecord | undefined;
   updateScope(taskId: string, scope: TaskScope): TaskRecord | undefined;
   transition(input: TaskTransition): TaskRecord | undefined;
@@ -68,6 +69,9 @@ export function createTaskRepository(db: ConcordDatabase): TaskRepository {
   `);
   const getStmt = db.prepare('SELECT * FROM tasks WHERE task_id = ?');
   const listStmt = db.prepare('SELECT * FROM tasks ORDER BY created_at ASC, task_id ASC');
+  const touchActivityStmt = db.prepare(
+    'UPDATE tasks SET updated_at = @updated_at WHERE task_id = @task_id',
+  );
   const updateStatusStmt = db.prepare(
     `UPDATE tasks
      SET status = @status, version = version + 1, updated_at = @updated_at
@@ -132,6 +136,10 @@ export function createTaskRepository(db: ConcordDatabase): TaskRepository {
     list() {
       const raw: unknown = listStmt.all();
       return rawListSchema.parse(raw).map(parseTaskRow);
+    },
+    touchActivity(taskId) {
+      touchActivityStmt.run({ task_id: taskId, updated_at: new Date().toISOString() });
+      return get(taskId);
     },
     updateStatus(taskId, status) {
       updateStatusStmt.run({ task_id: taskId, status, updated_at: new Date().toISOString() });

--- a/src/db/rows.ts
+++ b/src/db/rows.ts
@@ -105,6 +105,7 @@ export interface TaskRecord {
   /** Optional assignment/ownership lease deadline. */
   leaseExpiresAt: string | null;
   createdAt: string;
+  /** Latest successful, meaningful task write; independent of agent heartbeat. */
   updatedAt: string;
 }
 

--- a/src/tools/agent-messages.ts
+++ b/src/tools/agent-messages.ts
@@ -5,6 +5,7 @@ import type {
   AgentMessageErrorCode,
   AgentMessageRecord,
   Repositories,
+  TaskRecord,
 } from '../db/index.js';
 import { deliveryOutlook, transports } from '../domain/delivery.js';
 
@@ -32,6 +33,7 @@ export interface SendAgentMessageInput {
 export interface SendAgentMessageResult {
   message: AgentMessageRecord;
   idempotentReplay: boolean;
+  task: TaskRecord | null;
   /** What the sender should expect about when the recipient will see this. */
   outlook: string;
 }
@@ -131,6 +133,8 @@ export function handleSendAgentMessage(
   if (input.taskId !== undefined && repos.tasks.get(input.taskId) === undefined) {
     throw new Error(`Task ${input.taskId} does not exist.`);
   }
+  const contextualTaskId = input.taskId ?? parent?.taskId ?? null;
+  const task = contextualTaskId === null ? undefined : repos.tasks.get(contextualTaskId);
 
   const replay = repos.agentMessages.getByIdempotency(input.agentId, input.idempotencyKey);
   let message: AgentMessageRecord;
@@ -159,6 +163,7 @@ export function handleSendAgentMessage(
       return {
         message: replay,
         idempotentReplay: true,
+        task: task ?? null,
         outlook: deliveryOutlook(known?.capabilities ?? []),
       };
     }
@@ -167,7 +172,7 @@ export function handleSendAgentMessage(
   } else {
     message = repos.agentMessages.create({
       messageId: randomUUID(),
-      taskId: input.taskId ?? parent?.taskId ?? null,
+      taskId: contextualTaskId,
       senderAgentId: input.agentId,
       recipientAgentId,
       replyToMessageId: parent?.messageId ?? null,
@@ -199,7 +204,14 @@ export function handleSendAgentMessage(
     repos.agentMessages.markReplied(parent.messageId);
   }
   repos.agents.touch(input.agentId);
-  return { message, idempotentReplay, outlook: deliveryOutlook(endpoint.capabilities) };
+  const activityTask =
+    !idempotentReplay && task !== undefined ? repos.tasks.touchActivity(task.taskId) : task;
+  return {
+    message,
+    idempotentReplay,
+    task: activityTask ?? null,
+    outlook: deliveryOutlook(endpoint.capabilities),
+  };
 }
 
 export interface AgentCommunicationView {

--- a/src/tools/agent-messages.ts
+++ b/src/tools/agent-messages.ts
@@ -143,7 +143,8 @@ export function handleSendAgentMessage(
     if (
       replay.recipientAgentId !== recipientAgentId ||
       replay.content !== input.content ||
-      replay.replyToMessageId !== (parent?.messageId ?? null)
+      replay.replyToMessageId !== (parent?.messageId ?? null) ||
+      replay.taskId !== contextualTaskId
     ) {
       throw new AgentMessageDeliveryError(
         'unauthorized',

--- a/src/tools/claim-work.ts
+++ b/src/tools/claim-work.ts
@@ -110,7 +110,7 @@ export function handleClaimWork(repos: Repositories, input: ClaimWorkInput): Cla
   } else if (scopeAdded.length > 0) {
     task = repos.tasks.updateScope(input.task_id, scope) ?? existing;
   } else {
-    task = existing;
+    task = repos.tasks.touchActivity(input.task_id) ?? existing;
   }
 
   repos.events.record({

--- a/src/tools/handoff.ts
+++ b/src/tools/handoff.ts
@@ -62,6 +62,10 @@ export function handleHandoff(repos: Repositories, input: HandoffInput): Handoff
       status: 'success',
       detail: input.status,
     });
+    const activityTask = repos.tasks.touchActivity(input.task_id);
+    if (activityTask === undefined) {
+      throw new Error(`Task ${input.task_id} disappeared while evidence was recorded.`);
+    }
     if (input.agent_id !== undefined) {
       repos.agents.touch(input.agent_id);
     }
@@ -78,7 +82,7 @@ export function handleHandoff(repos: Repositories, input: HandoffInput): Handoff
         expected_version: input.expected_version,
       });
     }
-    const task = repos.tasks.get(input.task_id);
+    const task = reviewReady ? repos.tasks.get(input.task_id) : activityTask;
     if (task === undefined) {
       throw new Error(`Task ${input.task_id} disappeared while evidence was recorded.`);
     }

--- a/src/tools/update-task.ts
+++ b/src/tools/update-task.ts
@@ -1,8 +1,9 @@
-import type { Repositories, TaskUpdateRecord } from '../db/index.js';
+import type { Repositories, TaskRecord, TaskUpdateRecord } from '../db/index.js';
 import type { UpdateTaskInput } from '../domain/operations.js';
 
 export interface UpdateTaskResult {
   update: TaskUpdateRecord;
+  task: TaskRecord;
 }
 
 /** Append one durable, task-scoped memory entry for other agents and sessions. */
@@ -26,20 +27,27 @@ export function handleUpdateTask(repos: Repositories, input: UpdateTaskInput): U
     }
   }
 
-  const update = repos.taskUpdates.create({
-    taskId: input.task_id,
-    kind: input.kind,
-    content: input.content,
-    agent: input.agent ?? input.agent_id ?? task.agent,
+  const transact = repos.db.transaction(() => {
+    const update = repos.taskUpdates.create({
+      taskId: input.task_id,
+      kind: input.kind,
+      content: input.content,
+      agent: input.agent ?? input.agent_id ?? task.agent,
+    });
+    const updatedTask = repos.tasks.touchActivity(input.task_id);
+    if (updatedTask === undefined) {
+      throw new Error(`Task ${input.task_id} disappeared while its update was recorded.`);
+    }
+    repos.events.record({
+      taskId: input.task_id,
+      tool: 'update_task',
+      status: 'success',
+      detail: input.kind,
+    });
+    if (input.agent_id !== undefined) {
+      repos.agents.touch(input.agent_id);
+    }
+    return { update, task: updatedTask };
   });
-  repos.events.record({
-    taskId: input.task_id,
-    tool: 'update_task',
-    status: 'success',
-    detail: input.kind,
-  });
-  if (input.agent_id !== undefined) {
-    repos.agents.touch(input.agent_id);
-  }
-  return { update };
+  return transact();
 }

--- a/src/tools/workflow.ts
+++ b/src/tools/workflow.ts
@@ -380,6 +380,7 @@ function taskFields(task: TaskRecord): Record<string, unknown> {
     task_id: task.taskId,
     status: task.status,
     version: task.version,
+    updated_at: task.updatedAt,
     agent_id: task.agentId,
     assigned_agent_id: task.assignedAgentId,
     lease_expires_at: task.leaseExpiresAt,
@@ -593,6 +594,7 @@ export function registerWorkflowTools(
               content: result.update.content,
               agent: result.update.agent,
               created_at: result.update.createdAt,
+              task_updated_at: result.task.updatedAt,
             },
           };
         }
@@ -618,6 +620,8 @@ export function registerWorkflowTools(
             sender_agent_id: result.message.senderAgentId,
             recipient_agent_id: result.message.recipientAgentId,
             reply_to_message_id: result.message.replyToMessageId,
+            task_id: result.message.taskId,
+            task_updated_at: result.task?.updatedAt ?? null,
             provider: result.message.provider,
             provider_receipt: result.message.providerReceipt,
             delivered_at: result.message.deliveredAt,

--- a/test/artifacts/artifacts.test.ts
+++ b/test/artifacts/artifacts.test.ts
@@ -67,11 +67,14 @@ describe('writeArtifacts', () => {
       .object({
         generated_at: z.string(),
         presence: z.array(z.object({ agent_id: z.string(), liveness: z.string() })),
-        tasks: z.array(z.object({ task_id: z.string(), status: z.string() })),
+        tasks: z.array(
+          z.object({ task_id: z.string(), status: z.string(), updated_at: z.string() }),
+        ),
       })
       .parse(JSON.parse(readFileSync(join(dir, 'WORK_STATE.json'), 'utf8')));
     expect(workState.generated_at).toBe('2026-07-17T00:00:00.000Z');
     expect(workState.tasks[0]?.task_id).toBe('TASK-12');
+    expect(workState.tasks[0]?.updated_at).toBe(repos.tasks.get('TASK-12')?.updatedAt);
     expect(workState.presence[0]?.agent_id).toBe('claude-code:7p8v');
 
     const events = readFileSync(join(dir, 'events.jsonl'), 'utf8').trim().split('\n');

--- a/test/cli/cli-core.test.ts
+++ b/test/cli/cli-core.test.ts
@@ -78,6 +78,7 @@ describe('renderTasks', () => {
     expect(output).toContain('TASK-12');
     expect(output).toContain('claude-code');
     expect(output).toContain('Retry');
+    expect(output).toContain(repos.tasks.get('TASK-12')?.updatedAt ?? 'missing timestamp');
   });
 });
 
@@ -114,6 +115,7 @@ describe('buildStatus / renderStatusText', () => {
 
     const text = renderStatusText(view);
     expect(text).toContain('TASK-12');
+    expect(text).toContain(view.active[0]?.updatedAt ?? 'missing timestamp');
     expect(text).toContain('touches: billing');
     expect(text).toContain('TASK-12 <-> TASK-14');
   });

--- a/test/cli/dashboard.test.tsx
+++ b/test/cli/dashboard.test.tsx
@@ -99,6 +99,10 @@ describe('dashboard snapshot', () => {
 
     view.stdin.write('j');
     expect(view.lastFrame()).toContain('Use a queued retry');
+    expect(view.lastFrame()).toContain(
+      snapshot.tasks.find((item) => item.task.taskId === 'TASK-12')?.task.updatedAt ??
+        'missing timestamp',
+    );
   });
 
   it('uses a compact view below 70 columns', () => {

--- a/test/db/storage.test.ts
+++ b/test/db/storage.test.ts
@@ -178,6 +178,21 @@ describe('task repository', () => {
     expect(repos.tasks.get('CHILD')?.parentTaskId).toBe('PARENT');
     expect(repos.tasks.get('PARENT')?.parentTaskId).toBeNull();
   });
+
+  it('refreshes task activity without changing its lifecycle version', () => {
+    repos.tasks.create(baseTask);
+    const oldTimestamp = '2026-01-01T00:00:00.000Z';
+    repos.db
+      .prepare('UPDATE tasks SET updated_at = ? WHERE task_id = ?')
+      .run(oldTimestamp, 'TASK-12');
+
+    const touched = repos.tasks.touchActivity('TASK-12');
+
+    expect(touched?.updatedAt).not.toBe(oldTimestamp);
+    expect(touched).toMatchObject({ version: 1, status: 'active' });
+    expect(touched?.expectedFiles).toEqual(baseTask.expectedFiles);
+    expect(repos.tasks.touchActivity('MISSING')).toBeUndefined();
+  });
 });
 
 describe('handoff repository', () => {

--- a/test/tools/get-work-state.test.ts
+++ b/test/tools/get-work-state.test.ts
@@ -53,6 +53,7 @@ describe('handleGetWorkState', () => {
       'TASK-1',
       'TASK-2',
     ]);
+    expect(view.active.every((task) => task.updatedAt.length > 0)).toBe(true);
     // TASK-1's claim returned no overlaps at claim time, but the read surface
     // recomputes them, so the TASK-1 <-> TASK-2 conflict is now visible.
     expect(view.overlaps).toHaveLength(1);
@@ -86,6 +87,7 @@ describe('work-state MCP surface (end-to-end via in-memory transport)', () => {
 
       const called = await client.callTool({ name: 'inspect_work', arguments: {} });
       expect(JSON.stringify(called)).toContain('TASK-1');
+      expect(JSON.stringify(called)).toContain('updatedAt');
 
       const read = await client.readResource({ uri: WORK_STATE_URI });
       expect(JSON.stringify(read)).toContain('TASK-1');

--- a/test/tools/handoff.test.ts
+++ b/test/tools/handoff.test.ts
@@ -14,6 +14,10 @@ describe('handleHandoff', () => {
 
   it('records evidence without transferring ownership or changing task status', () => {
     handleClaimWork(repos, { task_id: 'TASK-12', title: 'Retry', modules: ['billing'] });
+    const oldTimestamp = '2026-01-01T00:00:00.000Z';
+    repos.db
+      .prepare('UPDATE tasks SET updated_at = ? WHERE task_id = ?')
+      .run(oldTimestamp, 'TASK-12');
     const result = handleHandoff(repos, {
       task_id: 'TASK-12',
       status: 'done',
@@ -24,7 +28,8 @@ describe('handleHandoff', () => {
     });
 
     expect(result.handoff.whatChanged).toBe('Queued retries instead of synchronous');
-    expect(repos.tasks.get('TASK-12')?.status).toBe('active');
+    expect(repos.tasks.get('TASK-12')).toMatchObject({ status: 'active', version: 1 });
+    expect(repos.tasks.get('TASK-12')?.updatedAt).not.toBe(oldTimestamp);
     expect(repos.handoffs.latestForTask('TASK-12')?.status).toBe('done');
     expect(repos.events.listByTask('TASK-12').map((e) => e.tool)).toEqual([
       'claim_work',

--- a/test/tools/workflow.test.ts
+++ b/test/tools/workflow.test.ts
@@ -58,13 +58,34 @@ describe('simplified workflow MCP contract', () => {
         },
       });
       expect(started.isError).not.toBe(true);
+      expect(JSON.stringify(started)).toContain('"updated_at"');
       expect(repos.tasks.get('TASK-1')).toMatchObject({
         status: 'active',
         agentId: 'codex:owner',
         expectedFiles: ['src/server.ts'],
       });
+      const oldTimestamp = '2026-01-01T00:00:00.000Z';
+      repos.db
+        .prepare('UPDATE tasks SET updated_at = ? WHERE task_id = ?')
+        .run(oldTimestamp, 'TASK-1');
 
-      await harness.client.callTool({
+      const reclaimed = await harness.client.callTool({
+        name: 'start_work',
+        arguments: {
+          task_id: 'TASK-1',
+          title: 'Simplify lifecycle',
+          kind: 'codex',
+          agent_id: 'codex:owner',
+        },
+      });
+      expect(reclaimed.isError).not.toBe(true);
+      expect(repos.tasks.get('TASK-1')).toMatchObject({ version: 1 });
+      expect(repos.tasks.get('TASK-1')?.updatedAt).not.toBe(oldTimestamp);
+
+      repos.db
+        .prepare('UPDATE tasks SET updated_at = ? WHERE task_id = ?')
+        .run(oldTimestamp, 'TASK-1');
+      const updated = await harness.client.callTool({
         name: 'update_work',
         arguments: {
           task_id: 'TASK-1',
@@ -73,6 +94,9 @@ describe('simplified workflow MCP contract', () => {
           content: 'Expose five tools',
         },
       });
+      expect(repos.tasks.get('TASK-1')).toMatchObject({ version: 1 });
+      expect(repos.tasks.get('TASK-1')?.updatedAt).not.toBe(oldTimestamp);
+      expect(JSON.stringify(updated)).toContain('"task_updated_at"');
       const inspected = await harness.client.callTool({
         name: 'inspect_work',
         arguments: { task_id: 'TASK-1' },
@@ -362,6 +386,10 @@ describe('simplified workflow MCP contract', () => {
         });
       }
       registerPullEndpoint(repos, 'codex:target', 'codex');
+      const oldTimestamp = '2026-01-01T00:00:00.000Z';
+      repos.db
+        .prepare('UPDATE tasks SET updated_at = ? WHERE task_id = ?')
+        .run(oldTimestamp, 'TASK-TARGET');
 
       const sent = await harness.client.callTool({
         name: 'update_work',
@@ -376,6 +404,12 @@ describe('simplified workflow MCP contract', () => {
       });
 
       expect(sent.isError).not.toBe(true);
+      expect(repos.tasks.get('TASK-TARGET')).toMatchObject({
+        version: 1,
+      });
+      expect(repos.tasks.get('TASK-TARGET')?.updatedAt).not.toBe(oldTimestamp);
+      expect(JSON.stringify(sent)).toContain('"task_id":"TASK-TARGET"');
+      expect(JSON.stringify(sent)).toContain('"task_updated_at"');
       // Codex is reachable only between steps of its own work, and the sender
       // is told so rather than being left to assume it landed.
       expect(JSON.stringify(sent)).toContain('next turn');
@@ -386,6 +420,43 @@ describe('simplified workflow MCP contract', () => {
       const drained = drainInbox(repos, 'codex:target', 'codex');
       expect(drained[0]?.content).toContain('Please re-check the parser boundary.');
       expect(repos.agentMessages.get(message?.messageId ?? '')?.status).toBe('delivered');
+      const deliveredTimestamp = repos.tasks.get('TASK-TARGET')?.updatedAt;
+      drainInbox(repos, 'codex:target', 'codex');
+      expect(repos.tasks.get('TASK-TARGET')?.updatedAt).toBe(deliveredTimestamp);
+
+      repos.db
+        .prepare('UPDATE tasks SET updated_at = ? WHERE task_id = ?')
+        .run(oldTimestamp, 'TASK-TARGET');
+      const replay = await harness.client.callTool({
+        name: 'update_work',
+        arguments: {
+          operation: 'prompt',
+          task_id: 'TASK-TARGET',
+          agent_id: 'codex:sender',
+          to_agent_id: 'codex:target',
+          content: 'Please re-check the parser boundary.',
+          idempotency_key: 'sender-1',
+        },
+      });
+      expect(JSON.stringify(replay)).toContain('"idempotent_replay":true');
+      expect(repos.tasks.get('TASK-TARGET')?.updatedAt).toBe(oldTimestamp);
+
+      const endpoint = repos.agentEndpoints.getByAgent('codex:target');
+      expect(endpoint).toBeDefined();
+      if (endpoint !== undefined) repos.agentEndpoints.disconnect(endpoint.endpointId);
+      const failed = await harness.client.callTool({
+        name: 'update_work',
+        arguments: {
+          operation: 'prompt',
+          task_id: 'TASK-TARGET',
+          agent_id: 'codex:sender',
+          to_agent_id: 'codex:target',
+          content: 'This should fail.',
+          idempotency_key: 'sender-failed',
+        },
+      });
+      expect(failed.isError).toBe(true);
+      expect(repos.tasks.get('TASK-TARGET')?.updatedAt).toBe(oldTimestamp);
 
       const inspected = await harness.client.callTool({
         name: 'inspect_work',
@@ -416,22 +487,55 @@ describe('simplified workflow MCP contract', () => {
         });
         registerPullEndpoint(repos, agentId, agentId.split(':')[0] ?? 'agent');
       }
+      await harness.client.callTool({
+        name: 'start_work',
+        arguments: {
+          task_id: 'TASK-THREAD',
+          title: 'Thread context',
+          kind: 'codex',
+          agent_id: 'codex:a',
+        },
+      });
+      const oldTimestamp = '2026-01-01T00:00:00.000Z';
+      repos.db
+        .prepare('UPDATE tasks SET updated_at = ? WHERE task_id = ?')
+        .run(oldTimestamp, 'TASK-THREAD');
+      await harness.client.callTool({
+        name: 'update_work',
+        arguments: {
+          operation: 'prompt',
+          agent_id: 'codex:a',
+          to_agent_id: 'claude:b',
+          content: 'Unscoped coordination',
+          idempotency_key: 'unscoped-1',
+        },
+      });
+      expect(repos.tasks.get('TASK-THREAD')?.updatedAt).toBe(oldTimestamp);
 
       const promptArguments = {
         operation: 'prompt',
+        task_id: 'TASK-THREAD',
         agent_id: 'codex:a',
         to_agent_id: 'claude:b',
         content: 'What did you find?',
         idempotency_key: 'question-1',
       } as const;
       await harness.client.callTool({ name: 'update_work', arguments: promptArguments });
+      expect(repos.tasks.get('TASK-THREAD')?.updatedAt).not.toBe(oldTimestamp);
+      repos.db
+        .prepare('UPDATE tasks SET updated_at = ? WHERE task_id = ?')
+        .run(oldTimestamp, 'TASK-THREAD');
       await harness.client.callTool({ name: 'update_work', arguments: promptArguments });
-      expect(repos.agentMessages.listByAgent('codex:a')).toHaveLength(1);
+      expect(repos.agentMessages.listByTask('TASK-THREAD')).toHaveLength(1);
+      expect(repos.tasks.get('TASK-THREAD')?.updatedAt).toBe(oldTimestamp);
 
       // A reply is only meaningful once the recipient has actually read the
       // message, which is what draining records.
       drainInbox(repos, 'claude:b', 'claude');
-      const parent = repos.agentMessages.listByAgent('codex:a')[0];
+      const parent = repos.agentMessages.listByTask('TASK-THREAD')[0];
+      repos.db
+        .prepare('UPDATE tasks SET updated_at = ? WHERE task_id = ?')
+        .run(oldTimestamp, 'TASK-THREAD');
       const reply = await harness.client.callTool({
         name: 'update_work',
         arguments: {
@@ -445,6 +549,8 @@ describe('simplified workflow MCP contract', () => {
       expect(reply.isError).not.toBe(true);
       expect(repos.agentMessages.get(parent?.messageId ?? '')?.status).toBe('replied');
       expect(repos.agentMessages.listThread(parent?.messageId ?? '')).toHaveLength(2);
+      expect(repos.tasks.get('TASK-THREAD')?.updatedAt).not.toBe(oldTimestamp);
+      expect(JSON.stringify(reply)).toContain('"task_id":"TASK-THREAD"');
     } finally {
       await close(harness);
     }

--- a/test/tools/workflow.test.ts
+++ b/test/tools/workflow.test.ts
@@ -441,6 +441,22 @@ describe('simplified workflow MCP contract', () => {
       expect(JSON.stringify(replay)).toContain('"idempotent_replay":true');
       expect(repos.tasks.get('TASK-TARGET')?.updatedAt).toBe(oldTimestamp);
 
+      const crossTaskReplay = await harness.client.callTool({
+        name: 'update_work',
+        arguments: {
+          operation: 'prompt',
+          task_id: 'TASK-SENDER',
+          agent_id: 'codex:sender',
+          to_agent_id: 'codex:target',
+          content: 'Please re-check the parser boundary.',
+          idempotency_key: 'sender-1',
+        },
+      });
+      expect(crossTaskReplay.isError).toBe(true);
+      expect(JSON.stringify(crossTaskReplay)).toContain(
+        'idempotency_key was already used for a different message',
+      );
+
       const endpoint = repos.agentEndpoints.getByAgent('codex:target');
       expect(endpoint).toBeDefined();
       if (endpoint !== undefined) repos.agentEndpoints.disconnect(endpoint.endpointId);


### PR DESCRIPTION
## Summary

- refresh `tasks.updated_at` for successful reclaims, durable task updates, handoff evidence, and new task-scoped prompts/replies
- keep task activity independent from agent heartbeat and preserve lifecycle compare-and-swap versions
- expose the maintained timestamp through MCP write responses, current-state projections, generated `WORK_STATE.json`, CLI output, and dashboard context
- preserve same-task idempotent replays, reject cross-task idempotency-key reuse, and keep failed sends, inbox delivery, and unscoped messages as explicit non-activity cases

## Root cause

Several meaningful task operations persisted related records or refreshed agent presence without updating the task row itself. Consumers that use `TaskRecord.updatedAt`, including dashboard ordering, could therefore make recently active work appear old.

## Impact

Task recency now reflects successful meaningful work without a database migration or changes to task ownership/version semantics. Existing output contracts remain compatible; the timestamp fields are additive.

## Validation

- `pnpm typecheck`
- `pnpm test` — 32 files, 249 tests passed
- `pnpm build`
- `pnpm lint`
- `pnpm format:check`
- `git diff --check`
