### PR TITLE
fix: derive agent identity from the session instead of minting one

### DIFF
--- a/src/cli/agent-identity.ts
+++ b/src/cli/agent-identity.ts
@@ -1,99 +1,59 @@
-import { createHash, randomBytes } from 'node:crypto';
-
-import { z } from 'zod';
-
-/** The one field we need from any client's hook payload. */
-const hookSessionSchema = z.object({ session_id: z.string().optional() }).loose();
+import {
+  agentIdForSession,
+  resolveIdentity,
+  UNRESOLVED_IDENTITY_MESSAGE,
+  type AgentIdentity,
+  type ResolveIdentityOptions,
+} from '../domain/identity.js';
 
 /**
- * Pull the session id out of a hook payload.
- *
- * Codex passes its session id on stdin rather than in the environment, so a
- * Codex hook has no other way to say which agent it is. Never throws: a hook
- * that cannot identify itself should fall through to the other strategies
- * rather than fail the tool call it is attached to.
+ * The CLI's view of identity. Derivation itself lives in `domain/identity.ts`
+ * so the MCP server resolves the *same* id from the same session — these are
+ * two doors into one agent, not two agents.
  */
-function hookSessionId(rawJson: string): string | undefined {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(rawJson);
-  } catch {
-    return undefined;
-  }
-  const result = hookSessionSchema.safeParse(parsed);
-  if (!result.success) return undefined;
-  const sessionId = result.data.session_id?.trim();
-  return sessionId === undefined || sessionId === '' ? undefined : sessionId;
-}
 
 /**
- * A stable agent id for one session of one client, e.g. `codex:4f2a91c7`.
+ * Work out which agent a CLI invocation is acting as.
  *
- * Hashed rather than truncated. Codex session ids are UUIDv7, whose leading
- * hex digits are a millisecond clock: the first eight advance only once per
- * ~65 seconds, so truncating them gave two Codex sessions started in the same
- * minute the same id — and therefore the same inbox.
- */
-function agentIdForSession(kind: string, sessionId: string | undefined): string {
-  const id = sessionId?.trim() ?? '';
-  const slug =
-    id === ''
-      ? randomBytes(4).toString('hex')
-      : createHash('sha256').update(id).digest('hex').slice(0, 8);
-  return `${kind}:${slug}`;
-}
-
-/**
- * A stable per-session agent id for Claude Code. Derived from the session id so
- * the same session always maps to the same identity (SessionStart is idempotent
- * via upsert); falls back to a random suffix when no session id is provided.
- *
- * An operator-supplied `CONCORD_AGENT_ID` wins, so a human coordinating agents
- * can name them ("alpha", "reviewer") instead of reading generated slugs.
- */
-export function sessionStartAgentId(
-  sessionId: string | undefined,
-  env: NodeJS.ProcessEnv = process.env,
-): string {
-  const explicit = env['CONCORD_AGENT_ID']?.trim();
-  if (explicit !== undefined && explicit !== '') return explicit;
-  return agentIdForSession('claude-code', sessionId);
-}
-
-/**
- * Work out which agent a CLI invocation is acting as, without being told.
- *
- * Hooks receive the session id in their stdin payload, but a plugin monitor
- * does not — it only has its environment. Claude Code exports
- * `CLAUDE_CODE_SESSION_ID` to both, and deriving from it here is what lets the
- * relay work in a session started as plain `claude`, with nothing to configure.
+ * An explicit `--agent` wins: it is typed by a human or written into a hook
+ * command, so it carries operator intent the way `CONCORD_AGENT_ID` does.
+ * Throws rather than generating an id — an invented id looks registered while
+ * being unreachable.
  */
 export function resolveAgentId(
   explicit: string | undefined,
   env: NodeJS.ProcessEnv = process.env,
-  options: { kind?: string; hookPayload?: string } = {},
+  options: ResolveIdentityOptions = {},
 ): string {
   const given = explicit?.trim();
   if (given !== undefined && given !== '') return given;
 
-  const configured = env['CONCORD_AGENT_ID']?.trim();
-  if (configured !== undefined && configured !== '') return configured;
-
-  const kind = options.kind ?? 'claude-code';
-
-  // Codex only reveals its session id on stdin, so a payload wins over the
-  // environment: a Codex hook run from inside a Claude Code session would
-  // otherwise inherit CLAUDE_CODE_SESSION_ID and answer as the wrong agent.
-  if (options.hookPayload !== undefined) {
-    const fromHook = hookSessionId(options.hookPayload);
-    if (fromHook !== undefined) return agentIdForSession(kind, fromHook);
+  const identity = resolveIdentity(env, options);
+  if (identity === undefined) {
+    throw new Error(UNRESOLVED_IDENTITY_MESSAGE);
   }
+  return identity.agentId;
+}
 
-  const sessionId = env['CLAUDE_CODE_SESSION_ID']?.trim();
-  if (sessionId !== undefined && sessionId !== '') return agentIdForSession(kind, sessionId);
-
-  throw new Error(
-    'Could not tell which agent this is. Run inside a Claude Code or Codex session, pass ' +
-      '--agent <id>, or set CONCORD_AGENT_ID.',
-  );
+/**
+ * The identity for a Claude Code SessionStart payload. Falls back to the
+ * environment when the payload carries no session id, so a hook that fires with
+ * an unexpected shape still lands on this session's real id.
+ */
+export function sessionStartIdentity(
+  sessionId: string | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): AgentIdentity | undefined {
+  const operator = env['CONCORD_AGENT_ID']?.trim();
+  if (operator === undefined || operator === '') {
+    const trimmed = sessionId?.trim();
+    if (trimmed !== undefined && trimmed !== '') {
+      return {
+        agentId: agentIdForSession('claude-code', trimmed),
+        kind: 'claude-code',
+        origin: 'session',
+      };
+    }
+  }
+  return resolveIdentity(env, { kind: 'claude-code' });
 }

--- a/src/cli/commands/hook.ts
+++ b/src/cli/commands/hook.ts
@@ -93,7 +93,11 @@ export interface SessionStartResult {
  * `start_work`, then tell it the `agent_id` and who else is active. Reads a
  * SessionStart JSON payload.
  */
-export function handleSessionStart(repos: Repositories, rawJson: string): SessionStartResult {
+export function handleSessionStart(
+  repos: Repositories,
+  rawJson: string,
+  env: NodeJS.ProcessEnv = process.env,
+): SessionStartResult {
   let parsed: unknown;
   try {
     parsed = JSON.parse(rawJson);
@@ -101,7 +105,9 @@ export function handleSessionStart(repos: Repositories, rawJson: string): Sessio
     parsed = {};
   }
   const payload = sessionStartPayloadSchema.parse(parsed);
-  const identity = sessionStartIdentity(payload.session_id);
+  // A malformed payload still has the environment to fall back on, since the
+  // hook runs inside the session it is describing.
+  const identity = sessionStartIdentity(payload.session_id, env);
   if (identity === undefined) {
     return { agentId: undefined, message: `Concord: ${UNRESOLVED_IDENTITY_MESSAGE}` };
   }

--- a/src/cli/commands/hook.ts
+++ b/src/cli/commands/hook.ts
@@ -4,8 +4,10 @@ import type { Command } from '@commander-js/extra-typings';
 import { z } from 'zod';
 
 import type { Repositories } from '../../db/index.js';
+import { UNRESOLVED_IDENTITY_MESSAGE } from '../../domain/identity.js';
 import { buildRoster } from '../../domain/presence.js';
-import { sessionStartAgentId } from '../agent-identity.js';
+import { ensureAgentRegistered } from '../../tools/register-agent.js';
+import { sessionStartIdentity } from '../agent-identity.js';
 import { openContext } from '../context.js';
 import { checkFileOverlaps } from './check.js';
 import { registerPullEndpoint } from './inbox.js';
@@ -77,10 +79,11 @@ const sessionStartPayloadSchema = z
   })
   .loose();
 
-export { sessionStartAgentId };
+export { sessionStartIdentity };
 
 export interface SessionStartResult {
-  agentId: string;
+  /** Undefined when no session id was available to derive an identity from. */
+  agentId: string | undefined;
   /** Context printed to stdout, which Claude Code injects into the session. */
   message: string;
 }
@@ -98,32 +101,25 @@ export function handleSessionStart(repos: Repositories, rawJson: string): Sessio
     parsed = {};
   }
   const payload = sessionStartPayloadSchema.parse(parsed);
-  const agentId = sessionStartAgentId(payload.session_id);
+  const identity = sessionStartIdentity(payload.session_id);
+  if (identity === undefined) {
+    return { agentId: undefined, message: `Concord: ${UNRESOLVED_IDENTITY_MESSAGE}` };
+  }
+  const agentId = identity.agentId;
 
-  repos.agents.upsert({
-    agentId,
-    kind: 'claude-code',
-    owner: null,
-    model: null,
-    pid: null,
-    cwd: payload.cwd ?? null,
-    worktree: null,
-    branch: null,
-    summary: null,
-    status: 'active',
-  });
+  ensureAgentRegistered(repos, identity, payload.cwd ?? null);
 
   // Advertise the session as reachable before any tool call, so a peer that
   // messages it early gets its message queued rather than rejected.
-  registerPullEndpoint(repos, agentId, 'claude-code');
+  registerPullEndpoint(repos, agentId, identity.kind);
 
   const others = buildRoster(repos.agents.list(), Date.now()).filter(
     (entry) => entry.agentId !== agentId,
   );
   const lines = [
-    `Concord: registered this session as agent \`${agentId}\`. Pass agent_id="${agentId}" to ` +
-      'Concord tools (start_work, update_work, finish_work) so your work is attributed and your ' +
-      'presence stays live.',
+    `Concord: this session is agent \`${agentId}\`. Concord resolves that identity from your ` +
+      'session on every tool call, so start_work, update_work, finish_work attribute your work ' +
+      'and keep your presence live without you passing an id.',
     'You can receive live messages from other agents in this workspace; they arrive on their own ' +
       'as relayed context, so you never need to poll for them.',
   ];

--- a/src/cli/commands/inbox.ts
+++ b/src/cli/commands/inbox.ts
@@ -11,6 +11,7 @@ import {
   renderMonitorLines,
   type DeliverableMessage,
 } from '../../domain/pull-inbox.js';
+import { ensureAgentRegistered } from '../../tools/register-agent.js';
 import { resolveAgentId } from '../agent-identity.js';
 import { openContext } from '../context.js';
 
@@ -31,20 +32,7 @@ export function registerPullEndpoint(
   // The endpoint references an agent row. Hook execution order is not
   // guaranteed, so do not assume the presence hook has already run — otherwise
   // whether messaging works depends on which SessionStart hook fired first.
-  if (repos.agents.get(agentId) === undefined) {
-    repos.agents.upsert({
-      agentId,
-      kind: provider,
-      owner: null,
-      model: null,
-      pid: null,
-      cwd: process.cwd(),
-      worktree: null,
-      branch: null,
-      summary: null,
-      status: 'active',
-    });
-  }
+  ensureAgentRegistered(repos, { agentId, kind: provider }, process.cwd());
   const capability = capabilityFor(provider);
   const existing = repos.agentEndpoints.getByAgent(agentId);
   repos.agentEndpoints.upsert({
@@ -153,12 +141,12 @@ export function registerInboxCommand(program: Command): void {
         ...(options.fromHook === true ? { hookPayload: readHookPayload() ?? '' } : {}),
       });
       registerPullEndpoint(context.repos, agentId, options.provider);
-      // Name the id, not just the capability. Only this id has a delivery
-      // endpoint, so an agent that lets start_work mint a fresh one becomes
-      // unreachable while still looking registered.
+      // Name the id. Clients whose session Concord can read resolve it on every
+      // tool call; clients that scrub their environment (Codex) cannot, and for
+      // those this line is the only place the agent learns who it is.
       process.stdout.write(
         `Concord: this session is agent \`${agentId}\` and can receive live messages from other ` +
-          `agents. Pass agent_id="${agentId}" to every Concord tool call; do not invent a ` +
+          `agents. If a Concord tool asks for agent_id, use "${agentId}"; do not invent a ` +
           'different id.\n',
       );
     });

--- a/src/domain/identity.ts
+++ b/src/domain/identity.ts
@@ -1,0 +1,175 @@
+import { createHash } from 'node:crypto';
+
+import { z } from 'zod';
+
+/**
+ * Who an agent is, derived rather than declared.
+ *
+ * One session is one agent. Every channel that registers presence — the MCP
+ * server, the relay CLI, the SessionStart hooks — derives the same id from the
+ * same session, so an agent's identity is the same string no matter which door
+ * it came through. Before this module each door minted its own: the MCP surface
+ * generated a random id that no delivery endpoint ever matched, so peer messages
+ * to it failed `target_not_promptable` forever.
+ */
+
+/**
+ * A client that reveals its session id in the environment of the processes it
+ * spawns, and the kind it registers as.
+ *
+ * Kind and session id are read from the same entry on purpose. Reading them
+ * independently let a Codex hook whose payload was missing fall through to
+ * `CLAUDE_CODE_SESSION_ID` and register `codex:<hash of a Claude session>` — an
+ * id belonging to no session at all. Pairing them makes that unrepresentable.
+ */
+export interface SessionSource {
+  readonly kind: string;
+  readonly envVar: string;
+}
+
+/**
+ * Clients whose session id reaches a child process.
+ *
+ * Codex is deliberately absent: it spawns MCP servers with a scrubbed
+ * environment (`HOME`, `LANG`, `LOGNAME`, `PATH`, `SHELL`, `TERM`, `TMPDIR`,
+ * `USER` — no session id, not even `PWD`) and passes its session id on stdin to
+ * hooks instead. Codex therefore resolves through `hookPayload`, never here.
+ */
+export const SESSION_SOURCES: readonly SessionSource[] = [
+  { kind: 'claude-code', envVar: 'CLAUDE_CODE_SESSION_ID' },
+];
+
+/** How an identity was established, for diagnostics and error messages. */
+export type IdentityOrigin = 'operator' | 'session' | 'hook';
+
+export interface AgentIdentity {
+  readonly agentId: string;
+  readonly kind: string;
+  readonly origin: IdentityOrigin;
+}
+
+/** The one field we need from any client's hook payload. */
+const hookSessionSchema = z.object({ session_id: z.string().optional() }).loose();
+
+/**
+ * A stable agent id for one session of one client, e.g. `claude-code:4f2a91c7`.
+ *
+ * Hashed rather than truncated. Codex session ids are UUIDv7, whose leading hex
+ * digits are a millisecond clock: the first eight advance only once per ~65
+ * seconds, so truncating them gave two Codex sessions started in the same minute
+ * the same id — and therefore the same inbox.
+ */
+export function agentIdForSession(kind: string, sessionId: string): string {
+  return `${kind}:${createHash('sha256').update(sessionId).digest('hex').slice(0, 8)}`;
+}
+
+/** The session source for a client, when that client exposes one. */
+function sourceFor(kind: string | undefined): SessionSource | undefined {
+  if (kind === undefined) return undefined;
+  return SESSION_SOURCES.find((source) => source.kind === kind);
+}
+
+/**
+ * Pull the session id out of a hook payload.
+ *
+ * Codex passes its session id on stdin rather than in the environment, so a
+ * Codex hook has no other way to say which agent it is. Never throws: a hook
+ * that cannot identify itself should fall through to the other strategies
+ * rather than fail the tool call it is attached to.
+ */
+function hookSessionId(rawJson: string): string | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawJson);
+  } catch {
+    return undefined;
+  }
+  const result = hookSessionSchema.safeParse(parsed);
+  if (!result.success) return undefined;
+  const sessionId = result.data.session_id?.trim();
+  return sessionId === undefined || sessionId === '' ? undefined : sessionId;
+}
+
+export interface ResolveIdentityOptions {
+  /** Client the agent runs in. Selects which session source may be read. */
+  kind?: string | undefined;
+  /** Hook payload JSON, for clients that pass their session id on stdin. */
+  hookPayload?: string | undefined;
+}
+
+/**
+ * Work out which agent this process is, without being told by a model.
+ *
+ * Returns undefined rather than inventing an identity. A generated id would
+ * look registered while being unreachable, which is the failure this module
+ * exists to prevent — callers must handle "I don't know" explicitly.
+ *
+ * `CONCORD_AGENT_ID` wins so a human coordinating agents can name them
+ * ("alpha", "reviewer") instead of reading generated slugs. It is set by
+ * whoever launches the agent, never by the agent itself.
+ */
+export function resolveIdentity(
+  env: NodeJS.ProcessEnv,
+  options: ResolveIdentityOptions = {},
+): AgentIdentity | undefined {
+  const kind = options.kind;
+
+  const operator = env['CONCORD_AGENT_ID']?.trim();
+  if (operator !== undefined && operator !== '') {
+    return { agentId: operator, kind: kind ?? kindOf(operator), origin: 'operator' };
+  }
+
+  if (options.hookPayload !== undefined) {
+    const sessionId = hookSessionId(options.hookPayload);
+    if (sessionId !== undefined) {
+      const hookKind = kind ?? 'claude-code';
+      return { agentId: agentIdForSession(hookKind, sessionId), kind: hookKind, origin: 'hook' };
+    }
+  }
+
+  // With a kind, only that client's source is consulted; without one (the MCP
+  // server, which is told nothing), take whichever source this process was
+  // actually launched by.
+  const candidates = kind === undefined ? SESSION_SOURCES : [sourceFor(kind)];
+  for (const source of candidates) {
+    if (source === undefined) continue;
+    const sessionId = env[source.envVar]?.trim();
+    if (sessionId !== undefined && sessionId !== '') {
+      return {
+        agentId: agentIdForSession(source.kind, sessionId),
+        kind: source.kind,
+        origin: 'session',
+      };
+    }
+  }
+  return undefined;
+}
+
+/** The client prefix of an agent id, for ids supplied whole by an operator. */
+function kindOf(agentId: string): string {
+  const separator = agentId.indexOf(':');
+  return separator === -1 ? 'unknown' : agentId.slice(0, separator);
+}
+
+/** What to tell a caller Concord cannot identify. */
+export const UNRESOLVED_IDENTITY_MESSAGE =
+  'Concord cannot tell which session you are. Run `concord inbox register` and pass the ' +
+  'agent_id it prints, or set CONCORD_AGENT_ID before starting this session.';
+
+/**
+ * Which agent a tool call is acting as.
+ *
+ * A resolved session identity always beats a supplied one: a model must not be
+ * able to act as — or send messages as — another agent by passing its id. The
+ * supplied id is honoured only where Concord genuinely cannot see the session,
+ * which today means Codex, whose hooks tell the model the id to pass back.
+ */
+export function resolveActorId(
+  session: AgentIdentity | undefined,
+  supplied: string | undefined,
+): string {
+  if (session !== undefined) return session.agentId;
+  const given = supplied?.trim();
+  if (given !== undefined && given !== '') return given;
+  throw new Error(UNRESOLVED_IDENTITY_MESSAGE);
+}

--- a/src/domain/operations.ts
+++ b/src/domain/operations.ts
@@ -11,10 +11,12 @@ type Require<T, Keys extends keyof T> = Omit<T, Keys> & {
   [Key in Keys]-?: NonNullable<T[Key]>;
 };
 
+/** `agent_id` is required here, unlike on the tool surface: by this point the
+ * caller has resolved the session identity, and nothing may invent one. */
 export type RegisterAgentInput = Pick<
   StartWorkInput,
-  'agent_id' | 'kind' | 'owner' | 'model' | 'summary' | 'branch' | 'worktree' | 'cwd' | 'pid'
-> & { status?: AgentStatus | undefined };
+  'kind' | 'owner' | 'model' | 'summary' | 'branch' | 'worktree' | 'cwd' | 'pid'
+> & { agent_id: string; status?: AgentStatus | undefined };
 
 export type ClaimWorkInput = Pick<
   StartWorkInput,
@@ -79,7 +81,13 @@ export type ReviewReadyInput = Pick<
   expected_version?: number | undefined;
 };
 
-type TransferActorInput = Pick<TransferWorkInput, 'task_id' | 'agent_id' | 'expected_version'>;
+/** Ownership actions always name their actor: `agent_id` is optional on the
+ * wire because Concord resolves it from the session, but by the time a
+ * lifecycle handler runs it has been resolved and is required. */
+type TransferActorInput = Require<
+  Pick<TransferWorkInput, 'task_id' | 'agent_id' | 'expected_version'>,
+  'agent_id'
+>;
 
 export type AssignTaskInput = Require<
   TransferActorInput & Pick<TransferWorkInput, 'to_agent_id' | 'lease_seconds' | 'reason'>,

--- a/src/domain/schemas.ts
+++ b/src/domain/schemas.ts
@@ -8,15 +8,24 @@ import { z } from 'zod';
 
 const taskIdField = z.string().min(1).describe('Stable task identifier, e.g. TASK-12');
 
+/**
+ * The actor's own identity, on every write tool.
+ *
+ * Normally omitted: Concord derives who you are from your session, and a
+ * resolved session identity overrides anything passed here — otherwise an agent
+ * could act, or send messages, as one of its peers. Supplying it matters only
+ * for clients whose session Concord cannot see (Codex, which scrubs the
+ * environment of the processes it spawns and tells the model its id via a
+ * SessionStart hook instead).
+ */
 const agentIdField = z
   .string()
-  .optional()
-  .describe('Existing agent identity to refresh; omit on the first call to generate one');
-
-const actorAgentIdField = z
-  .string()
   .min(1)
-  .describe('Registered agent identity performing this operation');
+  .optional()
+  .describe(
+    'Usually omit — Concord derives your identity from your session. Pass only the id your ' +
+      'client told you (Codex); a session Concord can see always wins.',
+  );
 
 const taskVersionField = z
   .number()
@@ -149,7 +158,7 @@ export const transferWorkInputShape = {
   action: z
     .enum(transferWorkActionValues)
     .describe('Ownership action to apply through the versioned task state machine'),
-  agent_id: actorAgentIdField,
+  agent_id: agentIdField,
   expected_version: taskVersionField,
   to_agent_id: z.string().min(1).optional().describe('Required for assign, reassign, and offer'),
   handoff_id: z
@@ -176,7 +185,7 @@ export type TransferWorkInput = z.infer<z.ZodObject<typeof transferWorkInputShap
 
 export const finishWorkInputShape = {
   task_id: taskIdField,
-  agent_id: actorAgentIdField,
+  agent_id: agentIdField,
   expected_version: taskVersionField,
   outcome: z
     .enum(['handoff', 'review_ready', 'complete', 'closed'])

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,9 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 
 import { writeArtifacts } from './artifacts/index.js';
 import { resolveRepoRoot } from './config/paths.js';
+import { resolveIdentity } from './domain/identity.js';
 import { createServer } from './server.js';
+import { ensureAgentRegistered } from './tools/register-agent.js';
 import { createTelemetryClient } from './telemetry/client.js';
 import { TelemetryTransport } from './telemetry/transport.js';
 import { WorkspaceManager } from './workspaces/manager.js';
@@ -11,8 +13,16 @@ import { WorkspaceManager } from './workspaces/manager.js';
 async function main(): Promise<void> {
   const repoRoot = resolveRepoRoot(process.cwd(), process.env);
   const workspaceManager = WorkspaceManager.fromEnvironment(repoRoot, process.env);
+  // One server process per session, with the session id in its environment, so
+  // this agent's identity is known before the transport connects — and it is the
+  // same id the relay CLI derives for the same session.
+  const identity = resolveIdentity(process.env);
+  if (identity !== undefined) {
+    ensureAgentRegistered(workspaceManager.current().repos, identity, repoRoot);
+  }
   const server = createServer(workspaceManager.current().repos, {
     workspaceManager,
+    ...(identity === undefined ? {} : { identity }),
     onToolWrite: (workspace) => {
       if (workspace !== undefined) {
         writeArtifacts(workspace.concordPath, workspace.repos);

--- a/src/install/instructions.ts
+++ b/src/install/instructions.ts
@@ -19,9 +19,10 @@ export const CONCORD_INSTRUCTIONS = `## Concord — shared work-state for coding
 
 This project uses Concord MCP. Keep coordination to the five workflow tools:
 
-- **Before editing**, call \`start_work\` with the task, your agent kind/id, and
+- **Before editing**, call \`start_work\` with the task, your agent kind, and
   expected files or modules. It registers presence, accepts assigned work when
-  appropriate, claims the scope, and returns overlap warnings.
+  appropriate, claims the scope, and returns overlap warnings. Concord derives
+  your \`agent_id\` from your session — omit it unless your client told you one.
 - Use \`inspect_work\` to read the workspace, one task, one agent, or one message
   thread. Use \`update_work\` for durable progress and for live prompts/replies
   to another promptable workspace agent, including while that agent is busy.

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import type { Repositories } from './db/index.js';
+import type { AgentIdentity } from './domain/identity.js';
 import { CONCORD_SERVER_INSTRUCTIONS } from './install/instructions.js';
 import { registerWorkStateResource } from './tools/get-work-state.js';
 import { registerWorkflowTools } from './tools/workflow.js';
@@ -19,7 +20,12 @@ export interface ServerOptions {
   onToolWrite?: (workspace: WorkspaceContext | undefined) => void;
   /** Enables automatic root resolution and optional per-operation workspace selection. */
   workspaceManager?: WorkspaceManager;
-  /** Delivers live prompts to provider sessions; defaults to a disconnected relay. */
+  /**
+   * Who this server's session is, resolved from the environment. When present it
+   * is the authority for every write tool, so a model cannot act as a peer by
+   * passing that peer's `agent_id`.
+   */
+  identity?: AgentIdentity;
 }
 
 /**
@@ -42,6 +48,6 @@ export function createServer(repos: Repositories, options: ServerOptions = {}): 
     options.onToolWrite?.(manager?.current());
     notifyWorkStateChanged();
   };
-  registerWorkflowTools(server, selectedRepos, onWrite, selectWorkspace);
+  registerWorkflowTools(server, selectedRepos, onWrite, selectWorkspace, options.identity);
   return server;
 }

--- a/src/tools/register-agent.ts
+++ b/src/tools/register-agent.ts
@@ -1,6 +1,5 @@
-import { randomBytes } from 'node:crypto';
-
 import type { AgentRecord, Repositories } from '../db/index.js';
+import type { AgentIdentity } from '../domain/identity.js';
 import type { RegisterAgentInput } from '../domain/operations.js';
 import { buildRoster, type PresenceEntry } from '../domain/presence.js';
 
@@ -12,24 +11,24 @@ export interface RegisterAgentResult {
   roster: PresenceEntry[];
 }
 
-/** A short, human-typable instance id, e.g. `claude-code:7p8v`. Generated when
- * the caller does not supply one; returned so it can be reused thereafter. */
-export function generateAgentId(kind: string): string {
-  return `${kind}:${randomBytes(2).toString('hex')}`;
-}
-
 /**
  * Register (or refresh) an agent's presence so concurrent agents are
  * distinguishable and can see who else is active. Returns the resolved identity
  * plus the current roster, so the caller learns who else is here immediately —
  * without a task claim (recon and research agents are visible too).
+ *
+ * `agent_id` is resolved by the caller from the session (`domain/identity.ts`)
+ * and is required. Generating one here is what created agents that no delivery
+ * endpoint could ever match: the relay registers endpoints under the
+ * session-derived id, so a minted id was addressable but permanently
+ * undeliverable.
  */
 export function handleRegisterAgent(
   repos: Repositories,
   input: RegisterAgentInput,
   now: number = Date.now(),
 ): RegisterAgentResult {
-  const agentId = input.agent_id ?? generateAgentId(input.kind);
+  const agentId = input.agent_id;
   const firstRegistration = repos.agents.get(agentId) === undefined;
 
   const agent = repos.agents.upsert({
@@ -46,4 +45,34 @@ export function handleRegisterAgent(
   });
 
   return { agent, firstRegistration, roster: buildRoster(repos.agents.list(), now) };
+}
+
+/**
+ * Give a resolved session a presence row, without disturbing one that is
+ * already there.
+ *
+ * Called by every channel that knows only who it is and nothing about the work
+ * — the MCP server at startup, the relay, the SessionStart hooks. `upsert` is a
+ * full replacement, so refreshing here rather than creating would blank the
+ * cwd, owner, model, and summary that a later `start_work` recorded (issue #68).
+ */
+export function ensureAgentRegistered(
+  repos: Repositories,
+  identity: Pick<AgentIdentity, 'agentId' | 'kind'>,
+  cwd: string | null = null,
+): AgentRecord {
+  const existing = repos.agents.get(identity.agentId);
+  if (existing !== undefined) return existing;
+  return repos.agents.upsert({
+    agentId: identity.agentId,
+    kind: identity.kind,
+    owner: null,
+    model: null,
+    pid: null,
+    cwd,
+    worktree: null,
+    branch: null,
+    summary: null,
+    status: 'active',
+  });
 }

--- a/src/tools/workflow.ts
+++ b/src/tools/workflow.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import type { Repositories, TaskRecord } from '../db/index.js';
+import { resolveActorId, type AgentIdentity } from '../domain/identity.js';
 import {
   finishWorkInputShape,
   type FinishWorkInput,
@@ -61,6 +62,15 @@ export interface StartWorkResult {
   resumedBy: 'new_claim' | 'claim' | 'assignment' | 'handoff' | 'reopen';
 }
 
+/**
+ * A tool input whose actor has already been resolved.
+ *
+ * `agent_id` is optional on the wire and required here: the boundary between
+ * "what a model asked for" and "who Concord decided you are" is this type, and
+ * the compiler will not let a handler skip it.
+ */
+type WithActor<T> = T & { agent_id: string };
+
 function taskOrThrow(repos: Repositories, taskId: string): TaskRecord {
   const task = repos.tasks.get(taskId);
   if (task === undefined) {
@@ -74,7 +84,7 @@ function taskOrThrow(repos: Repositories, taskId: string): TaskRecord {
  * operation. Existing assignments, addressed handoffs, proposed tasks, and
  * terminal tasks are resumed through the same proven lifecycle handlers.
  */
-function startWork(repos: Repositories, input: StartWorkInput): StartWorkResult {
+function startWork(repos: Repositories, input: WithActor<StartWorkInput>): StartWorkResult {
   const registration = handleRegisterAgent(repos, {
     agent_id: input.agent_id,
     kind: input.kind,
@@ -165,7 +175,10 @@ function startWork(repos: Repositories, input: StartWorkInput): StartWorkResult 
   return { registration, claim, resumedBy };
 }
 
-export function handleStartWork(repos: Repositories, input: StartWorkInput): StartWorkResult {
+export function handleStartWork(
+  repos: Repositories,
+  input: WithActor<StartWorkInput>,
+): StartWorkResult {
   const transact = repos.db.transaction(() => startWork(repos, input));
   return transact();
 }
@@ -216,12 +229,15 @@ function updateRequired<T>(value: T | undefined, field: string, operation: strin
   return value;
 }
 
-export function handleUpdateWork(repos: Repositories, input: UpdateWorkInput): UpdateWorkResult {
+export function handleUpdateWork(
+  repos: Repositories,
+  input: WithActor<UpdateWorkInput>,
+): UpdateWorkResult {
   const operation = input.operation ?? 'record';
   if (operation !== 'record') {
     return handleSendAgentMessage(repos, {
       operation,
-      agentId: updateRequired(input.agent_id, 'agent_id', operation),
+      agentId: input.agent_id,
       toAgentId: input.to_agent_id,
       replyToMessageId: input.reply_to_message_id,
       taskId: input.task_id,
@@ -258,7 +274,7 @@ export type TransferWorkResult = TaskLifecycleResult | HandoffLifecycleResult;
 
 export function handleTransferWork(
   repos: Repositories,
-  input: TransferWorkInput,
+  input: WithActor<TransferWorkInput>,
 ): TransferWorkResult {
   const common = {
     task_id: input.task_id,
@@ -338,7 +354,10 @@ export interface FinishWorkResult {
 }
 
 /** Record evidence and apply the requested review/terminal state atomically. */
-export function handleFinishWork(repos: Repositories, input: FinishWorkInput): FinishWorkResult {
+export function handleFinishWork(
+  repos: Repositories,
+  input: WithActor<FinishWorkInput>,
+): FinishWorkResult {
   const transact = repos.db.transaction(() => {
     const evidence = handleHandoff(repos, {
       task_id: input.task_id,
@@ -409,7 +428,15 @@ export function registerWorkflowTools(
   repos: Repositories,
   onWrite?: () => void,
   selectWorkspace?: SelectWorkspace,
+  session?: AgentIdentity,
 ): void {
+  /** Stamp the resolved actor onto a write tool's arguments. Throws with the
+   *  fix-it message when neither the session nor the caller identifies anyone. */
+  const withActor = <T extends { agent_id?: string | undefined }>(args: T): WithActor<T> => ({
+    ...args,
+    agent_id: resolveActorId(session, args.agent_id),
+  });
+
   server.registerTool(
     'start_work',
     {
@@ -421,7 +448,13 @@ export function registerWorkflowTools(
     },
     (args) => {
       const workspace = selectToolWorkspace(selectWorkspace, args.workspace_id);
-      const result = handleStartWork(repos, args);
+      // The session's kind wins alongside its id: the id embeds the kind, so
+      // registering under a different one would describe an agent that is not
+      // the one being addressed.
+      const result = handleStartWork(repos, {
+        ...withActor(args),
+        kind: session?.kind ?? args.kind,
+      });
       onWrite?.();
       const task = result.claim.task;
       return {
@@ -572,7 +605,7 @@ export function registerWorkflowTools(
     (args) => {
       const workspace = selectToolWorkspace(selectWorkspace, args.workspace_id);
       try {
-        const result = handleUpdateWork(repos, args);
+        const result = handleUpdateWork(repos, withActor(args));
         onWrite?.();
         if ('update' in result) {
           return {
@@ -665,7 +698,7 @@ export function registerWorkflowTools(
     },
     (args) => {
       const workspace = selectToolWorkspace(selectWorkspace, args.workspace_id);
-      const result = handleTransferWork(repos, args);
+      const result = handleTransferWork(repos, withActor(args));
       onWrite?.();
       return {
         content: [
@@ -698,7 +731,7 @@ export function registerWorkflowTools(
     },
     (args) => {
       const workspace = selectToolWorkspace(selectWorkspace, args.workspace_id);
-      const result = handleFinishWork(repos, args);
+      const result = handleFinishWork(repos, withActor(args));
       onWrite?.();
       return {
         content: [

--- a/test/cli/agent-identity.test.ts
+++ b/test/cli/agent-identity.test.ts
@@ -1,25 +1,28 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveAgentId, sessionStartAgentId } from '../../src/cli/agent-identity.js';
+import { resolveAgentId, sessionStartIdentity } from '../../src/cli/agent-identity.js';
+import { UNRESOLVED_IDENTITY_MESSAGE } from '../../src/domain/identity.js';
+
+const SESSION = 'a1b2c3d4-e5f6-7890';
 
 describe('resolveAgentId', () => {
   it('derives identity from the session alone, so plain `claude` needs no setup', () => {
-    expect(resolveAgentId(undefined, { CLAUDE_CODE_SESSION_ID: 'a1b2c3d4-e5f6-7890' })).toMatch(
+    expect(resolveAgentId(undefined, { CLAUDE_CODE_SESSION_ID: SESSION })).toMatch(
       /^claude-code:[0-9a-f]{8}$/,
     );
   });
 
   it('gives a monitor and a hook in one session the same identity', () => {
-    const env = { CLAUDE_CODE_SESSION_ID: 'a1b2c3d4-e5f6-7890' };
+    const env = { CLAUDE_CODE_SESSION_ID: SESSION };
 
-    expect(resolveAgentId(undefined, env)).toBe(sessionStartAgentId('a1b2c3d4-e5f6-7890', env));
+    expect(resolveAgentId(undefined, env)).toBe(sessionStartIdentity(SESSION, env)?.agentId);
   });
 
   it('prefers an operator-chosen name over the generated slug', () => {
     expect(
       resolveAgentId(undefined, {
         CONCORD_AGENT_ID: 'alpha',
-        CLAUDE_CODE_SESSION_ID: 'a1b2c3d4-e5f6-7890',
+        CLAUDE_CODE_SESSION_ID: SESSION,
       }),
     ).toBe('alpha');
   });
@@ -33,6 +36,25 @@ describe('resolveAgentId', () => {
   });
 
   it('explains itself when run outside any session', () => {
-    expect(() => resolveAgentId(undefined, {})).toThrow(/Could not tell which agent/);
+    expect(() => resolveAgentId(undefined, {})).toThrow(UNRESOLVED_IDENTITY_MESSAGE);
+  });
+});
+
+describe('sessionStartIdentity', () => {
+  it('matches the id derived from the same session id in the environment', () => {
+    const fromPayload = sessionStartIdentity(SESSION, {});
+    const fromEnv = sessionStartIdentity(undefined, { CLAUDE_CODE_SESSION_ID: SESSION });
+
+    expect(fromPayload?.agentId).toBe(fromEnv?.agentId);
+  });
+
+  it('falls back to the environment when the payload carries no session id', () => {
+    expect(sessionStartIdentity(undefined, { CLAUDE_CODE_SESSION_ID: SESSION })?.agentId).toMatch(
+      /^claude-code:[0-9a-f]{8}$/,
+    );
+  });
+
+  it('has no identity to offer when neither the payload nor the environment names one', () => {
+    expect(sessionStartIdentity(undefined, {})).toBeUndefined();
   });
 });

--- a/test/cli/hook.test.ts
+++ b/test/cli/hook.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import {
   decidePreToolUse,
   handleSessionStart,
-  sessionStartAgentId,
+  sessionStartIdentity,
 } from '../../src/cli/commands/hook.js';
 import { openDatabase } from '../../src/db/connection.js';
 import { createRepositories, type Repositories } from '../../src/db/index.js';
@@ -55,22 +55,24 @@ describe('decidePreToolUse', () => {
   });
 });
 
-describe('sessionStartAgentId', () => {
+describe('sessionStartIdentity', () => {
   it('derives a stable id from the session id', () => {
-    const id = sessionStartAgentId('a1b2c3d4-e5f6-7890');
+    const id = sessionStartIdentity('a1b2c3d4-e5f6-7890', {})?.agentId;
 
     expect(id).toMatch(/^claude-code:[0-9a-f]{8}$/);
-    expect(sessionStartAgentId('a1b2c3d4-e5f6-7890')).toBe(id);
+    expect(sessionStartIdentity('a1b2c3d4-e5f6-7890', {})?.agentId).toBe(id);
   });
 
   it('separates sessions that share a leading timestamp', () => {
-    expect(sessionStartAgentId('019fd3d0-aaaa-7211-b743-000000000001')).not.toBe(
-      sessionStartAgentId('019fd3d0-bbbb-7211-b743-000000000002'),
+    expect(sessionStartIdentity('019fd3d0-aaaa-7211-b743-000000000001', {})?.agentId).not.toBe(
+      sessionStartIdentity('019fd3d0-bbbb-7211-b743-000000000002', {})?.agentId,
     );
   });
 
-  it('falls back to a random suffix when no session id is given', () => {
-    expect(sessionStartAgentId(undefined)).toMatch(/^claude-code:[0-9a-f]{8}$/);
+  it('invents nothing when no session id is given', () => {
+    // A random suffix here would produce an agent the relay never registers an
+    // endpoint for: addressable, and permanently undeliverable.
+    expect(sessionStartIdentity(undefined, {})).toBeUndefined();
   });
 });
 
@@ -90,7 +92,7 @@ describe('handleSessionStart', () => {
     expect(result.message).toContain('start_work, update_work, finish_work');
     expect(result.message).not.toContain('claim_work');
     expect(result.message).toContain('No other agents');
-    expect(repos.agents.get(result.agentId)?.cwd).toBe('/repo');
+    expect(repos.agents.get(result.agentId ?? '')?.cwd).toBe('/repo');
   });
 
   it('is idempotent for the same session and lists other present agents', () => {

--- a/test/cli/hook.test.ts
+++ b/test/cli/hook.test.ts
@@ -109,8 +109,21 @@ describe('handleSessionStart', () => {
     expect(again.message).toContain('building the backend');
   });
 
-  it('tolerates a malformed payload by generating a random id', () => {
-    const result = handleSessionStart(repos, 'not json');
+  it('falls back to the environment when the payload is malformed', () => {
+    const result = handleSessionStart(repos, 'not json', {
+      CLAUDE_CODE_SESSION_ID: 'a1b2c3d4-e5f6-7890',
+    });
+
     expect(result.agentId).toMatch(/^claude-code:[0-9a-f]{8}$/);
+  });
+
+  it('registers nothing when a malformed payload has no environment to fall back on', () => {
+    // Generating an id here would create an agent the relay never registers an
+    // endpoint for: addressable by peers, and permanently undeliverable.
+    const result = handleSessionStart(repos, 'not json', {});
+
+    expect(result.agentId).toBeUndefined();
+    expect(result.message).toContain('concord inbox register');
+    expect(repos.agents.list()).toHaveLength(0);
   });
 });

--- a/test/cli/inbox.test.ts
+++ b/test/cli/inbox.test.ts
@@ -5,7 +5,7 @@ import { createRepositories, type Repositories } from '../../src/db/index.js';
 import { renderHookPayload, renderMonitorLines } from '../../src/domain/pull-inbox.js';
 import { CONCORD_SERVER_INSTRUCTIONS } from '../../src/install/instructions.js';
 import { drainInbox, registerPullEndpoint } from '../../src/cli/commands/inbox.js';
-import { sessionStartAgentId } from '../../src/cli/agent-identity.js';
+import { agentIdForSession } from '../../src/domain/identity.js';
 import { endpointPromptable, handleSendAgentMessage } from '../../src/tools/agent-messages.js';
 
 function registerAgent(repos: Repositories, agentId: string): void {
@@ -157,8 +157,8 @@ describe('pull-transport inbox', () => {
   it('gives two sessions started in the same minute different identities', () => {
     // Codex session ids are UUIDv7: the leading hex is a millisecond clock, so
     // the first eight characters only change about once a minute.
-    const a = sessionStartAgentId('019fd3d0-75d2-7211-b743-d770c8c76fc6', {});
-    const b = sessionStartAgentId('019fd3d0-9999-7211-b743-000000000000', {});
+    const a = agentIdForSession('claude-code', '019fd3d0-75d2-7211-b743-d770c8c76fc6');
+    const b = agentIdForSession('claude-code', '019fd3d0-9999-7211-b743-000000000000');
 
     expect(a).not.toBe(b);
   });

--- a/test/domain/identity.test.ts
+++ b/test/domain/identity.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  agentIdForSession,
+  resolveActorId,
+  resolveIdentity,
+  UNRESOLVED_IDENTITY_MESSAGE,
+} from '../../src/domain/identity.js';
+
+const SESSION = 'a1b2c3d4-e5f6-7890';
+
+describe('resolveIdentity', () => {
+  it('derives identity from the session alone, so a plain session needs no setup', () => {
+    const identity = resolveIdentity({ CLAUDE_CODE_SESSION_ID: SESSION });
+
+    expect(identity?.agentId).toMatch(/^claude-code:[0-9a-f]{8}$/);
+    expect(identity?.kind).toBe('claude-code');
+    expect(identity?.origin).toBe('session');
+  });
+
+  it('gives the MCP server and the relay in one session the same id', () => {
+    const env = { CLAUDE_CODE_SESSION_ID: SESSION };
+
+    // No kind: the MCP server is told nothing. With a kind: the CLI passes
+    // --provider. Both must land on the same agent, or messages bounce.
+    expect(resolveIdentity(env)?.agentId).toBe(
+      resolveIdentity(env, { kind: 'claude-code' })?.agentId,
+    );
+  });
+
+  it('prefers an operator-chosen name over the derived slug', () => {
+    const identity = resolveIdentity({
+      CONCORD_AGENT_ID: 'alpha',
+      CLAUDE_CODE_SESSION_ID: SESSION,
+    });
+
+    expect(identity?.agentId).toBe('alpha');
+    expect(identity?.origin).toBe('operator');
+  });
+
+  it('reads a session id a client passes on stdin instead of the environment', () => {
+    const identity = resolveIdentity(
+      {},
+      { kind: 'codex', hookPayload: JSON.stringify({ session_id: SESSION }) },
+    );
+
+    expect(identity?.agentId).toBe(agentIdForSession('codex', SESSION));
+    expect(identity?.origin).toBe('hook');
+  });
+
+  it('never lets one client borrow another client session id', () => {
+    // A Codex hook whose payload is missing must not fall through to the Claude
+    // Code environment and register codex:<hash of a Claude session>.
+    expect(resolveIdentity({ CLAUDE_CODE_SESSION_ID: SESSION }, { kind: 'codex' })).toBeUndefined();
+  });
+
+  it('returns undefined rather than inventing an id when nothing identifies the session', () => {
+    // An invented id looks registered while being unreachable — the exact
+    // failure this module exists to prevent.
+    expect(resolveIdentity({})).toBeUndefined();
+    expect(resolveIdentity({ CLAUDE_CODE_SESSION_ID: '   ' })).toBeUndefined();
+  });
+
+  it('gives different sessions different ids, including ones started in the same second', () => {
+    const first = resolveIdentity({
+      CLAUDE_CODE_SESSION_ID: '019467a0-0000-7000-8000-000000000001',
+    });
+    const second = resolveIdentity({
+      CLAUDE_CODE_SESSION_ID: '019467a0-0000-7000-8000-000000000002',
+    });
+
+    expect(first?.agentId).not.toBe(second?.agentId);
+  });
+});
+
+describe('resolveActorId', () => {
+  const session = {
+    agentId: 'claude-code:abcd1234',
+    kind: 'claude-code',
+    origin: 'session',
+  } as const;
+
+  it('uses the resolved session identity', () => {
+    expect(resolveActorId(session, undefined)).toBe('claude-code:abcd1234');
+  });
+
+  it('ignores a supplied id so an agent cannot act as one of its peers', () => {
+    expect(resolveActorId(session, 'claude-code:99999999')).toBe('claude-code:abcd1234');
+  });
+
+  it('falls back to a supplied id only where the session is invisible', () => {
+    // Codex scrubs the environment of the processes it spawns, so its MCP
+    // server cannot see the session; its SessionStart hook tells the model the id.
+    expect(resolveActorId(undefined, 'codex:1a2b3c4d')).toBe('codex:1a2b3c4d');
+  });
+
+  it('explains how to fix an unidentifiable caller instead of minting an id', () => {
+    expect(() => resolveActorId(undefined, undefined)).toThrow(UNRESOLVED_IDENTITY_MESSAGE);
+    expect(() => resolveActorId(undefined, '  ')).toThrow(UNRESOLVED_IDENTITY_MESSAGE);
+  });
+});

--- a/test/tools/get-work-state.test.ts
+++ b/test/tools/get-work-state.test.ts
@@ -10,6 +10,9 @@ import { workspaceIdForRoot } from '../../src/config/paths.js';
 import { openDatabase } from '../../src/db/connection.js';
 import { createRepositories, type Repositories } from '../../src/db/index.js';
 import { createServer } from '../../src/server.js';
+
+/** A server whose session Concord can see, as in any Claude Code session. */
+const SESSION = { agentId: 'test-agent:abcd1234', kind: 'test-agent', origin: 'session' } as const;
 import { handleClaimWork } from '../../src/tools/claim-work.js';
 import { handleGetWorkState, WORK_STATE_URI } from '../../src/tools/get-work-state.js';
 import { WorkspaceManager } from '../../src/workspaces/manager.js';
@@ -71,7 +74,7 @@ describe('work-state MCP surface (end-to-end via in-memory transport)', () => {
       agent: 'codex',
     });
 
-    const server = createServer(repos);
+    const server = createServer(repos, { identity: SESSION });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     const client = new Client({ name: 'test-client', version: '0.0.0' });
     await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
@@ -99,7 +102,7 @@ describe('work-state MCP surface (end-to-end via in-memory transport)', () => {
 
   it('pushes a resources/updated notification to subscribers when work-state changes', async () => {
     const repos = createRepositories(openDatabase(':memory:'));
-    const server = createServer(repos);
+    const server = createServer(repos, { identity: SESSION });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     const client = new Client({ name: 'test-client', version: '0.0.0' });
     await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
@@ -133,6 +136,7 @@ describe('work-state MCP surface (end-to-end via in-memory transport)', () => {
     const manager = new WorkspaceManager(firstRoot);
     const writtenRoots: string[] = [];
     const server = createServer(manager.current().repos, {
+      identity: SESSION,
       workspaceManager: manager,
       onToolWrite: (workspace) => {
         if (workspace !== undefined) {
@@ -193,7 +197,10 @@ describe('work-state MCP surface (end-to-end via in-memory transport)', () => {
   it('returns an MCP tool error for an invalid workspace selector', async () => {
     const root = repoDir('invalid-join');
     const manager = new WorkspaceManager(root);
-    const server = createServer(manager.current().repos, { workspaceManager: manager });
+    const server = createServer(manager.current().repos, {
+      identity: SESSION,
+      workspaceManager: manager,
+    });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     const client = new Client({ name: 'test-client', version: '0.0.0' });
     await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);

--- a/test/tools/register-agent.test.ts
+++ b/test/tools/register-agent.test.ts
@@ -4,7 +4,7 @@ import { openDatabase } from '../../src/db/connection.js';
 import { createRepositories, type Repositories } from '../../src/db/index.js';
 import { handleClaimWork } from '../../src/tools/claim-work.js';
 import { handleHandoff } from '../../src/tools/handoff.js';
-import { generateAgentId, handleRegisterAgent } from '../../src/tools/register-agent.js';
+import { ensureAgentRegistered, handleRegisterAgent } from '../../src/tools/register-agent.js';
 import { handleUpdateTask } from '../../src/tools/update-task.js';
 
 describe('handleRegisterAgent', () => {
@@ -13,10 +13,14 @@ describe('handleRegisterAgent', () => {
     repos = createRepositories(openDatabase(':memory:'));
   });
 
-  it('generates a kind-prefixed id and registers a new agent', () => {
-    const result = handleRegisterAgent(repos, { kind: 'claude-code', owner: 'alex' });
+  it('registers a new agent under the identity it was given', () => {
+    const result = handleRegisterAgent(repos, {
+      agent_id: 'claude-code:abcd1234',
+      kind: 'claude-code',
+      owner: 'alex',
+    });
     expect(result.firstRegistration).toBe(true);
-    expect(result.agent.agentId).toMatch(/^claude-code:[0-9a-f]{4}$/);
+    expect(result.agent.agentId).toBe('claude-code:abcd1234');
     expect(result.agent.status).toBe('active');
     expect(result.roster).toHaveLength(1);
     expect(result.roster[0]?.liveness).toBe('live');
@@ -60,12 +64,41 @@ describe('handleRegisterAgent', () => {
       'building the backend',
     );
   });
+});
 
-  it('generateAgentId produces distinct kind-prefixed ids', () => {
-    const a = generateAgentId('codex');
-    const b = generateAgentId('codex');
-    expect(a).toMatch(/^codex:[0-9a-f]{4}$/);
-    expect(a).not.toBe(b);
+describe('ensureAgentRegistered', () => {
+  let repos: Repositories;
+  beforeEach(() => {
+    repos = createRepositories(openDatabase(':memory:'));
+  });
+
+  it('creates a presence row for a session that knows only who it is', () => {
+    const agent = ensureAgentRegistered(
+      repos,
+      { agentId: 'claude-code:abcd1234', kind: 'claude-code' },
+      '/repo',
+    );
+
+    expect(agent.agentId).toBe('claude-code:abcd1234');
+    expect(agent.cwd).toBe('/repo');
+  });
+
+  it('never blanks metadata a richer registration already recorded', () => {
+    // The relay calls this every couple of seconds. `upsert` is a full
+    // replacement, so refreshing rather than preserving would erase the summary
+    // and owner that start_work stored (issue #68).
+    handleRegisterAgent(repos, {
+      agent_id: 'claude-code:abcd1234',
+      kind: 'claude-code',
+      owner: 'alex',
+      summary: 'building the relay',
+    });
+
+    ensureAgentRegistered(repos, { agentId: 'claude-code:abcd1234', kind: 'claude-code' }, '/repo');
+
+    expect(repos.agents.get('claude-code:abcd1234')?.summary).toBe('building the relay');
+    expect(repos.agents.get('claude-code:abcd1234')?.owner).toBe('alex');
+    expect(repos.agents.list()).toHaveLength(1);
   });
 });
 

--- a/test/tools/workflow.test.ts
+++ b/test/tools/workflow.test.ts
@@ -6,6 +6,7 @@ import { openDatabase } from '../../src/db/connection.js';
 import { createRepositories, type Repositories } from '../../src/db/index.js';
 import { createServer } from '../../src/server.js';
 import { drainInbox, registerPullEndpoint } from '../../src/cli/commands/inbox.js';
+import { resolveIdentity, type AgentIdentity } from '../../src/domain/identity.js';
 import { PUBLIC_WORKFLOW_TOOLS } from '../../src/tools/workflow.js';
 
 interface Harness {
@@ -13,8 +14,8 @@ interface Harness {
   server: ReturnType<typeof createServer>;
 }
 
-async function connect(repos: Repositories): Promise<Harness> {
-  const server = createServer(repos, {});
+async function connect(repos: Repositories, identity?: AgentIdentity): Promise<Harness> {
+  const server = createServer(repos, identity === undefined ? {} : { identity });
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   const client = new Client({ name: 'workflow-test', version: '0.0.0' });
   await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
@@ -661,6 +662,116 @@ describe('simplified workflow MCP contract', () => {
       expect(repos.agentMessages.listByAgent('codex:target')).toHaveLength(1);
       expect(repos.agentMessages.get(pending.messageId)?.status).toBe('pending');
       expect(JSON.stringify(result)).toContain('"idempotent_replay":true');
+    } finally {
+      await close(harness);
+    }
+  });
+});
+
+describe('one identity per session', () => {
+  let repos: Repositories;
+  const env = { CLAUDE_CODE_SESSION_ID: '019fd3d0-75d2-7211-b743-d770c8c76fc6' };
+
+  beforeEach(() => {
+    repos = createRepositories(openDatabase(':memory:'));
+  });
+
+  it('gives the relay and start_work the same agent, with one delivery endpoint', async () => {
+    // The regression: start_work used to mint a random id while the relay
+    // registered the session-derived one, so the session existed twice and
+    // every message addressed to the id start_work returned bounced.
+    const identity = resolveIdentity(env);
+    if (identity === undefined) throw new Error('fixture env must resolve an identity');
+
+    registerPullEndpoint(repos, identity.agentId, identity.kind);
+    const harness = await connect(repos, identity);
+    try {
+      const started = await harness.client.callTool({
+        name: 'start_work',
+        arguments: { task_id: 'T1', title: 'Unified identity', kind: 'claude-code' },
+      });
+
+      expect(JSON.stringify(started)).toContain(identity.agentId);
+      expect(repos.agents.list()).toHaveLength(1);
+      expect(repos.agentEndpoints.getByAgent(identity.agentId)).toBeDefined();
+    } finally {
+      await close(harness);
+    }
+  });
+
+  it('delivers a peer message to an agent that only ever called start_work', async () => {
+    // Two sessions, two servers, one workspace — the shape of the original bug
+    // report, where every reply to the start_work agent failed to deliver.
+    const identity = resolveIdentity(env);
+    if (identity === undefined) throw new Error('fixture env must resolve an identity');
+    const peer: AgentIdentity = {
+      agentId: 'claude-code:peer0001',
+      kind: 'claude-code',
+      origin: 'session',
+    };
+    registerPullEndpoint(repos, identity.agentId, identity.kind);
+    registerPullEndpoint(repos, peer.agentId, peer.kind);
+
+    const mine = await connect(repos, identity);
+    const theirs = await connect(repos, peer);
+    try {
+      await mine.client.callTool({
+        name: 'start_work',
+        arguments: { task_id: 'T1', title: 'Unified identity', kind: 'claude-code' },
+      });
+      const sent = await theirs.client.callTool({
+        name: 'update_work',
+        arguments: {
+          operation: 'prompt',
+          to_agent_id: identity.agentId,
+          content: 'Can you hear me?',
+          idempotency_key: 'peer-1',
+        },
+      });
+
+      // Previously target_not_promptable: the id start_work returned had no endpoint.
+      expect(sent.isError).not.toBe(true);
+      expect(drainInbox(repos, identity.agentId, identity.kind)).toHaveLength(1);
+    } finally {
+      await close(theirs);
+      await close(mine);
+    }
+  });
+
+  it('ignores an agent_id a caller supplies when it can see the session', async () => {
+    const identity = resolveIdentity(env);
+    if (identity === undefined) throw new Error('fixture env must resolve an identity');
+    const harness = await connect(repos, identity);
+    try {
+      await harness.client.callTool({
+        name: 'start_work',
+        arguments: {
+          task_id: 'T1',
+          title: 'Unified identity',
+          kind: 'claude-code',
+          agent_id: 'claude-code:someone-else',
+        },
+      });
+
+      // Honouring it would let an agent claim, finish, or message as a peer.
+      expect(repos.agents.get('claude-code:someone-else')).toBeUndefined();
+      expect(repos.tasks.get('T1')?.agentId).toBe(identity.agentId);
+    } finally {
+      await close(harness);
+    }
+  });
+
+  it('refuses to act rather than invent an identity it cannot resolve', async () => {
+    const harness = await connect(repos);
+    try {
+      const result = await harness.client.callTool({
+        name: 'start_work',
+        arguments: { task_id: 'T1', title: 'No identity', kind: 'claude-code' },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result)).toContain('concord inbox register');
+      expect(repos.agents.list()).toHaveLength(0);
     } finally {
       await close(harness);
     }


### PR DESCRIPTION
## The bug

Concord had three producers of `agent_id` and they disagreed:

| Producer | Formula | Result |
|---|---|---|
| Relay CLI — `resolveAgentId` | `sha256(sessionId)[0..8]` | `claude-code:3377596d` |
| SessionStart hook | same | matches the relay |
| MCP `start_work` — `generateAgentId` | `randomBytes(2)` | `claude-code:8bd7` |

Only the CLI writes `agent_endpoints`. So an agent that let `start_work` mint its id got an identity no endpoint would ever match — visible in presence, addressable by peers, permanently undeliverable. The tool schema made this the default path: `agent_id` was documented as *"omit on the first call to generate one"*.

Measured in one live workspace: 28 endpoints, all on session-derived ids, and **23 of 24 agents with minted ids had no endpoint at all**. Peer replies to them failed `target_not_promptable` — loudly to the sender, silently to the addressee.

## The fix

**One identity per session, derived rather than declared.**

Derivation now lives once in `src/domain/identity.ts`, which both `cli/` and `tools/` depend on. The layering rule (`tools` may not import `cli`) is exactly why the MCP side grew its own generator; moving derivation down to `domain/` removes the reason for a second one.

`SESSION_SOURCES` pairs each client's kind with the env var carrying its session id, so the two are always read together. That closes a latent bug: a Codex hook with a missing payload used to fall through to `CLAUDE_CODE_SESSION_ID` and register `codex:<hash of a Claude session>` — an id belonging to no session at all.

The MCP server resolves its own identity at startup. Claude Code spawns one server per session with `CLAUDE_CODE_SESSION_ID` in its environment, so this is known before the transport connects — no `initialize` callback needed.

A resolved session identity now **overrides** any `agent_id` a caller passes, which also closes a spoofing hole: previously a model could claim, finish, or send messages as one of its peers.

Nothing invents an id any more. Where identity cannot be resolved, tools fail with a message saying how to fix it.

## Codex

`agent_id` stays on the tool surface as a fallback, because Codex spawns MCP children with a scrubbed environment — `HOME`, `LANG`, `LOGNAME`, `PATH`, `SHELL`, `TERM`, `TMPDIR`, `USER`, and nothing else, not even `PWD`. Its session id reaches hooks on stdin only, so its SessionStart hook tells the model the id to pass back, as today. The identity is still session-derived and still minted by Concord, just relayed through the model.

Closing that residual gap needs ppid correlation (the MCP server's parent *is* the Codex process, verified) and is deliberately not in this PR.

## Verification

All five CI gates pass. Beyond unit tests, verified end-to-end against the built `dist/`:

- The relay CLI and the MCP server independently derived `claude-code:b8ad1d07` for the same session — one agent row, one endpoint, zero agents without endpoints.
- A second session (`claude-code:82b3b676`, also session-derived, no 4-char mint) prompted it: `status: delivered`, no error code, and `concord inbox drain` printed the message. This is the exact round trip that previously failed.

New regression tests pin all of it: peer delivery to a start_work-only agent, a supplied `agent_id` being ignored when the session is visible, and refusal to act rather than invent an identity.

## Follow-ups (not in this PR)

- `installClaudeRelayPlugin` resolves to the executing tree, so `concord setup` from a temp checkout leaves `~/.claude/skills/concord-relay` dangling and the relay loads in no new session.
- `concord doctor` should validate that link and count agents without endpoints — this whole failure was invisible to the tool built to surface it.