### PR TITLE
feat: archive agents unseen for an hour instead of dropping them

### DIFF
--- a/src/db/rows.ts
+++ b/src/db/rows.ts
@@ -413,7 +413,7 @@ export function parseEventRow(raw: unknown): EventRecord {
 
 // --- agents ----------------------------------------------------------------
 
-/** Status an agent reports about its own work. Liveness (live/idle/away) is
+/** Status an agent reports about its own work. Liveness (live/idle/away/archived) is
  * derived separately from `last_seen` in `domain/presence.ts`. */
 export const agentStatusValues = ['active', 'blocked', 'waiting_review', 'done'] as const;
 export type AgentStatus = (typeof agentStatusValues)[number];

--- a/src/domain/presence.ts
+++ b/src/domain/presence.ts
@@ -5,19 +5,24 @@ import type { AgentRecord, AgentStatus, TaskRecord } from '../db/index.js';
  * A registered claim is durable, but presence must decay so a crashed or
  * walked-away agent stops looking active. Distinct from the agent's *reported*
  * status (active/blocked/waiting_review/done), which says what it is doing.
+ * Agent records are never deleted: an agent unseen for long enough becomes
+ * `archived` and drops off the roster, but its id and history remain.
  */
-export type Liveness = 'live' | 'idle' | 'away';
+export type Liveness = 'live' | 'idle' | 'away' | 'archived';
 
-/** How long since `last_seen` before an agent is considered idle, then away. */
+/** How long since `last_seen` before an agent is considered idle, away, then
+ * archived. */
 export interface PresenceThresholds {
   idleAfterMs: number;
   awayAfterMs: number;
+  archiveAfterMs: number;
 }
 
-/** Live under 5 min, idle under 30 min, away beyond. */
+/** Live under 5 min, idle under 30 min, away under 1 h, archived beyond. */
 export const DEFAULT_PRESENCE_THRESHOLDS: PresenceThresholds = {
   idleAfterMs: 5 * 60 * 1000,
   awayAfterMs: 30 * 60 * 1000,
+  archiveAfterMs: 60 * 60 * 1000,
 };
 
 /** A single agent's presence for display in a roster. */
@@ -34,7 +39,8 @@ export interface PresenceEntry {
 }
 
 /** Derive liveness from a `last_seen` ISO timestamp relative to `now` (ms since
- * epoch). Unparseable timestamps are treated as `away`. */
+ * epoch). Unparseable timestamps are treated as `archived` — an agent whose
+ * last activity cannot be read must not sit on the roster forever. */
 export function deriveLiveness(
   lastSeen: string,
   now: number,
@@ -42,9 +48,12 @@ export function deriveLiveness(
 ): Liveness {
   const seen = Date.parse(lastSeen);
   if (Number.isNaN(seen)) {
-    return 'away';
+    return 'archived';
   }
   const age = now - seen;
+  if (age >= thresholds.archiveAfterMs) {
+    return 'archived';
+  }
   if (age >= thresholds.awayAfterMs) {
     return 'away';
   }
@@ -54,7 +63,7 @@ export function deriveLiveness(
   return 'live';
 }
 
-const LIVENESS_ORDER: Record<Liveness, number> = { live: 0, idle: 1, away: 2 };
+const LIVENESS_ORDER: Record<Liveness, number> = { live: 0, idle: 1, away: 2, archived: 3 };
 
 function ageSecondsOf(lastSeen: string, now: number): number {
   const seen = Date.parse(lastSeen);
@@ -67,7 +76,8 @@ function ageSecondsOf(lastSeen: string, now: number): number {
 /**
  * Build the presence roster from registered agents: live agents first, then by
  * most-recently-seen. This is the "who is here and what are they doing" view
- * that other agents read before or while working.
+ * that other agents read before or while working. Archived agents are omitted
+ * — they stay registered forever, they just no longer appear here.
  */
 /** An active claim whose owning agent is no longer reliably present. */
 export interface StaleClaim {
@@ -85,7 +95,7 @@ export interface StaleClaim {
  * without handing off" case a durable claim alone cannot surface. Only claims
  * carrying an `agentId` are assessed; unattributed claims are left alone (they
  * predate presence and would be noise). A claim is stale when its agent is
- * `away`, or when the referenced agent never registered.
+ * `away` or `archived`, or when the referenced agent never registered.
  */
 export function detectStaleClaims(
   tasks: readonly TaskRecord[],
@@ -108,7 +118,9 @@ export function detectStaleClaims(
         reason: 'agent-unregistered',
         ageSeconds: null,
       });
-    } else if (deriveLiveness(agent.lastSeen, now, thresholds) === 'away') {
+    } else if (
+      LIVENESS_ORDER[deriveLiveness(agent.lastSeen, now, thresholds)] >= LIVENESS_ORDER.away
+    ) {
       stale.push({
         taskId: task.taskId,
         title: task.title,
@@ -137,6 +149,7 @@ export function buildRoster(
       lastSeen: agent.lastSeen,
       ageSeconds: ageSecondsOf(agent.lastSeen, now),
     }))
+    .filter((entry) => entry.liveness !== 'archived')
     .sort((a, b) => {
       const byLiveness = LIVENESS_ORDER[a.liveness] - LIVENESS_ORDER[b.liveness];
       if (byLiveness !== 0) {

--- a/test/domain/presence.test.ts
+++ b/test/domain/presence.test.ts
@@ -36,21 +36,28 @@ describe('deriveLiveness', () => {
     expect(deriveLiveness(ago(10 * 60 * 1000), NOW)).toBe('idle');
   });
 
-  it('is away beyond the away threshold', () => {
-    expect(deriveLiveness(ago(60 * 60 * 1000), NOW)).toBe('away');
+  it('is away between the away and archive thresholds', () => {
+    expect(deriveLiveness(ago(45 * 60 * 1000), NOW)).toBe('away');
+  });
+
+  it('is archived beyond the archive threshold', () => {
+    expect(deriveLiveness(ago(2 * 60 * 60 * 1000), NOW)).toBe('archived');
   });
 
   it('treats the boundary as the later state (>=)', () => {
     expect(deriveLiveness(ago(5 * 60 * 1000), NOW)).toBe('idle');
     expect(deriveLiveness(ago(30 * 60 * 1000), NOW)).toBe('away');
+    expect(deriveLiveness(ago(60 * 60 * 1000), NOW)).toBe('archived');
   });
 
-  it('treats an unparseable timestamp as away', () => {
-    expect(deriveLiveness('not-a-date', NOW)).toBe('away');
+  it('treats an unparseable timestamp as archived', () => {
+    expect(deriveLiveness('not-a-date', NOW)).toBe('archived');
   });
 
   it('honours custom thresholds', () => {
-    expect(deriveLiveness(ago(2000), NOW, { idleAfterMs: 1000, awayAfterMs: 5000 })).toBe('idle');
+    expect(
+      deriveLiveness(ago(2000), NOW, { idleAfterMs: 1000, awayAfterMs: 5000, archiveAfterMs: 9000 }),
+    ).toBe('idle');
   });
 });
 
@@ -69,7 +76,7 @@ describe('buildRoster', () => {
   it('orders live agents first, then most-recently-seen', () => {
     const roster = buildRoster(
       [
-        agent({ agentId: 'away-old', lastSeen: ago(60 * 60 * 1000) }),
+        agent({ agentId: 'away-old', lastSeen: ago(45 * 60 * 1000) }),
         agent({ agentId: 'live-older', lastSeen: ago(2 * 60 * 1000) }),
         agent({ agentId: 'idle-mid', lastSeen: ago(10 * 60 * 1000) }),
         agent({ agentId: 'live-newer', lastSeen: ago(30 * 1000) }),
@@ -82,6 +89,15 @@ describe('buildRoster', () => {
       'idle-mid',
       'away-old',
     ]);
+  });
+
+  it('omits archived agents (unseen for an hour) without deleting them', () => {
+    const agents = [
+      agent({ agentId: 'still-away', lastSeen: ago(45 * 60 * 1000) }),
+      agent({ agentId: 'long-gone', lastSeen: ago(3 * 60 * 60 * 1000) }),
+    ];
+    expect(buildRoster(agents, NOW).map((entry) => entry.agentId)).toEqual(['still-away']);
+    expect(agents).toHaveLength(2);
   });
 
   it('returns an empty roster when no agents are registered', () => {
@@ -117,13 +133,24 @@ describe('detectStaleClaims', () => {
   it('flags an active claim whose owning agent is away', () => {
     const stale = detectStaleClaims(
       [task({ taskId: 'T-1', agentId: 'claude-code:7p8v' })],
-      [agent({ agentId: 'claude-code:7p8v', lastSeen: ago(60 * 60 * 1000) })],
+      [agent({ agentId: 'claude-code:7p8v', lastSeen: ago(45 * 60 * 1000) })],
       NOW,
     );
     expect(stale).toHaveLength(1);
     expect(stale[0]?.reason).toBe('agent-away');
     expect(stale[0]?.taskId).toBe('T-1');
-    expect(stale[0]?.ageSeconds).toBe(3600);
+    expect(stale[0]?.ageSeconds).toBe(2700);
+  });
+
+  it('still flags a claim whose owning agent is archived', () => {
+    const stale = detectStaleClaims(
+      [task({ taskId: 'T-1', agentId: 'claude-code:7p8v' })],
+      [agent({ agentId: 'claude-code:7p8v', lastSeen: ago(2 * 60 * 60 * 1000) })],
+      NOW,
+    );
+    expect(stale).toHaveLength(1);
+    expect(stale[0]?.reason).toBe('agent-away');
+    expect(stale[0]?.ageSeconds).toBe(7200);
   });
 
   it('flags a claim whose agent never registered', () => {

--- a/test/domain/presence.test.ts
+++ b/test/domain/presence.test.ts
@@ -56,7 +56,11 @@ describe('deriveLiveness', () => {
 
   it('honours custom thresholds', () => {
     expect(
-      deriveLiveness(ago(2000), NOW, { idleAfterMs: 1000, awayAfterMs: 5000, archiveAfterMs: 9000 }),
+      deriveLiveness(ago(2000), NOW, {
+        idleAfterMs: 1000,
+        awayAfterMs: 5000,
+        archiveAfterMs: 9000,
+      }),
     ).toBe('idle');
   });
 });


### PR DESCRIPTION
## What

Agent records are never deleted — but an agent that walked away an hour ago should not sit on the roster forever. This adds `archived` as a fourth **derived** liveness tier (`live` / `idle` / `away` / `archived`), crossing at 1 hour since `last_seen`.

## How

Liveness is already derived from `last_seen` rather than stored (`src/domain/presence.ts`), so this needed no schema change and no migration — just a new threshold (`archiveAfterMs`, default 1h) and one filter.

`buildRoster` is the single function behind every roster surface, so filtering archived entries there hides them everywhere at once, with no per-surface edits:

- the dashboard **Agents** panel
- `concord who` and `concord status`
- the `get_work_state` MCP tool / `concord://work-state` resource
- the session-start hook's "who else is here"
- the `WORK_STATE.json` artifact

The registry itself is untouched: the id, history, and claims all remain, so an archived agent that comes back is simply live again on its next heartbeat.

## Judgment calls

- **Stale-claim detection still sees archived agents.** A claim abandoned by a long-gone agent stays flagged (`reason: 'agent-away'`) rather than disappearing along with its owner. Reusing the existing reason avoids widening the `StaleClaim` union for no caller benefit.
- **An unparseable `last_seen` now derives `archived` rather than `away`** — a corrupt timestamp would otherwise pin that agent to the roster permanently, which is exactly what archiving exists to prevent.
- **`concord status`'s "Live prompting" section still lists archived agents** as unreachable. That is a reachability view, not a presence roster; changing it felt out of scope.

## Behaviour change

At exactly the 1-hour mark, agents previously rendered as `away` now drop off rosters entirely. Nothing is deleted.

## Testing

`pnpm typecheck`, `pnpm lint`, and `pnpm test` all clean on this branch (275 tests). New cases cover the archived tier, the `>=` threshold boundaries, roster omission asserting the underlying records survive, and archived claims still being flagged stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)