### PR TITLE
Validate claim metadata fields

### DIFF
--- a/src/domain/schemas.ts
+++ b/src/domain/schemas.ts
@@ -32,6 +32,25 @@ const workspaceIdField = z
     'Workspace id returned by a Concord operation. Omit to use the automatically resolved repository workspace.',
   );
 
+const serializedToolParameterPattern = /<\/\s*(?:summary|notes)\s*>|<\s*parameter\s+name\s*=/i;
+
+/**
+ * Some clients can accidentally serialize later tool arguments into an
+ * earlier free-text field. Accepting that payload would create a claim without
+ * its real expected_files/modules/domains and silently weaken overlap checks.
+ * Reject the recognizable serialization markers so the client retries with
+ * each argument in its proper top-level field.
+ */
+function claimMetadataField(description: string) {
+  return z
+    .string()
+    .refine((value) => !serializedToolParameterPattern.test(value), {
+      message:
+        'Serialized tool parameter markup is not allowed; pass expected_files, notes, and other arguments as separate top-level fields.',
+    })
+    .describe(description);
+}
+
 const evidenceInputShape = {
   what_changed: z.string().min(1).describe('Concise summary of what changed'),
   changed_files: z.array(z.string()).optional().describe('Files that changed'),
@@ -50,22 +69,22 @@ const provenanceField = z
 
 export const startWorkInputShape = {
   task_id: taskIdField,
-  title: z.string().min(1).describe('Short human-readable title'),
-  kind: z.string().min(1).describe('Agent type or provider, e.g. claude-code or codex'),
+  title: claimMetadataField('Short human-readable title').min(1),
+  kind: claimMetadataField('Agent type or provider, e.g. claude-code or codex').min(1),
   agent_id: agentIdField,
-  owner: z.string().optional().describe('Human accountable for this agent and task'),
-  model: z.string().optional().describe('Model the agent is running'),
-  summary: z.string().optional().describe('One-line description of the current work'),
-  branch: z.string().optional().describe('Git branch, if known'),
-  worktree: z.string().optional().describe('Git worktree path, if used'),
-  cwd: z.string().optional().describe('Agent working directory'),
+  owner: claimMetadataField('Human accountable for this agent and task').optional(),
+  model: claimMetadataField('Model the agent is running').optional(),
+  summary: claimMetadataField('One-line description of the current work').optional(),
+  branch: claimMetadataField('Git branch, if known').optional(),
+  worktree: claimMetadataField('Git worktree path, if used').optional(),
+  cwd: claimMetadataField('Agent working directory').optional(),
   pid: z.number().int().optional().describe('Agent process id, if known'),
-  parent_task_id: z.string().optional().describe('Parent task for a smaller claimed unit'),
+  parent_task_id: claimMetadataField('Parent task for a smaller claimed unit').optional(),
   expected_files: z.array(z.string()).optional().describe('Files expected to change'),
   modules: z.array(z.string()).optional().describe('Logical modules touched'),
   domains: z.array(z.string()).optional().describe('Product domains touched'),
   risk_tags: z.array(z.string()).optional().describe('Risk tags shared with related work'),
-  notes: z.string().optional().describe('Concise task notes'),
+  notes: claimMetadataField('Concise task notes').optional(),
   workspace_id: workspaceIdField,
 } as const;
 export type StartWorkInput = z.infer<z.ZodObject<typeof startWorkInputShape>>;

--- a/test/domain/schemas.test.ts
+++ b/test/domain/schemas.test.ts
@@ -1,0 +1,96 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { openDatabase } from '../../src/db/connection.js';
+import { createRepositories } from '../../src/db/index.js';
+import { startWorkInputShape } from '../../src/domain/schemas.js';
+import { createServer } from '../../src/server.js';
+
+const startWorkInputSchema = z.object(startWorkInputShape);
+
+describe('start_work input schema', () => {
+  it('rejects serialized tool parameters embedded in claim metadata', () => {
+    const result = startWorkInputSchema.safeParse({
+      task_id: 'DEV-810',
+      title: 'Fix edge regeneration',
+      kind: 'claude-code',
+      summary:
+        'Implement the fix.</summary>\n<parameter name="notes">Keep parity.</notes>\n' +
+        '<parameter name="expected_files">["src/edge.ts"]',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some(
+          (issue) =>
+            issue.path.join('.') === 'summary' && issue.message.includes('pass expected_files'),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it('preserves expected_files when metadata is sent in separate fields', () => {
+    const result = startWorkInputSchema.parse({
+      task_id: 'DEV-810',
+      title: 'Fix edge regeneration',
+      kind: 'claude-code',
+      summary: 'Implement the fix.',
+      notes: 'Keep parity.',
+      expected_files: ['src/edge.ts', 'test/edge.test.ts'],
+    });
+
+    expect(result).toMatchObject({
+      summary: 'Implement the fix.',
+      notes: 'Keep parity.',
+      expected_files: ['src/edge.ts', 'test/edge.test.ts'],
+    });
+  });
+
+  it('rejects the malformed call atomically at the MCP boundary', async () => {
+    const repos = createRepositories(openDatabase(':memory:'));
+    const server = createServer(repos, {});
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: 'schema-test', version: '0.0.0' });
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+    try {
+      const result = await client.callTool({
+        name: 'start_work',
+        arguments: {
+          task_id: 'DEV-810',
+          title: 'Fix edge regeneration',
+          kind: 'claude-code',
+          agent_id: 'claude-code:dev-810',
+          summary:
+            'Implement the fix.</summary>\n' + '<parameter name="expected_files">["src/edge.ts"]',
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result)).toContain('pass expected_files');
+      expect(repos.agents.get('claude-code:dev-810')).toBeUndefined();
+      expect(repos.tasks.get('DEV-810')).toBeUndefined();
+
+      const retry = await client.callTool({
+        name: 'start_work',
+        arguments: {
+          task_id: 'DEV-810',
+          title: 'Fix edge regeneration',
+          kind: 'claude-code',
+          agent_id: 'claude-code:dev-810',
+          summary: 'Implement the fix.',
+          expected_files: ['src/edge.ts'],
+        },
+      });
+
+      expect(retry.isError).not.toBe(true);
+      expect(repos.tasks.get('DEV-810')?.expectedFiles).toEqual(['src/edge.ts']);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- reject serialized tool-parameter markup embedded in `start_work` metadata
- fail malformed calls before writing agent or task state
- preserve `expected_files` when the client retries with canonical top-level fields
- add schema and real MCP-boundary regression coverage

## Why

A malformed client payload placed later parameters such as `notes` and `expected_files` inside `summary`. Concord accepted the text and created a claim without its file-level scope, silently weakening the highest-precision overlap signal.

The server now treats recognizable parameter serialization as invalid metadata and asks the client to resend the values separately. It deliberately does not infer safety-critical claim scope from malformed free text.

## Impact

Malformed claims no longer enter durable state with missing file scope. Valid non-editing claims may still omit `expected_files`, and valid claims preserve the supplied paths unchanged.

## Validation

- `pnpm exec prettier --check src/domain/schemas.ts test/domain/schemas.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — 33 files, 252 tests passed
- `pnpm build`
- `git diff --check`
