### PR TITLE
Track idle receiver lifecycle and recovery

### DIFF
--- a/src/artifacts/work-state-view.ts
+++ b/src/artifacts/work-state-view.ts
@@ -1,6 +1,7 @@
 import { dirname } from 'node:path';
 
 import type { Repositories, TaskRecord } from '../db/index.js';
+import { effectiveEndpointCapabilities } from '../domain/delivery.js';
 import { detectOverlaps } from '../domain/overlap.js';
 import { endpointPromptable } from '../tools/agent-messages.js';
 import {
@@ -141,7 +142,7 @@ export function buildStatus(repos: Repositories, now: number = Date.now()): Stat
         agentId: agent.agentId,
         promptable: endpointPromptable(endpoint, now),
         provider: endpoint?.provider ?? null,
-        capabilities: endpoint?.capabilities ?? [],
+        capabilities: effectiveEndpointCapabilities(endpoint, now),
       };
     }),
   };

--- a/src/cli/commands/inbox.ts
+++ b/src/cli/commands/inbox.ts
@@ -8,6 +8,7 @@ import { databasePath, resolveRepoRoot } from '../../config/paths.js';
 import type { Repositories } from '../../db/index.js';
 import {
   capabilityFor,
+  effectiveEndpointCapabilities,
   encodeCapabilities,
   monitorCapabilityFor,
   type EndpointCapability,
@@ -26,6 +27,18 @@ import { openContext } from '../context.js';
 
 /** How long a registered pull endpoint stays promptable between drains. */
 const PULL_ENDPOINT_TTL_MS = 90_000;
+/** A receiver that misses this many seconds of polls is no longer advertised. */
+const MIN_RECEIVER_TTL_MS = 10_000;
+
+function receiverExpiry(interval: number, now = Date.now()): string {
+  return new Date(now + Math.max(MIN_RECEIVER_TTL_MS, interval * 3)).toISOString();
+}
+
+function heartbeatReceiver(repos: Repositories, agentId: string, interval: number): void {
+  const endpoint = repos.agentEndpoints.getByAgent(agentId);
+  if (endpoint === undefined) throw new Error(`Agent ${agentId} has no registered endpoint.`);
+  repos.agentEndpoints.heartbeatReceiver(endpoint.endpointId, receiverExpiry(interval));
+}
 
 /**
  * Advertise that `agentId` can receive messages by draining them from inside
@@ -45,9 +58,11 @@ export function registerPullEndpoint(
   ensureAgentRegistered(repos, { agentId, kind: provider }, process.cwd());
   const existing = repos.agentEndpoints.getByAgent(agentId);
   const preservePush = existing?.transport === 'local-ipc' && existing.status === 'connected';
-  const capabilities = preservePush
-    ? [...new Set([...existing.capabilities, ...encodeCapabilities(capability)])]
-    : encodeCapabilities(capability);
+  const preserveReceiver = effectiveEndpointCapabilities(existing, now).includes('idle');
+  const capabilities =
+    preservePush || preserveReceiver
+      ? [...new Set([...(existing?.capabilities ?? []), ...encodeCapabilities(capability)])]
+      : encodeCapabilities(capability);
   repos.agentEndpoints.upsert({
     endpointId: existing?.endpointId ?? randomUUID(),
     agentId,
@@ -124,6 +139,8 @@ export async function watchInbox(
       process.off('SIGTERM', stopWatching);
       try {
         registerPullEndpoint(repos, agentId, provider);
+        const endpoint = repos.agentEndpoints.getByAgent(agentId);
+        if (endpoint !== undefined) repos.agentEndpoints.clearReceiver(endpoint.endpointId);
       } catch (registrationError) {
         if (error === undefined) error = registrationError;
       }
@@ -134,6 +151,7 @@ export async function watchInbox(
       let messages: DeliverableMessage[];
       try {
         messages = drainInbox(repos, agentId, provider, monitorCapability);
+        heartbeatReceiver(repos, agentId, interval);
       } catch (error) {
         // A monitor is the session's live receive endpoint. Transient SQLite
         // contention must delay a poll, never tear that endpoint down.
@@ -283,7 +301,14 @@ export function registerInboxCommand(program: Command): void {
         kind: options.provider,
         ...(options.fromHook === true ? { hookPayload: readHookPayload() ?? '' } : {}),
       });
-      const messages = drainInbox(context.repos, agentId, options.provider);
+      const isMonitor = options.format === 'monitor';
+      const messages = drainInbox(
+        context.repos,
+        agentId,
+        options.provider,
+        isMonitor ? monitorCapabilityFor(options.provider) : capabilityFor(options.provider),
+      );
+      if (isMonitor) heartbeatReceiver(context.repos, agentId, 2_000);
       // Silence matters: a hook that prints on an empty inbox would inject
       // noise into the session on every single tool call.
       if (messages.length === 0) return;

--- a/src/db/repositories/agent-endpoints.ts
+++ b/src/db/repositories/agent-endpoints.ts
@@ -26,6 +26,8 @@ export interface AgentEndpointRepository {
   getByAgent(agentId: string): AgentEndpointRecord | undefined;
   list(): AgentEndpointRecord[];
   heartbeat(endpointId: string, expiresAt?: string | null): AgentEndpointRecord | undefined;
+  heartbeatReceiver(endpointId: string, expiresAt: string): AgentEndpointRecord | undefined;
+  clearReceiver(endpointId: string): AgentEndpointRecord | undefined;
   disconnect(endpointId: string): AgentEndpointRecord | undefined;
 }
 
@@ -63,6 +65,16 @@ export function createAgentEndpointRepository(db: ConcordDatabase): AgentEndpoin
   const disconnectStmt = db.prepare(`
     UPDATE agent_endpoints
     SET status = 'disconnected', updated_at = @now
+    WHERE endpoint_id = @endpoint_id
+  `);
+  const heartbeatReceiverStmt = db.prepare(`
+    UPDATE agent_endpoints
+    SET receiver_expires_at = @receiver_expires_at, updated_at = @now
+    WHERE endpoint_id = @endpoint_id
+  `);
+  const clearReceiverStmt = db.prepare(`
+    UPDATE agent_endpoints
+    SET receiver_expires_at = NULL, updated_at = @now
     WHERE endpoint_id = @endpoint_id
   `);
 
@@ -109,6 +121,18 @@ export function createAgentEndpointRepository(db: ConcordDatabase): AgentEndpoin
         expires_at: expiresAt,
         now: new Date().toISOString(),
       });
+      return get(endpointId);
+    },
+    heartbeatReceiver(endpointId, expiresAt) {
+      heartbeatReceiverStmt.run({
+        endpoint_id: endpointId,
+        receiver_expires_at: expiresAt,
+        now: new Date().toISOString(),
+      });
+      return get(endpointId);
+    },
+    clearReceiver(endpointId) {
+      clearReceiverStmt.run({ endpoint_id: endpointId, now: new Date().toISOString() });
       return get(endpointId);
     },
     disconnect(endpointId) {

--- a/src/db/rows.ts
+++ b/src/db/rows.ts
@@ -486,6 +486,7 @@ export interface AgentEndpointRecord {
   status: AgentEndpointStatus;
   lastSeen: string;
   expiresAt: string | null;
+  receiverExpiresAt: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -501,6 +502,7 @@ const agentEndpointDbRowSchema = z.object({
   status: agentEndpointStatusSchema,
   last_seen: z.string(),
   expires_at: z.string().nullable(),
+  receiver_expires_at: z.string().nullable(),
   created_at: z.string(),
   updated_at: z.string(),
 });
@@ -518,6 +520,7 @@ export function parseAgentEndpointRow(raw: unknown): AgentEndpointRecord {
     status: row.status,
     lastSeen: row.last_seen,
     expiresAt: row.expires_at,
+    receiverExpiresAt: row.receiver_expires_at,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -214,4 +214,10 @@ export const migrations: readonly string[] = [
   CREATE INDEX idx_agent_message_events_message
     ON agent_message_events(message_id, id);
   `,
+  // 009 — short lease owned by the process that can wake an idle harness.
+  // This is deliberately separate from the session endpoint lease: hooks can
+  // prove that a session is alive, but cannot prove its background receiver is.
+  `
+  ALTER TABLE agent_endpoints ADD COLUMN receiver_expires_at TEXT;
+  `,
 ];

--- a/src/domain/delivery.ts
+++ b/src/domain/delivery.ts
@@ -79,3 +79,38 @@ export function deliveryOutlook(capabilities: readonly string[]): string {
 export function supportsImmediateDelivery(capabilities: readonly string[]): boolean {
   return capabilities.includes('inject') || capabilities.includes('steer');
 }
+
+/** The small part of an endpoint needed to derive honest receive capability. */
+export interface ReceiverEndpoint {
+  transport: string;
+  capabilities: readonly string[];
+  status: string;
+  expiresAt: string | null;
+  receiverExpiresAt: string | null;
+}
+
+/** Whether something is presently able to wake this endpoint while it is idle. */
+export function receiverActive(endpoint: ReceiverEndpoint | undefined, now = Date.now()): boolean {
+  if (
+    endpoint?.status !== 'connected' ||
+    (!endpoint.capabilities.includes('idle') && !endpoint.capabilities.includes('inject'))
+  ) {
+    return false;
+  }
+  if (endpoint.transport !== 'pull') {
+    return endpoint.expiresAt === null || Date.parse(endpoint.expiresAt) > now;
+  }
+  return endpoint.receiverExpiresAt !== null && Date.parse(endpoint.receiverExpiresAt) > now;
+}
+
+/** Strip idle-only promises when the process that fulfils them is not alive. */
+export function effectiveEndpointCapabilities(
+  endpoint: ReceiverEndpoint | undefined,
+  now = Date.now(),
+): string[] {
+  if (endpoint === undefined) return [];
+  if (receiverActive(endpoint, now)) return [...endpoint.capabilities];
+  return endpoint.capabilities.filter(
+    (capability) => capability !== 'idle' && capability !== 'inject',
+  );
+}

--- a/src/tools/agent-messages.ts
+++ b/src/tools/agent-messages.ts
@@ -7,7 +7,12 @@ import type {
   Repositories,
   TaskRecord,
 } from '../db/index.js';
-import { deliveryOutlook, supportsImmediateDelivery, transports } from '../domain/delivery.js';
+import {
+  deliveryOutlook,
+  effectiveEndpointCapabilities,
+  supportsImmediateDelivery,
+  transports,
+} from '../domain/delivery.js';
 
 export class AgentMessageDeliveryError extends Error {
   constructor(
@@ -180,7 +185,7 @@ export function handleSendAgentMessage(
         message: replay,
         idempotentReplay: true,
         task: task ?? null,
-        outlook: deliveryOutlook(known?.capabilities ?? []),
+        outlook: deliveryOutlook(effectiveEndpointCapabilities(known)),
         delivery: 'delivered',
         immediateMode: null,
       };
@@ -228,7 +233,7 @@ export function handleSendAgentMessage(
     message,
     idempotentReplay,
     task: activityTask ?? null,
-    outlook: deliveryOutlook(endpoint.capabilities),
+    outlook: deliveryOutlook(effectiveEndpointCapabilities(endpoint)),
     delivery: 'queued_pull',
     immediateMode: null,
   };
@@ -256,7 +261,8 @@ export async function handleSendAgentMessageWithDelivery(
   if (result.message.status !== 'pending') return result;
 
   const endpoint = repos.agentEndpoints.getByAgent(result.message.recipientAgentId);
-  if (endpoint?.transport !== 'local-ipc' || !supportsImmediateDelivery(endpoint.capabilities)) {
+  const capabilities = effectiveEndpointCapabilities(endpoint);
+  if (endpoint?.transport !== 'local-ipc' || !supportsImmediateDelivery(capabilities)) {
     return result;
   }
 
@@ -278,7 +284,7 @@ export async function handleSendAgentMessageWithDelivery(
           : 'The recipient accepted this and started a new turn immediately.',
     };
   } catch (error) {
-    if (endpoint.capabilities.includes('pull')) {
+    if (capabilities.includes('pull')) {
       return {
         ...result,
         outlook:
@@ -317,7 +323,7 @@ export function inspectAgentCommunication(
     agentId,
     promptable: endpointPromptable(endpoint),
     provider: endpoint?.provider ?? null,
-    capabilities: endpoint?.capabilities ?? [],
+    capabilities: effectiveEndpointCapabilities(endpoint),
     inbox: messages.filter((message) => message.recipientAgentId === agentId),
     outbox: messages.filter((message) => message.senderAgentId === agentId),
   };

--- a/src/tools/workflow.ts
+++ b/src/tools/workflow.ts
@@ -1,6 +1,8 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import type { Repositories, TaskRecord } from '../db/index.js';
+import { receiverActive } from '../domain/delivery.js';
+import { harnessConfigFor } from '../domain/harness-config.js';
 import { resolveActorId, type AgentIdentity } from '../domain/identity.js';
 import { SocketAgentMessageDispatcher } from '../relay/socket-dispatcher.js';
 import {
@@ -438,6 +440,54 @@ export function registerWorkflowTools(
   session?: AgentIdentity,
   dispatcher: AgentMessageDispatcher = new SocketAgentMessageDispatcher(),
 ): void {
+  interface WorkflowToolResponse {
+    content: { type: 'text'; text: string }[];
+    structuredContent?: Record<string, unknown>;
+    isError?: boolean;
+  }
+  const warnedInactiveReceivers = new Set<string>();
+
+  /** Add one neutral recovery hint per inactive period to this MCP session. */
+  const withReceiverAdvisory = <T extends WorkflowToolResponse>(result: T): T => {
+    const agentId = session?.agentId;
+    if (agentId === undefined) return result;
+    const endpoint = repos.agentEndpoints.getByAgent(agentId);
+    const config = endpoint === undefined ? undefined : harnessConfigFor(endpoint.provider);
+    if (endpoint === undefined || config?.monitor.verified !== true || !config.monitor.background) {
+      return result;
+    }
+    if (receiverActive(endpoint)) {
+      warnedInactiveReceivers.delete(agentId);
+      return result;
+    }
+    // Give a just-created session time to start the monitor supplied by its
+    // SessionStart hook before describing the receiver as inactive.
+    if (Date.now() - Date.parse(endpoint.createdAt) < 10_000) return result;
+    if (warnedInactiveReceivers.has(agentId)) return result;
+    warnedInactiveReceivers.add(agentId);
+
+    const command = config.monitor.command?.replace('<agent-id>', agentId) ?? null;
+    const recovery =
+      command === null
+        ? `Restart the ${config.monitor.kind.replaceAll('-', ' ')} for this session.`
+        : `Restart it with: \`${command}\`.`;
+    const text =
+      "Concord's idle receiver is inactive; cause unknown. Restart unless intentionally " +
+      `stopped or permission declined. ${recovery}`;
+    return {
+      ...result,
+      content: [...result.content, { type: 'text', text }],
+      structuredContent: {
+        ...result.structuredContent,
+        receiver_advisory: {
+          status: 'inactive',
+          cause: 'unknown',
+          command,
+        },
+      },
+    };
+  };
+
   /** Stamp the resolved actor onto a write tool's arguments. Throws with the
    *  fix-it message when neither the session nor the caller identifies anyone. */
   const withActor = <T extends { agent_id?: string | undefined }>(args: T): WithActor<T> => ({
@@ -465,7 +515,7 @@ export function registerWorkflowTools(
       });
       onWrite?.();
       const task = result.claim.task;
-      return {
+      return withReceiverAdvisory({
         content: [
           {
             type: 'text',
@@ -487,7 +537,7 @@ export function registerWorkflowTools(
           })),
           breadth_reasons: result.claim.breadthReasons,
         },
-      };
+      });
     },
   );
 
@@ -510,7 +560,7 @@ export function registerWorkflowTools(
       const workspace = selectToolWorkspace(selectWorkspace, args.workspace_id);
       const result = handleInspectWork(repos, args);
       if (result.scope === 'workspace') {
-        return {
+        return withReceiverAdvisory({
           content: [
             {
               type: 'text',
@@ -533,10 +583,10 @@ export function registerWorkflowTools(
             open_questions: result.state.openQuestions,
             communications: result.state.communications,
           },
-        };
+        });
       }
       if (result.scope === 'agent') {
-        return {
+        return withReceiverAdvisory({
           content: [
             {
               type: 'text',
@@ -553,10 +603,10 @@ export function registerWorkflowTools(
             scope: result.scope,
             ...result.communication,
           },
-        };
+        });
       }
       if (result.scope === 'message') {
-        return {
+        return withReceiverAdvisory({
           content: [
             {
               type: 'text',
@@ -572,9 +622,9 @@ export function registerWorkflowTools(
             thread: result.thread,
             events: result.events,
           },
-        };
+        });
       }
-      return {
+      return withReceiverAdvisory({
         content: [
           {
             type: 'text',
@@ -598,7 +648,7 @@ export function registerWorkflowTools(
           overlaps: result.context.overlaps,
           messages: result.context.messages,
         },
-      };
+      });
     },
   );
 
@@ -616,7 +666,7 @@ export function registerWorkflowTools(
         const result = await handleUpdateWork(repos, withActor(args), dispatcher);
         onWrite?.();
         if ('update' in result) {
-          return {
+          return withReceiverAdvisory({
             content: [
               {
                 type: 'text',
@@ -637,9 +687,9 @@ export function registerWorkflowTools(
               created_at: result.update.createdAt,
               task_updated_at: result.task.updatedAt,
             },
-          };
+          });
         }
-        return {
+        return withReceiverAdvisory({
           content: [
             {
               type: 'text',
@@ -671,11 +721,11 @@ export function registerWorkflowTools(
             immediate_mode: result.immediateMode,
             outlook: result.outlook,
           },
-        };
+        });
       } catch (error) {
         onWrite?.();
         if (error instanceof AgentMessageDeliveryError) {
-          return {
+          return withReceiverAdvisory({
             isError: true,
             content: [
               {
@@ -690,7 +740,7 @@ export function registerWorkflowTools(
               status: 'failed',
               error_code: error.code,
             },
-          };
+          });
         }
         throw error;
       }
@@ -710,7 +760,7 @@ export function registerWorkflowTools(
       const workspace = selectToolWorkspace(selectWorkspace, args.workspace_id);
       const result = handleTransferWork(repos, withActor(args));
       onWrite?.();
-      return {
+      return withReceiverAdvisory({
         content: [
           {
             type: 'text',
@@ -726,7 +776,7 @@ export function registerWorkflowTools(
           action: args.action,
           ...transferFields(result),
         },
-      };
+      });
     },
   );
 
@@ -743,7 +793,7 @@ export function registerWorkflowTools(
       const workspace = selectToolWorkspace(selectWorkspace, args.workspace_id);
       const result = handleFinishWork(repos, withActor(args));
       onWrite?.();
-      return {
+      return withReceiverAdvisory({
         content: [
           {
             type: 'text',
@@ -761,7 +811,7 @@ export function registerWorkflowTools(
           handoff_id: result.evidence.handoff.id,
           review_ready: result.evidence.reviewReady,
         },
-      };
+      });
     },
   );
 }

--- a/test/cli/cli-commands.test.ts
+++ b/test/cli/cli-commands.test.ts
@@ -84,7 +84,7 @@ describe('CLI read/export commands', () => {
 
   it('doctor reports schema version and adoption', () => {
     const report = runDoctor(dir);
-    expect(report).toContain('schema v8, expected v8');
+    expect(report).toContain('schema v9, expected v9');
     expect(report).toContain('TASK-12');
     expect(report).toContain('start_work: yes');
     // The resolved workspace path is surfaced so agents don't have to hunt for it.

--- a/test/cli/inbox.test.ts
+++ b/test/cli/inbox.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../../src/domain/pull-inbox.js';
 import { CONCORD_SERVER_INSTRUCTIONS } from '../../src/install/instructions.js';
 import { drainInbox, registerPullEndpoint, watchInbox } from '../../src/cli/commands/inbox.js';
-import { monitorCapabilityFor } from '../../src/domain/delivery.js';
+import { effectiveEndpointCapabilities, monitorCapabilityFor } from '../../src/domain/delivery.js';
 import { agentIdForSession } from '../../src/domain/identity.js';
 import { endpointPromptable, handleSendAgentMessage } from '../../src/tools/agent-messages.js';
 
@@ -104,14 +104,58 @@ describe('pull-transport inbox', () => {
 
   it('only advertises Cursor idle reachability while its monitor is running', () => {
     registerPullEndpoint(repos, 'beta', 'cursor');
-    expect(repos.agentEndpoints.getByAgent('beta')?.capabilities).not.toContain('idle');
+    expect(effectiveEndpointCapabilities(repos.agentEndpoints.getByAgent('beta'))).not.toContain(
+      'idle',
+    );
 
     drainInbox(repos, 'beta', 'cursor', monitorCapabilityFor('cursor'));
+    const endpoint = repos.agentEndpoints.getByAgent('beta');
+    expect(endpoint).toBeDefined();
+    if (endpoint !== undefined) {
+      repos.agentEndpoints.heartbeatReceiver(
+        endpoint.endpointId,
+        new Date(Date.now() + 10_000).toISOString(),
+      );
+    }
 
-    expect(repos.agentEndpoints.getByAgent('beta')?.capabilities).toContain('idle');
+    expect(effectiveEndpointCapabilities(repos.agentEndpoints.getByAgent('beta'))).toContain(
+      'idle',
+    );
 
+    // A busy-turn hook may drain concurrently with the monitor. It refreshes
+    // the endpoint without erasing a receiver lease it does not own.
     registerPullEndpoint(repos, 'beta', 'cursor');
-    expect(repos.agentEndpoints.getByAgent('beta')?.capabilities).not.toContain('idle');
+    expect(effectiveEndpointCapabilities(repos.agentEndpoints.getByAgent('beta'))).toContain(
+      'idle',
+    );
+
+    if (endpoint !== undefined) repos.agentEndpoints.clearReceiver(endpoint.endpointId);
+    expect(effectiveEndpointCapabilities(repos.agentEndpoints.getByAgent('beta'))).not.toContain(
+      'idle',
+    );
+  });
+
+  it('stops advertising idle delivery when the receiver heartbeat expires', () => {
+    registerPullEndpoint(repos, 'beta', 'gemini', Date.now(), monitorCapabilityFor('gemini'));
+    const endpoint = repos.agentEndpoints.getByAgent('beta');
+    expect(endpoint).toBeDefined();
+    if (endpoint === undefined) return;
+
+    repos.agentEndpoints.heartbeatReceiver(
+      endpoint.endpointId,
+      new Date(Date.now() + 10_000).toISOString(),
+    );
+    expect(effectiveEndpointCapabilities(repos.agentEndpoints.getByAgent('beta'))).toContain(
+      'idle',
+    );
+
+    repos.agentEndpoints.heartbeatReceiver(
+      endpoint.endpointId,
+      new Date(Date.now() - 1).toISOString(),
+    );
+    const capabilities = effectiveEndpointCapabilities(repos.agentEndpoints.getByAgent('beta'));
+    expect(capabilities).not.toContain('idle');
+    expect(capabilities).not.toContain('inject');
   });
 
   it('removes signal listeners when a one-shot monitor receives a message', async () => {
@@ -128,7 +172,9 @@ describe('pull-transport inbox', () => {
     expect(delivered).toEqual(['wake up']);
     expect(process.listenerCount('SIGINT')).toBe(beforeInt);
     expect(process.listenerCount('SIGTERM')).toBe(beforeTerm);
-    expect(repos.agentEndpoints.getByAgent('beta')?.capabilities).not.toContain('idle');
+    expect(effectiveEndpointCapabilities(repos.agentEndpoints.getByAgent('beta'))).not.toContain(
+      'idle',
+    );
   });
 
   it('keeps a live watcher running through transient SQLite contention', async () => {
@@ -153,7 +199,21 @@ describe('pull-transport inbox', () => {
   });
 
   it('tells the sender a Claude Code agent will see it either way', () => {
-    registerPullEndpoint(repos, 'beta', 'claude-code');
+    registerPullEndpoint(
+      repos,
+      'beta',
+      'claude-code',
+      Date.now(),
+      monitorCapabilityFor('claude-code'),
+    );
+    const endpoint = repos.agentEndpoints.getByAgent('beta');
+    expect(endpoint).toBeDefined();
+    if (endpoint !== undefined) {
+      repos.agentEndpoints.heartbeatReceiver(
+        endpoint.endpointId,
+        new Date(Date.now() + 10_000).toISOString(),
+      );
+    }
     const outlook = handleSendAgentMessage(repos, {
       operation: 'prompt',
       agentId: 'alpha',

--- a/test/db/connection.test.ts
+++ b/test/db/connection.test.ts
@@ -13,7 +13,7 @@ describe('openDatabase', () => {
   it('applies all migrations (user_version at head) and creates tables', () => {
     const db = openDatabase(':memory:');
     const version: unknown = db.pragma('user_version', { simple: true });
-    expect(version).toBe(8);
+    expect(version).toBe(9);
 
     const raw: unknown = db.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all();
     const names = new Set(
@@ -73,7 +73,7 @@ describe('openDatabase', () => {
     const task = parseTaskRow(
       upgraded.prepare('SELECT * FROM tasks WHERE task_id = ?').get('LEGACY'),
     );
-    expect(upgraded.pragma('user_version', { simple: true })).toBe(8);
+    expect(upgraded.pragma('user_version', { simple: true })).toBe(9);
     expect(task.status).toBe('handed_off');
     expect(task.agentId).toBe('codex:old');
     expect(task.version).toBe(1);

--- a/test/db/storage.test.ts
+++ b/test/db/storage.test.ts
@@ -62,7 +62,7 @@ describe('migrations', () => {
   it('is idempotent when reopening (user_version already at head)', () => {
     const { db } = newRepos();
     const version: unknown = db.pragma('user_version', { simple: true });
-    expect(version).toBe(8);
+    expect(version).toBe(9);
   });
 });
 

--- a/test/tools/workflow.test.ts
+++ b/test/tools/workflow.test.ts
@@ -699,6 +699,41 @@ describe('one identity per session', () => {
     }
   });
 
+  it('advises once when this session receiver is inactive, then re-arms after recovery', async () => {
+    const identity = resolveIdentity(env);
+    if (identity === undefined) throw new Error('fixture env must resolve an identity');
+    registerPullEndpoint(repos, identity.agentId, identity.kind);
+    repos.db
+      .prepare('UPDATE agent_endpoints SET created_at = ? WHERE agent_id = ?')
+      .run('2026-01-01T00:00:00.000Z', identity.agentId);
+
+    const harness = await connect(repos, identity);
+    try {
+      const first = await harness.client.callTool({ name: 'inspect_work', arguments: {} });
+      expect(JSON.stringify(first)).toContain('idle receiver is inactive; cause unknown');
+      expect(JSON.stringify(first)).toContain('"receiver_advisory"');
+
+      const duplicate = await harness.client.callTool({ name: 'inspect_work', arguments: {} });
+      expect(JSON.stringify(duplicate)).not.toContain('receiver_advisory');
+
+      const endpoint = repos.agentEndpoints.getByAgent(identity.agentId);
+      expect(endpoint).toBeDefined();
+      if (endpoint === undefined) return;
+      repos.agentEndpoints.heartbeatReceiver(
+        endpoint.endpointId,
+        new Date(Date.now() + 10_000).toISOString(),
+      );
+      const recovered = await harness.client.callTool({ name: 'inspect_work', arguments: {} });
+      expect(JSON.stringify(recovered)).not.toContain('receiver_advisory');
+
+      repos.agentEndpoints.clearReceiver(endpoint.endpointId);
+      const inactiveAgain = await harness.client.callTool({ name: 'inspect_work', arguments: {} });
+      expect(JSON.stringify(inactiveAgain)).toContain('receiver_advisory');
+    } finally {
+      await close(harness);
+    }
+  });
+
   it('delivers a peer message to an agent that only ever called start_work', async () => {
     // Two sessions, two servers, one workspace — the shape of the original bug
     // report, where every reply to the start_work agent failed to deliver.


### PR DESCRIPTION
## Summary
- add a short receiver lease separate from endpoint/session liveness
- advertise idle/inject only while the real monitor or managed controller is active
- attach a neutral, one-time restart advisory to the next Concord workflow call when the receiver is inactive
- preserve cause as unknown instead of inferring user intent or permission state

## Verification
- pnpm lint
- pnpm typecheck
- pnpm test (312 passing)
- pnpm build
- real Terminal smoke test in /Users/alexchoi/Documents/concord-tests/talking-test

## Live harness observation
- Gemini registered but remained busy-only with receiver_expires_at NULL while its MCP/background-shell approval was pending
- Codex stopped at the hook-trust review before endpoint registration
- no permission prompt was approved

Stacked on #111 so this PR contains only the fast-follow receiver lifecycle change.