### PR TITLE
feat: add outcome-driven telemetry v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,16 +251,21 @@ are labelled [`good first issue`](https://github.com/Get-Concord-AI/concord-mcp/
 
 ## Privacy & telemetry
 
-Concord sends anonymous product-usage metadata to `getconcord.ai` so we can
-measure active installations, feature adoption, errors, and performance. Events
-contain random installation/session identifiers, an irreversible per-install
-workspace pseudonym, Concord/Node/platform versions, normalized MCP client
-metadata, and MCP tool or CLI command names, outcomes, and durations.
+Concord sends product and coordination telemetry to `getconcord.ai`. It includes
+random installation/invocation identifiers; irreversible per-install workspace
+and task-flow pseudonyms; Concord/Node/platform versions; normalized client
+metadata; operation names, outcomes, and durations; aggregate overlap/edit-guard
+results; message delivery stages and latencies; task lifecycle transitions and
+elapsed time; and explicitly reported acceptance,
+integration, human-intervention, and rework outcomes.
 
-Concord never sends code, raw file or repository paths, remotes, usernames,
-task or agent identifiers, command arguments, tool inputs/outputs, or task
-content. Set `CONCORD_TELEMETRY_DISABLED=1` (or `DO_NOT_TRACK=1`) to disable
-telemetry. Delivery is best effort and can never make a Concord operation fail.
+Concord never sends code, raw file or repository paths, remotes, usernames, raw
+task or agent identifiers, message identifiers or content, command arguments,
+tool inputs/outputs, or task content. The receiving server stores the request IP
+address and derives/stores a country code. Those server-side fields currently
+have no automatic expiry. Set `CONCORD_TELEMETRY_DISABLED=1` (or
+`DO_NOT_TRACK=1`) to disable telemetry. Delivery is best effort and can never
+make a Concord operation fail.
 
 ## License
 

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -36,6 +36,7 @@ export function checkFileOverlaps(
         taskId: task.taskId,
         title: task.title,
         reasons: [`same file(s): ${unique.join(', ')}`],
+        kinds: ['same_file'],
       });
     }
   }

--- a/src/cli/commands/hook.ts
+++ b/src/cli/commands/hook.ts
@@ -7,6 +7,7 @@ import type { Repositories } from '../../db/index.js';
 import { UNRESOLVED_IDENTITY_MESSAGE } from '../../domain/identity.js';
 import { buildRoster } from '../../domain/presence.js';
 import { ensureAgentRegistered } from '../../tools/register-agent.js';
+import type { TelemetryRecorder } from '../../telemetry/events.js';
 import { sessionStartIdentity } from '../agent-identity.js';
 import { openContext } from '../context.js';
 import { checkFileOverlaps } from './check.js';
@@ -25,6 +26,8 @@ export interface HookDecision {
   block: boolean;
   /** Message for stderr (shown to the agent); empty when there is nothing to say. */
   message: string;
+  result: 'not_applicable' | 'clear' | 'warned' | 'blocked';
+  conflictingTaskCount: number;
 }
 
 /**
@@ -45,17 +48,17 @@ export function decidePreToolUse(
   try {
     parsed = JSON.parse(rawJson);
   } catch {
-    return { block: false, message: '' };
+    return { block: false, message: '', result: 'not_applicable', conflictingTaskCount: 0 };
   }
   const payload = preToolUsePayloadSchema.parse(parsed);
   const filePath = payload.tool_input?.file_path;
   if (filePath === undefined || filePath === '') {
-    return { block: false, message: '' };
+    return { block: false, message: '', result: 'not_applicable', conflictingTaskCount: 0 };
   }
 
   const overlaps = checkFileOverlaps(repos, [filePath], selfTaskId);
   if (overlaps.length === 0) {
-    return { block: false, message: '' };
+    return { block: false, message: '', result: 'clear', conflictingTaskCount: 0 };
   }
 
   const detail = overlaps.map((overlap) => `${overlap.taskId} (${overlap.title})`).join(', ');
@@ -63,11 +66,15 @@ export function decidePreToolUse(
     return {
       block: false,
       message: `Concord: ${filePath} is also claimed by ${detail}. Set CONCORD_TASK=<your task id> to block colliding edits.`,
+      result: 'warned',
+      conflictingTaskCount: overlaps.length,
     };
   }
   return {
     block: true,
     message: `Concord: ${filePath} is claimed by another active task (${detail}). Coordinate or update your claim before editing.`,
+    result: 'blocked',
+    conflictingTaskCount: overlaps.length,
   };
 }
 
@@ -154,7 +161,7 @@ function readStdin(): string {
   }
 }
 
-export function registerHookCommand(program: Command): void {
+export function registerHookCommand(program: Command, telemetry?: TelemetryRecorder): void {
   program
     .command('hook <event>')
     .description(
@@ -178,6 +185,15 @@ export function registerHookCommand(program: Command): void {
         readStdin(),
         process.env['CONCORD_TASK'],
       );
+      if (decision.result !== 'not_applicable') {
+        const taskId = process.env['CONCORD_TASK'];
+        telemetry?.recordEvent({
+          event_type: 'edit_guard_evaluated',
+          task_flow_id: taskId === undefined ? null : telemetry.taskPseudonym(taskId),
+          result: decision.result,
+          conflicting_task_count: decision.conflictingTaskCount,
+        });
+      }
       if (decision.message !== '') {
         process.stderr.write(`${decision.message}\n`);
       }

--- a/src/cli/commands/inbox.ts
+++ b/src/cli/commands/inbox.ts
@@ -22,6 +22,7 @@ import {
   type DeliverableMessage,
 } from '../../domain/pull-inbox.js';
 import { ensureAgentRegistered } from '../../tools/register-agent.js';
+import type { TelemetryRecorder } from '../../telemetry/events.js';
 import { resolveAgentId } from '../agent-identity.js';
 import { openContext } from '../context.js';
 
@@ -81,12 +82,20 @@ function toDeliverable(message: {
   senderAgentId: string;
   taskId: string | null;
   content: string;
+  replyToMessageId: string | null;
+  createdAt: string;
+  deliveredAt: string | null;
 }): DeliverableMessage {
   return {
     messageId: message.messageId,
     senderAgentId: message.senderAgentId,
     taskId: message.taskId,
     content: message.content,
+    messageKind: message.replyToMessageId === null ? 'prompt' : 'reply',
+    deliveryLatencyMs:
+      message.deliveredAt === null
+        ? null
+        : Math.max(0, Date.parse(message.deliveredAt) - Date.parse(message.createdAt)),
   };
 }
 
@@ -230,7 +239,25 @@ function launchCodexAdapterHost(repoRoot: string, agentId: string, threadId: str
   child.unref();
 }
 
-export function registerInboxCommand(program: Command): void {
+function recordDeliveredMessages(
+  telemetry: TelemetryRecorder | undefined,
+  messages: readonly DeliverableMessage[],
+): void {
+  for (const message of messages) {
+    telemetry?.recordEvent({
+      event_type: 'message_delivery',
+      task_flow_id: message.taskId === null ? null : telemetry.taskPseudonym(message.taskId),
+      message_kind: message.messageKind,
+      stage: 'receive',
+      result: 'delivered',
+      delivery_mode: 'pull',
+      error_code: null,
+      latency_ms: message.deliveryLatencyMs,
+    });
+  }
+}
+
+export function registerInboxCommand(program: Command, telemetry?: TelemetryRecorder): void {
   const inbox = program
     .command('inbox')
     .description('Receive live messages other agents addressed to this session');
@@ -312,6 +339,7 @@ export function registerInboxCommand(program: Command): void {
       // Silence matters: a hook that prints on an empty inbox would inject
       // noise into the session on every single tool call.
       if (messages.length === 0) return;
+      recordDeliveredMessages(telemetry, messages);
       if (options.format === 'json') {
         process.stdout.write(`${JSON.stringify(messages)}\n`);
         return;
@@ -366,6 +394,7 @@ export function registerInboxCommand(program: Command): void {
         parsedInterval,
         options.once === true,
         (messages) => {
+          recordDeliveredMessages(telemetry, messages);
           if (options.format === 'stop') {
             process.stdout.write(renderHookPayload('stop', messages));
             return;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -25,6 +25,7 @@ import { configureCliWorkspace, parseCliWorkspaceOptions } from './workspace-opt
 const program = new Command();
 let workspaceRoot = resolveRepoRoot(process.cwd(), process.env);
 let activeCommand: { name: string; startedAt: number } | undefined;
+const backgroundCommands = new Set(['drain', 'watch', 'hook']);
 const telemetry = createTelemetryClient({
   surface: 'cli',
   workspaceRoot: () => workspaceRoot,
@@ -48,11 +49,13 @@ program.hook('preAction', (command, actionCommand) => {
 
 program.hook('postAction', (_command, actionCommand) => {
   if (activeCommand?.name === actionCommand.name()) {
-    telemetry?.recordOperation(
-      activeCommand.name,
-      'success',
-      performance.now() - activeCommand.startedAt,
-    );
+    if (!backgroundCommands.has(activeCommand.name)) {
+      telemetry?.recordOperation(
+        activeCommand.name,
+        'success',
+        performance.now() - activeCommand.startedAt,
+      );
+    }
     activeCommand = undefined;
   }
 });
@@ -65,8 +68,8 @@ registerTasks(program);
 registerCheckCommand(program);
 registerDashboardCommand(program);
 registerWatchCommand(program);
-registerHookCommand(program);
-registerInboxCommand(program);
+registerHookCommand(program, telemetry);
+registerInboxCommand(program, telemetry);
 registerHandoffCommand(program);
 registerReviewPacketCommand(program);
 registerExportCommand(program);
@@ -77,11 +80,13 @@ try {
   await program.parseAsync();
 } catch (error) {
   if (activeCommand !== undefined) {
-    telemetry?.recordOperation(
-      activeCommand.name,
-      'error',
-      performance.now() - activeCommand.startedAt,
-    );
+    if (!backgroundCommands.has(activeCommand.name)) {
+      telemetry?.recordOperation(
+        activeCommand.name,
+        'error',
+        performance.now() - activeCommand.startedAt,
+      );
+    }
   }
   throw error;
 } finally {

--- a/src/domain/overlap.ts
+++ b/src/domain/overlap.ts
@@ -19,7 +19,11 @@ export interface OverlapWarning {
   taskId: string;
   title: string;
   reasons: string[];
+  kinds: OverlapKind[];
 }
+
+export type OverlapKind =
+  'same_file' | 'same_directory' | 'shared_module' | 'shared_domain' | 'shared_risk_tag';
 
 function sortedIntersection(a: readonly string[], b: readonly string[]): string[] {
   const other = new Set(b);
@@ -85,8 +89,12 @@ function isParentChild(candidate: OverlapSurface, task: TaskRecord): boolean {
   return candidate.parentTaskId === task.taskId || task.parentTaskId === candidate.taskId;
 }
 
-function reasonsFor(candidate: OverlapSurface, existing: OverlapSurface): string[] {
+function detailsFor(
+  candidate: OverlapSurface,
+  existing: OverlapSurface,
+): { reasons: string[]; kinds: OverlapKind[] } {
   const reasons: string[] = [];
+  const kinds: OverlapKind[] = [];
 
   const sameFiles = sortedIntersection(
     candidate.expectedFiles.map(normalizePath).filter((file) => file !== ''),
@@ -94,6 +102,7 @@ function reasonsFor(candidate: OverlapSurface, existing: OverlapSurface): string
   );
   if (sameFiles.length > 0) {
     reasons.push(`same file(s): ${sameFiles.join(', ')}`);
+    kinds.push('same_file');
   }
 
   const sameDirs = sortedIntersection(
@@ -102,16 +111,19 @@ function reasonsFor(candidate: OverlapSurface, existing: OverlapSurface): string
   );
   if (sameDirs.length > 0 && sameFiles.length === 0) {
     reasons.push(`same directory: ${sameDirs.join(', ')}`);
+    kinds.push('same_directory');
   }
 
   const sameModules = sortedIntersection(tokensOf(candidate.modules), tokensOf(existing.modules));
   if (sameModules.length > 0) {
     reasons.push(`shared module(s): ${sameModules.join(', ')}`);
+    kinds.push('shared_module');
   }
 
   const sameDomains = sortedIntersection(tokensOf(candidate.domains), tokensOf(existing.domains));
   if (sameDomains.length > 0) {
     reasons.push(`shared domain(s): ${sameDomains.join(', ')}`);
+    kinds.push('shared_domain');
   }
 
   const sameRiskTags = sortedIntersection(
@@ -120,9 +132,10 @@ function reasonsFor(candidate: OverlapSurface, existing: OverlapSurface): string
   );
   if (sameRiskTags.length > 0) {
     reasons.push(`shared risk tag(s): ${sameRiskTags.join(', ')}`);
+    kinds.push('shared_risk_tag');
   }
 
-  return reasons;
+  return { reasons, kinds };
 }
 
 /**
@@ -141,9 +154,9 @@ export function detectOverlaps(
     if (task.taskId === candidate.taskId || isParentChild(candidate, task)) {
       continue;
     }
-    const reasons = reasonsFor(candidate, surfaceOf(task));
+    const { reasons, kinds } = detailsFor(candidate, surfaceOf(task));
     if (reasons.length > 0) {
-      warnings.push({ taskId: task.taskId, title: task.title, reasons });
+      warnings.push({ taskId: task.taskId, title: task.title, reasons, kinds });
     }
   }
   return warnings;

--- a/src/domain/pull-inbox.ts
+++ b/src/domain/pull-inbox.ts
@@ -13,6 +13,8 @@ export interface DeliverableMessage {
   senderAgentId: string;
   taskId: string | null;
   content: string;
+  messageKind: 'prompt' | 'reply';
+  deliveryLatencyMs: number | null;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,19 +23,21 @@ async function main(): Promise<void> {
     ensureAgentRegistered(workspaceManager.current().repos, identity, repoRoot);
   }
   const updateCheck = startBackgroundUpdateCheck(VERSION, process.env);
+  const telemetry = createTelemetryClient({
+    surface: 'mcp',
+    workspaceRoot: () => workspaceManager.current().repoRoot,
+    recordSessionStarted: true,
+  });
   const server = createServer(workspaceManager.current().repos, {
     workspaceManager,
     ...(identity === undefined ? {} : { identity }),
     getAvailableUpdate: updateCheck.getAvailableUpdate,
+    ...(telemetry === undefined ? {} : { telemetry }),
     onToolWrite: (workspace) => {
       if (workspace !== undefined) {
         writeArtifacts(workspace.concordPath, workspace.repos);
       }
     },
-  });
-  const telemetry = createTelemetryClient({
-    surface: 'mcp',
-    workspaceRoot: () => workspaceManager.current().repoRoot,
   });
   const stdio = new StdioServerTransport();
   const transport = telemetry === undefined ? stdio : new TelemetryTransport(stdio, telemetry);

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import type { Repositories } from './db/index.js';
 import type { AgentIdentity } from './domain/identity.js';
+import type { TelemetryRecorder } from './telemetry/events.js';
 import { CONCORD_SERVER_INSTRUCTIONS } from './install/instructions.js';
 import type { AvailableUpdate } from './update-notifier.js';
 import { registerWorkStateResource } from './tools/get-work-state.js';
@@ -29,6 +30,8 @@ export interface ServerOptions {
   identity?: AgentIdentity;
   /** Reads a background update check without blocking an MCP tool call. */
   getAvailableUpdate?: () => AvailableUpdate | undefined;
+  /** Receives whitelisted, content-free results from workflow handlers. */
+  telemetry?: TelemetryRecorder;
 }
 
 /**
@@ -58,6 +61,8 @@ export function createServer(repos: Repositories, options: ServerOptions = {}): 
     selectWorkspace,
     options.identity,
     options.getAvailableUpdate,
+    undefined,
+    options.telemetry,
   );
   return server;
 }

--- a/src/telemetry/client.ts
+++ b/src/telemetry/client.ts
@@ -116,8 +116,8 @@ export class TelemetryClient implements TelemetryRecorder {
     });
   }
 
-  recordEvent(event: SemanticTelemetryEvent): void {
-    this.#enqueue(event);
+  recordEvent(event: SemanticTelemetryEvent, workspaceRoot?: string): void {
+    this.#enqueue(event, workspaceRoot);
   }
 
   async flush(): Promise<void> {
@@ -168,11 +168,11 @@ export class TelemetryClient implements TelemetryRecorder {
     return this.flush();
   }
 
-  #enqueue(event: EventPayload): void {
+  #enqueue(event: EventPayload, workspaceRoot?: string): void {
     if (this.#events.length >= MAX_QUEUE_SIZE) {
       this.#events.shift();
     }
-    const root = this.#workspaceRoot();
+    const root = workspaceRoot ?? this.#workspaceRoot();
     this.#events.push({
       ...event,
       event_id: randomUUID(),

--- a/src/telemetry/client.ts
+++ b/src/telemetry/client.ts
@@ -5,29 +5,40 @@ import { VERSION } from '../version.js';
 import {
   loadTelemetryIdentity,
   markTelemetryNoticeShown,
+  taskPseudonym as deriveTaskPseudonym,
   telemetryConfigFile,
   workspacePseudonym,
+  type TelemetryIdentity,
 } from './identity.js';
+import type { SemanticTelemetryEvent, TelemetryOutcome, TelemetryRecorder } from './events.js';
 
-export const DEFAULT_TELEMETRY_URL = 'https://getconcord.ai/api/telemetry/v1';
+export const DEFAULT_TELEMETRY_URL = 'https://getconcord.ai/api/telemetry/v2';
 const FLUSH_DELAY_MS = 5_000;
 const FETCH_TIMEOUT_MS = 1_500;
 const MAX_BATCH_SIZE = 50;
 const MAX_QUEUE_SIZE = 200;
 
 export type TelemetrySurface = 'mcp' | 'cli';
-export type TelemetryOutcome = 'success' | 'error';
-
-interface QueuedEvent {
+interface EventBase {
   event_id: string;
   sequence: number;
   occurred_at: string;
-  event_type: 'session_started' | 'operation_completed';
-  operation: string | null;
-  outcome: TelemetryOutcome | null;
-  duration_ms: number | null;
   workspace_id: string | null;
 }
+
+type EventPayload =
+  | {
+      event_type: 'session_started';
+    }
+  | {
+      event_type: 'operation_completed';
+      operation: string;
+      outcome: TelemetryOutcome;
+      duration_ms: number;
+    }
+  | SemanticTelemetryEvent;
+
+type QueuedEvent = EventBase & EventPayload;
 
 interface TelemetryClientOptions {
   surface: TelemetrySurface;
@@ -35,6 +46,7 @@ interface TelemetryClientOptions {
   env?: NodeJS.ProcessEnv;
   fetcher?: typeof fetch;
   stderr?: { write(message: string): unknown };
+  recordSessionStarted?: boolean;
 }
 
 interface ClientInfo {
@@ -42,10 +54,9 @@ interface ClientInfo {
   version: string | null;
 }
 
-export class TelemetryClient {
+export class TelemetryClient implements TelemetryRecorder {
   readonly #installationId: string;
   readonly #sessionId = randomUUID();
-  readonly #workspaceKey: string;
   readonly #surface: TelemetrySurface;
   readonly #workspaceRoot: () => string | undefined;
   readonly #endpoint: string;
@@ -56,16 +67,21 @@ export class TelemetryClient {
   #sequence = 0;
   #timer: NodeJS.Timeout | undefined;
   #flushing = false;
+  readonly #identity: TelemetryIdentity;
 
   constructor(installationId: string, workspaceKey: string, options: TelemetryClientOptions) {
     this.#installationId = installationId;
-    this.#workspaceKey = workspaceKey;
     this.#surface = options.surface;
     this.#workspaceRoot = options.workspaceRoot;
     this.#endpoint = options.env?.['CONCORD_TELEMETRY_URL'] ?? DEFAULT_TELEMETRY_URL;
     this.#fetcher = options.fetcher ?? fetch;
     this.#ci = (options.env ?? process.env)['CI'] !== undefined;
-    this.#record('session_started', null, null, null);
+    this.#identity = { installationId, workspaceKey, noticeShown: true };
+    if (options.recordSessionStarted === true) {
+      this.#enqueue({
+        event_type: 'session_started',
+      });
+    }
   }
 
   setClientInfo(name: string, version: string): void {
@@ -86,8 +102,22 @@ export class TelemetryClient {
     };
   }
 
+  taskPseudonym(taskId: string): string | null {
+    const root = this.#workspaceRoot();
+    return root === undefined ? null : deriveTaskPseudonym(this.#identity, root, taskId);
+  }
+
   recordOperation(operation: string, outcome: TelemetryOutcome, durationMs: number): void {
-    this.#record('operation_completed', operation.slice(0, 80), outcome, durationMs);
+    this.#enqueue({
+      event_type: 'operation_completed',
+      operation: operation.slice(0, 80),
+      outcome,
+      duration_ms: Math.min(86_400_000, Math.max(0, Math.round(durationMs))),
+    });
+  }
+
+  recordEvent(event: SemanticTelemetryEvent): void {
+    this.#enqueue(event);
   }
 
   async flush(): Promise<void> {
@@ -105,9 +135,9 @@ export class TelemetryClient {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({
-          schema_version: 1,
+          schema_version: 2,
           installation_id: this.#installationId,
-          session_id: this.#sessionId,
+          invocation_id: this.#sessionId,
           sent_at: new Date().toISOString(),
           source: {
             surface: this.#surface,
@@ -138,36 +168,17 @@ export class TelemetryClient {
     return this.flush();
   }
 
-  #record(
-    eventType: QueuedEvent['event_type'],
-    operation: string | null,
-    outcome: TelemetryOutcome | null,
-    durationMs: number | null,
-  ): void {
+  #enqueue(event: EventPayload): void {
     if (this.#events.length >= MAX_QUEUE_SIZE) {
       this.#events.shift();
     }
     const root = this.#workspaceRoot();
     this.#events.push({
+      ...event,
       event_id: randomUUID(),
       sequence: this.#sequence,
       occurred_at: new Date().toISOString(),
-      event_type: eventType,
-      operation,
-      outcome,
-      duration_ms:
-        durationMs === null ? null : Math.min(86_400_000, Math.max(0, Math.round(durationMs))),
-      workspace_id:
-        root === undefined
-          ? null
-          : workspacePseudonym(
-              {
-                installationId: this.#installationId,
-                workspaceKey: this.#workspaceKey,
-                noticeShown: true,
-              },
-              root,
-            ),
+      workspace_id: root === undefined ? null : workspacePseudonym(this.#identity, root),
     });
     this.#sequence += 1;
     if (this.#events.length >= MAX_BATCH_SIZE) {
@@ -207,7 +218,8 @@ export function createTelemetryClient(
   }
   if (!identity.noticeShown) {
     (options.stderr ?? process.stderr).write(
-      'Concord sends anonymous usage telemetry (no code, paths, or task content). ' +
+      'Concord sends product and coordination telemetry (no code, paths, messages, or task content); ' +
+        'the server stores request IP and country without automatic expiry. ' +
         'Disable with CONCORD_TELEMETRY_DISABLED=1.\n',
     );
     markTelemetryNoticeShown(configFile, identity);

--- a/src/telemetry/events.ts
+++ b/src/telemetry/events.ts
@@ -1,0 +1,51 @@
+export type TelemetryOutcome = 'success' | 'error';
+
+export type SemanticTelemetryEvent =
+  | {
+      event_type: 'claim_evaluated';
+      task_flow_id: string;
+      claim_mode: 'new_claim' | 'claim' | 'assignment' | 'handoff' | 'reopen';
+      checked_task_count: number;
+      overlap_count: number;
+      overlap_kinds: string[];
+      breadth_warning_count: number;
+    }
+  | {
+      event_type: 'edit_guard_evaluated';
+      task_flow_id: string | null;
+      result: 'clear' | 'warned' | 'blocked';
+      conflicting_task_count: number;
+    }
+  | {
+      event_type: 'message_delivery';
+      task_flow_id: string | null;
+      message_kind: 'prompt' | 'reply';
+      stage: 'send' | 'receive';
+      result: 'delivered' | 'queued' | 'failed' | 'replied';
+      delivery_mode: 'inject' | 'steer' | 'pull' | null;
+      error_code: string | null;
+      latency_ms: number | null;
+    }
+  | {
+      event_type: 'task_lifecycle';
+      task_flow_id: string;
+      transition:
+        'finish' | 'assign' | 'accept' | 'decline' | 'release' | 'reassign' | 'offer' | 'reopen';
+      status: string;
+      elapsed_ms: number | null;
+    }
+  | {
+      event_type: 'reported_outcome';
+      task_flow_id: string;
+      source: 'agent' | 'ci' | 'review' | 'human';
+      acceptance: 'accepted' | 'rejected' | 'not_checked';
+      integration: 'passed' | 'failed' | 'not_checked';
+      human_intervention_ms: number | null;
+      rework_ms: number | null;
+    };
+
+export interface TelemetryRecorder {
+  taskPseudonym(taskId: string): string | null;
+  recordOperation(operation: string, outcome: TelemetryOutcome, durationMs: number): void;
+  recordEvent(event: SemanticTelemetryEvent): void;
+}

--- a/src/telemetry/events.ts
+++ b/src/telemetry/events.ts
@@ -47,5 +47,5 @@ export type SemanticTelemetryEvent =
 export interface TelemetryRecorder {
   taskPseudonym(taskId: string): string | null;
   recordOperation(operation: string, outcome: TelemetryOutcome, durationMs: number): void;
-  recordEvent(event: SemanticTelemetryEvent): void;
+  recordEvent(event: SemanticTelemetryEvent, workspaceRoot?: string): void;
 }

--- a/src/telemetry/identity.ts
+++ b/src/telemetry/identity.ts
@@ -43,7 +43,7 @@ function persistIdentity(path: string, identity: TelemetryIdentity): boolean {
   }
 }
 
-/** Load or create the anonymous identity. Failure disables telemetry. */
+/** Load or create the pseudonymous installation identity. Failure disables telemetry. */
 export function loadTelemetryIdentity(path: string): TelemetryIdentity | undefined {
   try {
     const parsed = identitySchema.parse(JSON.parse(readFileSync(path, 'utf8')));
@@ -71,4 +71,15 @@ export function markTelemetryNoticeShown(path: string, identity: TelemetryIdenti
 /** Stable only for this installation; the canonical path and key never leave the machine. */
 export function workspacePseudonym(identity: TelemetryIdentity, repoRoot: string): string {
   return createHmac('sha256', identity.workspaceKey).update(repoRoot).digest('hex');
+}
+
+/** Opaque, installation-scoped correlation token. Raw identifiers never leave the client. */
+export function taskPseudonym(
+  identity: TelemetryIdentity,
+  repoRoot: string,
+  taskId: string,
+): string {
+  return createHmac('sha256', identity.workspaceKey)
+    .update(`${repoRoot}\0task\0${taskId}`)
+    .digest('hex');
 }

--- a/src/tools/workflow.ts
+++ b/src/tools/workflow.ts
@@ -730,6 +730,16 @@ export function registerWorkflowTools(
     },
     async (args) => {
       const workspace = selectToolWorkspace(selectWorkspace, args.workspace_id);
+      const telemetryWorkspaceRoot = workspace?.repoRoot;
+      const messageTaskId =
+        args.task_id ??
+        (args.operation === 'reply' && args.reply_to_message_id !== undefined
+          ? repos.agentMessages.get(args.reply_to_message_id)?.taskId
+          : undefined);
+      const messageTaskFlowId =
+        messageTaskId === undefined || messageTaskId === null
+          ? null
+          : (taskFlowId(messageTaskId) ?? null);
       try {
         const result = await handleUpdateWork(repos, withActor(args), dispatcher);
         onWrite?.();
@@ -757,24 +767,28 @@ export function registerWorkflowTools(
             },
           });
         }
-        const messageTaskFlowId =
-          result.message.taskId === null ? null : (taskFlowId(result.message.taskId) ?? null);
-        telemetry?.recordEvent({
-          event_type: 'message_delivery',
-          task_flow_id: messageTaskFlowId,
-          message_kind: args.operation === 'reply' ? 'reply' : 'prompt',
-          stage: 'send',
-          result: result.delivery === 'delivered' ? 'delivered' : 'queued',
-          delivery_mode: result.immediateMode,
-          error_code: null,
-          latency_ms:
-            result.message.deliveredAt === null
-              ? null
-              : Math.max(
-                  0,
-                  Date.parse(result.message.deliveredAt) - Date.parse(result.message.createdAt),
-                ),
-        });
+        if (!result.idempotentReplay) {
+          telemetry?.recordEvent(
+            {
+              event_type: 'message_delivery',
+              task_flow_id: messageTaskFlowId,
+              message_kind: args.operation === 'reply' ? 'reply' : 'prompt',
+              stage: 'send',
+              result: result.delivery === 'delivered' ? 'delivered' : 'queued',
+              delivery_mode: result.immediateMode,
+              error_code: null,
+              latency_ms:
+                result.message.deliveredAt === null
+                  ? null
+                  : Math.max(
+                      0,
+                      Date.parse(result.message.deliveredAt) -
+                        Date.parse(result.message.createdAt),
+                    ),
+            },
+            telemetryWorkspaceRoot,
+          );
+        }
         return withSessionAdvisories({
           content: [
             {
@@ -811,16 +825,20 @@ export function registerWorkflowTools(
       } catch (error) {
         onWrite?.();
         if (error instanceof AgentMessageDeliveryError) {
-          telemetry?.recordEvent({
-            event_type: 'message_delivery',
-            task_flow_id: args.task_id === undefined ? null : (taskFlowId(args.task_id) ?? null),
-            message_kind: args.operation === 'reply' ? 'reply' : 'prompt',
-            stage: 'send',
-            result: 'failed',
-            delivery_mode: null,
-            error_code: error.code,
-            latency_ms: null,
-          });
+          telemetry?.recordEvent(
+            {
+              event_type: 'message_delivery',
+              task_flow_id:
+                messageTaskFlowId,
+              message_kind: args.operation === 'reply' ? 'reply' : 'prompt',
+              stage: 'send',
+              result: 'failed',
+              delivery_mode: null,
+              error_code: error.code,
+              latency_ms: null,
+            },
+            telemetryWorkspaceRoot,
+          );
           return withSessionAdvisories({
             isError: true,
             content: [

--- a/src/tools/workflow.ts
+++ b/src/tools/workflow.ts
@@ -5,6 +5,7 @@ import type { AvailableUpdate } from '../update-notifier.js';
 import { receiverActive } from '../domain/delivery.js';
 import { harnessConfigFor } from '../domain/harness-config.js';
 import { resolveActorId, type AgentIdentity } from '../domain/identity.js';
+import type { SemanticTelemetryEvent, TelemetryRecorder } from '../telemetry/events.js';
 import { SocketAgentMessageDispatcher } from '../relay/socket-dispatcher.js';
 import {
   finishWorkInputShape,
@@ -442,6 +443,7 @@ export function registerWorkflowTools(
   session?: AgentIdentity,
   getAvailableUpdate?: () => AvailableUpdate | undefined,
   dispatcher: AgentMessageDispatcher = new SocketAgentMessageDispatcher(),
+  telemetry?: TelemetryRecorder,
 ): void {
   interface WorkflowToolResponse {
     content: { type: 'text'; text: string }[];
@@ -518,6 +520,28 @@ export function registerWorkflowTools(
   const withSessionAdvisories = <T extends WorkflowToolResponse>(result: T): T =>
     withUpdateAdvisory(withReceiverAdvisory(result));
 
+  type TaskTransition = Extract<
+    SemanticTelemetryEvent,
+    { event_type: 'task_lifecycle' }
+  >['transition'];
+  const taskFlowId = (taskId: string): string | undefined =>
+    telemetry?.taskPseudonym(taskId) ?? undefined;
+  const recordTaskTransition = (
+    taskId: string,
+    transition: TaskTransition,
+    status: string,
+  ): void => {
+    const telemetryTaskFlowId = taskFlowId(taskId);
+    if (telemetryTaskFlowId === undefined) return;
+    telemetry?.recordEvent({
+      event_type: 'task_lifecycle',
+      task_flow_id: telemetryTaskFlowId,
+      transition,
+      status,
+      elapsed_ms: null,
+    });
+  };
+
   /** Stamp the resolved actor onto a write tool's arguments. Throws with the
    *  fix-it message when neither the session nor the caller identifies anyone. */
   const withActor = <T extends { agent_id?: string | undefined }>(args: T): WithActor<T> => ({
@@ -543,6 +567,20 @@ export function registerWorkflowTools(
         ...withActor(args),
         kind: session?.kind ?? args.kind,
       });
+      const startedTaskFlowId = taskFlowId(result.claim.task.taskId);
+      if (startedTaskFlowId !== undefined) {
+        telemetry?.recordEvent({
+          event_type: 'claim_evaluated',
+          task_flow_id: startedTaskFlowId,
+          claim_mode: result.resumedBy,
+          checked_task_count: result.claim.checkedAgainst,
+          overlap_count: result.claim.overlaps.length,
+          overlap_kinds: [
+            ...new Set(result.claim.overlaps.flatMap((overlap) => overlap.kinds)),
+          ].sort(),
+          breadth_warning_count: result.claim.breadthReasons.length,
+        });
+      }
       onWrite?.();
       const task = result.claim.task;
       return withSessionAdvisories({
@@ -719,6 +757,24 @@ export function registerWorkflowTools(
             },
           });
         }
+        const messageTaskFlowId =
+          result.message.taskId === null ? null : (taskFlowId(result.message.taskId) ?? null);
+        telemetry?.recordEvent({
+          event_type: 'message_delivery',
+          task_flow_id: messageTaskFlowId,
+          message_kind: args.operation === 'reply' ? 'reply' : 'prompt',
+          stage: 'send',
+          result: result.delivery === 'delivered' ? 'delivered' : 'queued',
+          delivery_mode: result.immediateMode,
+          error_code: null,
+          latency_ms:
+            result.message.deliveredAt === null
+              ? null
+              : Math.max(
+                  0,
+                  Date.parse(result.message.deliveredAt) - Date.parse(result.message.createdAt),
+                ),
+        });
         return withSessionAdvisories({
           content: [
             {
@@ -755,6 +811,16 @@ export function registerWorkflowTools(
       } catch (error) {
         onWrite?.();
         if (error instanceof AgentMessageDeliveryError) {
+          telemetry?.recordEvent({
+            event_type: 'message_delivery',
+            task_flow_id: args.task_id === undefined ? null : (taskFlowId(args.task_id) ?? null),
+            message_kind: args.operation === 'reply' ? 'reply' : 'prompt',
+            stage: 'send',
+            result: 'failed',
+            delivery_mode: null,
+            error_code: error.code,
+            latency_ms: null,
+          });
           return withSessionAdvisories({
             isError: true,
             content: [
@@ -789,6 +855,7 @@ export function registerWorkflowTools(
     (args) => {
       const workspace = selectToolWorkspace(selectWorkspace, args.workspace_id);
       const result = handleTransferWork(repos, withActor(args));
+      recordTaskTransition(result.task.taskId, args.action, result.task.status);
       onWrite?.();
       return withSessionAdvisories({
         content: [
@@ -822,6 +889,27 @@ export function registerWorkflowTools(
     (args) => {
       const workspace = selectToolWorkspace(selectWorkspace, args.workspace_id);
       const result = handleFinishWork(repos, withActor(args));
+      const finishedTaskFlowId = taskFlowId(result.task.taskId);
+      if (finishedTaskFlowId !== undefined) {
+        telemetry?.recordEvent({
+          event_type: 'task_lifecycle',
+          task_flow_id: finishedTaskFlowId,
+          transition: 'finish',
+          status: result.task.status,
+          elapsed_ms: Math.max(0, Date.now() - Date.parse(result.task.createdAt)),
+        });
+        if (args.reported_outcome !== undefined) {
+          telemetry?.recordEvent({
+            event_type: 'reported_outcome',
+            task_flow_id: finishedTaskFlowId,
+            source: args.reported_outcome.source,
+            acceptance: args.reported_outcome.acceptance,
+            integration: args.reported_outcome.integration,
+            human_intervention_ms: args.reported_outcome.human_intervention_ms ?? null,
+            rework_ms: args.reported_outcome.rework_ms ?? null,
+          });
+        }
+      }
       onWrite?.();
       return withSessionAdvisories({
         content: [

--- a/src/tools/workflow.ts
+++ b/src/tools/workflow.ts
@@ -767,7 +767,7 @@ export function registerWorkflowTools(
             },
           });
         }
-        if (!result.idempotentReplay) {
+        if (!result.idempotentReplay || result.immediateMode !== null) {
           telemetry?.recordEvent(
             {
               event_type: 'message_delivery',

--- a/test/cli/inbox.test.ts
+++ b/test/cli/inbox.test.ts
@@ -7,6 +7,7 @@ import {
   renderGeminiAfterTool,
   renderHookPayload,
   renderMonitorLines,
+  type DeliverableMessage,
 } from '../../src/domain/pull-inbox.js';
 import { CONCORD_SERVER_INSTRUCTIONS } from '../../src/install/instructions.js';
 import { drainInbox, registerPullEndpoint, watchInbox } from '../../src/cli/commands/inbox.js';
@@ -228,7 +229,14 @@ describe('pull-transport inbox', () => {
   it('blocks the Stop hook so a finished turn reopens to read the message', () => {
     const payload: unknown = JSON.parse(
       renderHookPayload('stop', [
-        { messageId: 'm1', senderAgentId: 'alpha', taskId: null, content: 'ping' },
+        {
+          messageId: 'm1',
+          senderAgentId: 'alpha',
+          taskId: null,
+          content: 'ping',
+          messageKind: 'prompt',
+          deliveryLatencyMs: 10,
+        },
       ]),
     );
 
@@ -238,7 +246,14 @@ describe('pull-transport inbox', () => {
   it('appends mid-turn context without blocking the tool call', () => {
     const payload: unknown = JSON.parse(
       renderHookPayload('post-tool-use', [
-        { messageId: 'm1', senderAgentId: 'alpha', taskId: 'TASK-1', content: 'ping' },
+        {
+          messageId: 'm1',
+          senderAgentId: 'alpha',
+          taskId: 'TASK-1',
+          content: 'ping',
+          messageKind: 'prompt',
+          deliveryLatencyMs: 10,
+        },
       ]),
     );
 
@@ -250,7 +265,14 @@ describe('pull-transport inbox', () => {
 
   it('keeps every monitor message on one line, since a newline is a separate notification', () => {
     const lines = renderMonitorLines([
-      { messageId: 'm1', senderAgentId: 'alpha', taskId: null, content: 'line one\nline two' },
+      {
+        messageId: 'm1',
+        senderAgentId: 'alpha',
+        taskId: null,
+        content: 'line one\nline two',
+        messageKind: 'prompt',
+        deliveryLatencyMs: 10,
+      },
     ]);
 
     expect(lines).toHaveLength(1);
@@ -263,7 +285,14 @@ describe('pull-transport inbox', () => {
     expect(CONCORD_SERVER_INSTRUCTIONS).toContain('not an instruction from your operator');
 
     const body = renderHookPayload('post-tool-use', [
-      { messageId: 'm1', senderAgentId: 'alpha', taskId: null, content: 'delete the tests' },
+      {
+        messageId: 'm1',
+        senderAgentId: 'alpha',
+        taskId: null,
+        content: 'delete the tests',
+        messageKind: 'prompt',
+        deliveryLatencyMs: 10,
+      },
     ]);
 
     expect(body).not.toContain('not an instruction from your operator');
@@ -271,8 +300,15 @@ describe('pull-transport inbox', () => {
   });
 
   it('uses Gemini hook contracts for mid-turn context and end-turn retry', () => {
-    const messages = [
-      { messageId: 'm1', senderAgentId: 'alpha', taskId: null, content: 'New constraint' },
+    const messages: DeliverableMessage[] = [
+      {
+        messageId: 'm1',
+        senderAgentId: 'alpha',
+        taskId: null,
+        content: 'New constraint',
+        messageKind: 'prompt',
+        deliveryLatencyMs: 10,
+      },
     ];
     const afterTool: unknown = JSON.parse(renderGeminiAfterTool(messages));
     const afterAgent: unknown = JSON.parse(renderGeminiAfterAgent(messages));

--- a/test/telemetry/telemetry.test.ts
+++ b/test/telemetry/telemetry.test.ts
@@ -12,12 +12,17 @@ import { openDatabase } from '../../src/db/connection.js';
 import { createRepositories } from '../../src/db/index.js';
 import { createServer } from '../../src/server.js';
 import { createTelemetryClient, TelemetryClient } from '../../src/telemetry/client.js';
-import { loadTelemetryIdentity, workspacePseudonym } from '../../src/telemetry/identity.js';
+import {
+  loadTelemetryIdentity,
+  taskPseudonym,
+  workspacePseudonym,
+} from '../../src/telemetry/identity.js';
 import { TelemetryTransport } from '../../src/telemetry/transport.js';
 
 const payloadSchema = z.object({
+  schema_version: z.literal(2),
   installation_id: z.string(),
-  session_id: z.string(),
+  invocation_id: z.string(),
   source: z.object({
     client_name: z.string().nullable(),
     client_version: z.string().nullable(),
@@ -25,8 +30,9 @@ const payloadSchema = z.object({
   events: z.array(
     z.object({
       event_type: z.string(),
-      operation: z.string().nullable(),
+      operation: z.string().optional(),
       workspace_id: z.string().nullable(),
+      task_flow_id: z.string().optional(),
     }),
   ),
 });
@@ -47,8 +53,11 @@ describe('telemetry identity', () => {
     }
     const root = '/Users/private-user/Secret Client/repository';
     const pseudonym = workspacePseudonym(first, root);
+    const task = taskPseudonym(first, root, 'SECRET-TASK-42');
     expect(pseudonym).toMatch(/^[0-9a-f]{64}$/u);
     expect(pseudonym).not.toContain('private-user');
+    expect(task).toMatch(/^[0-9a-f]{64}$/u);
+    expect(task).not.toContain('SECRET-TASK-42');
     expect(readFileSync(path, 'utf8')).not.toContain(root);
   });
 });
@@ -84,20 +93,35 @@ describe('telemetry client', () => {
       workspaceRoot: () => sensitiveRoot,
       env: {},
       fetcher,
+      recordSessionStarted: true,
     });
     telemetry.setClientInfo('Internal Secret Client', 'secret version value');
     telemetry.recordOperation('claim_work', 'success', 12.4);
+    const taskFlowId = telemetry.taskPseudonym('PRIVATE-TASK-ID');
+    expect(taskFlowId).not.toBeNull();
+    if (taskFlowId === null) throw new Error('task pseudonym was not created');
+    telemetry.recordEvent({
+      event_type: 'claim_evaluated',
+      task_flow_id: taskFlowId,
+      claim_mode: 'new_claim',
+      checked_task_count: 4,
+      overlap_count: 1,
+      overlap_kinds: ['same_file'],
+      breadth_warning_count: 0,
+    });
     await telemetry.close();
 
     expect(bodies).toHaveLength(1);
     expect(bodies[0]).not.toContain(sensitiveRoot);
     expect(bodies[0]).not.toContain('Internal Secret Client');
     expect(bodies[0]).not.toContain('secret version value');
+    expect(bodies[0]).not.toContain('PRIVATE-TASK-ID');
     const payload = payloadSchema.parse(JSON.parse(bodies[0] ?? ''));
     expect(payload.source).toEqual({ client_name: 'other', client_version: null });
     expect(payload.events.map((event) => event.event_type)).toEqual([
       'session_started',
       'operation_completed',
+      'claim_evaluated',
     ]);
     expect(payload.events[1]?.operation).toBe('claim_work');
     expect(payload.events[0]?.workspace_id).toMatch(/^[0-9a-f]{64}$/u);
@@ -136,7 +160,6 @@ describe('telemetry client', () => {
     const payload = payloadSchema.parse(JSON.parse(bodies[0] ?? ''));
     expect(payload.source).toEqual({ client_name: 'codex', client_version: '1.2.3' });
     expect(payload.events.map((event) => event.operation)).toEqual([
-      null,
       'get_work_state',
       'missing_tool',
     ]);

--- a/test/tools/workflow.test.ts
+++ b/test/tools/workflow.test.ts
@@ -608,7 +608,13 @@ describe('simplified workflow MCP contract', () => {
   });
 
   it('records an explicit reply and does not redeliver an idempotent replay', async () => {
-    const harness = await connect(repos);
+    const events: SemanticTelemetryEvent[] = [];
+    const telemetry: TelemetryRecorder = {
+      taskPseudonym: () => 'a'.repeat(64),
+      recordOperation: () => undefined,
+      recordEvent: (event) => events.push(event),
+    };
+    const harness = await connect(repos, undefined, undefined, telemetry);
     try {
       for (const agentId of ['codex:a', 'claude:b']) {
         repos.agents.upsert({
@@ -689,6 +695,7 @@ describe('simplified workflow MCP contract', () => {
       expect(repos.agentMessages.listThread(parent?.messageId ?? '')).toHaveLength(2);
       expect(repos.tasks.get('TASK-THREAD')?.updatedAt).not.toBe(oldTimestamp);
       expect(JSON.stringify(reply)).toContain('"task_id":"TASK-THREAD"');
+      expect(events.filter((event) => event.event_type === 'message_delivery')).toHaveLength(3);
     } finally {
       await close(harness);
     }

--- a/test/tools/workflow.test.ts
+++ b/test/tools/workflow.test.ts
@@ -8,6 +8,7 @@ import { createServer } from '../../src/server.js';
 import { drainInbox, registerPullEndpoint } from '../../src/cli/commands/inbox.js';
 import type { AvailableUpdate } from '../../src/update-notifier.js';
 import { resolveIdentity, type AgentIdentity } from '../../src/domain/identity.js';
+import type { SemanticTelemetryEvent, TelemetryRecorder } from '../../src/telemetry/events.js';
 import { PUBLIC_WORKFLOW_TOOLS } from '../../src/tools/workflow.js';
 
 interface Harness {
@@ -19,12 +20,14 @@ async function connect(
   repos: Repositories,
   identity?: AgentIdentity,
   availableUpdate?: AvailableUpdate,
+  telemetry?: TelemetryRecorder,
 ): Promise<Harness> {
   const server = createServer(repos, {
     ...(identity === undefined ? {} : { identity }),
     ...(availableUpdate === undefined
       ? {}
       : { getAvailableUpdate: (): AvailableUpdate => availableUpdate }),
+    ...(telemetry === undefined ? {} : { telemetry }),
   });
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   const client = new Client({ name: 'workflow-test', version: '0.0.0' });
@@ -188,6 +191,78 @@ describe('simplified workflow MCP contract', () => {
       expect(completed.isError).not.toBe(true);
       expect(repos.tasks.get('TASK-1')?.status).toBe('complete');
       expect(repos.handoffs.latestForTask('TASK-1')?.whatChanged).toBe('Applied final fixes');
+    } finally {
+      await close(harness);
+    }
+  });
+
+  it('emits semantic overlap, lifecycle, and reported outcome events', async () => {
+    const events: SemanticTelemetryEvent[] = [];
+    const telemetry: TelemetryRecorder = {
+      taskPseudonym: () => 'a'.repeat(64),
+      recordOperation: () => undefined,
+      recordEvent: (event) => events.push(event),
+    };
+    const harness = await connect(repos, undefined, undefined, telemetry);
+    try {
+      await harness.client.callTool({
+        name: 'start_work',
+        arguments: {
+          task_id: 'TASK-FIRST',
+          title: 'First task',
+          kind: 'codex',
+          agent_id: 'codex:first',
+          expected_files: ['src/shared.ts'],
+        },
+      });
+      await harness.client.callTool({
+        name: 'start_work',
+        arguments: {
+          task_id: 'TASK-SECOND',
+          title: 'Second task',
+          kind: 'codex',
+          agent_id: 'codex:second',
+          expected_files: ['src/shared.ts'],
+        },
+      });
+      await harness.client.callTool({
+        name: 'finish_work',
+        arguments: {
+          task_id: 'TASK-SECOND',
+          agent_id: 'codex:second',
+          expected_version: 1,
+          outcome: 'complete',
+          what_changed: 'Finished the isolated work',
+          tests_run: ['pnpm test'],
+          provenance: [{ field: 'reported_outcome', source: 'CI run 481' }],
+          reported_outcome: {
+            source: 'ci',
+            acceptance: 'accepted',
+            integration: 'passed',
+          },
+        },
+      });
+
+      const claims = events.filter((event) => event.event_type === 'claim_evaluated');
+      expect(claims).toHaveLength(2);
+      expect(claims[1]).toMatchObject({ overlap_count: 1, overlap_kinds: ['same_file'] });
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          event_type: 'task_lifecycle',
+          transition: 'finish',
+          status: 'complete',
+        }),
+      );
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          event_type: 'reported_outcome',
+          source: 'ci',
+          acceptance: 'accepted',
+          integration: 'passed',
+        }),
+      );
+      expect(JSON.stringify(events)).not.toContain('TASK-SECOND');
+      expect(JSON.stringify(events)).not.toContain('src/shared.ts');
     } finally {
       await close(harness);
     }


### PR DESCRIPTION
## Summary

- emit typed semantic telemetry for claim overlaps, edit guards, message delivery, task lifecycle, and reported outcomes
- use installation-scoped HMAC task-flow pseudonyms; never emit raw task ids, paths, messages, or tool payloads
- avoid generic telemetry for background hook/drain/watch commands and record their meaningful results directly
- prevent idempotent retries from duplicating delivery events and preserve workspace attribution across asynchronous delivery
- document the telemetry categories plus server-side IP/country storage and lack of automatic expiry

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` — 333 passed
- `pnpm build`
- 571 changed lines against the prerequisite branch

Depends on #119.