### PR TITLE
Publish Concord to the official MCP Registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,17 @@ jobs:
       - name: Publish
         run: npm publish --access public
 
+      - name: Install MCP Registry publisher
+        run: |
+          curl -fsSL \
+            "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" \
+            | tar xz mcp-publisher
+
+      - name: Publish to the MCP Registry
+        run: |
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@concord-ai/concord-mcp",
-  "version": "0.10.0",
-  "description": "Shared work-state and task memory for coding agents: coordinate work, preserve decisions, and hand off through MCP.",
+  "version": "0.10.1",
+  "description": "Cross-harness communication and shared work-state for coding agents through MCP.",
+  "mcpName": "io.github.Get-Concord-AI/concord-mcp",
   "keywords": [
     "mcp",
     "model-context-protocol",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.Get-Concord-AI/concord-mcp",
+  "title": "Concord MCP",
+  "description": "Cross-harness communication and shared work-state for AI coding agents.",
+  "version": "0.10.1",
+  "websiteUrl": "https://getconcord.ai",
+  "repository": {
+    "url": "https://github.com/Get-Concord-AI/concord-mcp",
+    "source": "github",
+    "id": "1300719974"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@concord-ai/concord-mcp",
+      "version": "0.10.1",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 /** Single source of truth for the package version, shared by the CLI and server. */
-export const VERSION = '0.10.0';
+export const VERSION = '0.10.1';


### PR DESCRIPTION
## Summary

- add validated `server.json` metadata for the official MCP Registry
- add the required npm `mcpName` ownership marker
- release the metadata as patch version 0.10.1
- publish to the registry via GitHub OIDC after npm publication

## Verification

- `mcp-publisher validate`
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (39 files, 312 tests)
- `pnpm build`
- `npm pack --dry-run --json`