### PR TITLE
feat: persist reported task outcomes

### DIFF
--- a/src/artifacts/handoff-md.ts
+++ b/src/artifacts/handoff-md.ts
@@ -3,6 +3,7 @@ import { bulletList, codeBulletList } from './markdown.js';
 
 /** Render a human-readable HANDOFF.md for a task and its latest handoff. */
 export function renderHandoffMarkdown(task: TaskRecord, handoff: HandoffRecord): string {
+  const outcome = handoff.reportedOutcome;
   return [
     `# Handoff: ${task.taskId} — ${task.title}`,
     '',
@@ -17,6 +18,18 @@ export function renderHandoffMarkdown(task: TaskRecord, handoff: HandoffRecord):
     '## What changed',
     '',
     handoff.whatChanged,
+    '',
+    '## Reported outcome',
+    '',
+    outcome === null
+      ? '_Not reported_'
+      : [
+          `- Source: ${outcome.source}`,
+          `- Acceptance: ${outcome.acceptance}`,
+          `- Integration: ${outcome.integration}`,
+          `- Human intervention: ${String(outcome.human_intervention_ms ?? 0)} ms`,
+          `- Rework: ${String(outcome.rework_ms ?? 0)} ms`,
+        ].join('\n'),
     '',
     '## Changed files',
     '',

--- a/src/artifacts/review-packet-md.ts
+++ b/src/artifacts/review-packet-md.ts
@@ -8,6 +8,18 @@ function renderProvenance(review: ReviewRecord): string {
   return review.provenance.map((entry) => `- ${entry.field}: ${entry.source}`).join('\n');
 }
 
+function renderReportedOutcome(handoff: HandoffRecord | undefined): string {
+  const outcome = handoff?.reportedOutcome;
+  if (outcome === undefined || outcome === null) return '_Not reported_';
+  return [
+    `- Source: ${outcome.source}`,
+    `- Acceptance: ${outcome.acceptance}`,
+    `- Integration: ${outcome.integration}`,
+    `- Human intervention: ${String(outcome.human_intervention_ms ?? 0)} ms`,
+    `- Rework: ${String(outcome.rework_ms ?? 0)} ms`,
+  ].join('\n');
+}
+
 /**
  * Render a REVIEW_PACKET.md combining the task, its latest review packet, and
  * (when available) its latest handoff for changed files and decisions.
@@ -38,6 +50,10 @@ export function renderReviewPacketMarkdown(
     '## Decisions',
     '',
     bulletList(decisions),
+    '',
+    '## Reported outcome',
+    '',
+    renderReportedOutcome(handoff),
     '',
     '## Tests run',
     '',

--- a/src/db/repositories/handoffs.ts
+++ b/src/db/repositories/handoffs.ts
@@ -7,6 +7,7 @@ import {
   type HandoffDeliveryStatus,
   type HandoffRecord,
 } from '../rows.js';
+import type { ReportedOutcome } from '../../domain/schemas.js';
 
 /** Input for recording a handoff. Array fields default to `[]` at the caller. */
 export interface NewHandoff {
@@ -26,6 +27,7 @@ export interface NewHandoff {
   deliveryStatus?: HandoffDeliveryStatus;
   expiresAt?: string | null;
   taskVersion?: number | null;
+  reportedOutcome?: ReportedOutcome | null;
 }
 
 export interface HandoffRepository {
@@ -49,12 +51,12 @@ export function createHandoffRepository(db: ConcordDatabase): HandoffRepository 
       task_id, status, changed_files, what_changed, tests_run, known_risks,
       assumptions, decisions, guardrails_checked, needs_review_from, next_steps,
       from_agent_id, to_agent_id, delivery_status, expires_at, resolved_at,
-      task_version, resolution_reason, created_at
+      task_version, resolution_reason, reported_outcome, created_at
     ) VALUES (
       @task_id, @status, @changed_files, @what_changed, @tests_run, @known_risks,
       @assumptions, @decisions, @guardrails_checked, @needs_review_from, @next_steps,
       @from_agent_id, @to_agent_id, @delivery_status, @expires_at, @resolved_at,
-      @task_version, @resolution_reason, @created_at
+      @task_version, @resolution_reason, @reported_outcome, @created_at
     )
   `);
   const getByIdStmt = db.prepare('SELECT * FROM handoffs WHERE id = ?');
@@ -103,6 +105,10 @@ export function createHandoffRepository(db: ConcordDatabase): HandoffRepository 
         resolved_at: null,
         task_version: handoff.taskVersion ?? null,
         resolution_reason: null,
+        reported_outcome:
+          handoff.reportedOutcome === undefined || handoff.reportedOutcome === null
+            ? null
+            : JSON.stringify(handoff.reportedOutcome),
         created_at: new Date().toISOString(),
       });
       const raw: unknown = getByIdStmt.get(info.lastInsertRowid);

--- a/src/db/repositories/handoffs.ts
+++ b/src/db/repositories/handoffs.ts
@@ -6,8 +6,8 @@ import {
   serializeStringArray,
   type HandoffDeliveryStatus,
   type HandoffRecord,
+  type ReportedOutcome,
 } from '../rows.js';
-import type { ReportedOutcome } from '../../domain/schemas.js';
 
 /** Input for recording a handoff. Array fields default to `[]` at the caller. */
 export interface NewHandoff {

--- a/src/db/repositories/handoffs.ts
+++ b/src/db/repositories/handoffs.ts
@@ -6,7 +6,7 @@ import {
   serializeStringArray,
   type HandoffDeliveryStatus,
   type HandoffRecord,
-  type ReportedOutcome,
+  type ReportedOutcomeRecord,
 } from '../rows.js';
 
 /** Input for recording a handoff. Array fields default to `[]` at the caller. */
@@ -27,7 +27,7 @@ export interface NewHandoff {
   deliveryStatus?: HandoffDeliveryStatus;
   expiresAt?: string | null;
   taskVersion?: number | null;
-  reportedOutcome?: ReportedOutcome | null;
+  reportedOutcome?: ReportedOutcomeRecord | null;
 }
 
 export interface HandoffRepository {

--- a/src/db/rows.ts
+++ b/src/db/rows.ts
@@ -66,7 +66,7 @@ export interface ProvenanceEntry {
 
 const provenanceSchema = z.array(z.object({ field: z.string(), source: z.string() }));
 
-export const reportedOutcomeSchema = z
+const reportedOutcomeDbSchema = z
   .object({
     source: z.enum(['agent', 'ci', 'review', 'human']),
     acceptance: z.enum(['accepted', 'rejected', 'not_checked']).default('not_checked'),
@@ -83,12 +83,12 @@ export const reportedOutcomeSchema = z
       value.rework_ms !== undefined,
     { message: 'reported_outcome must contain at least one measured result' },
   );
-export type ReportedOutcome = z.infer<typeof reportedOutcomeSchema>;
+export type ReportedOutcomeRecord = z.infer<typeof reportedOutcomeDbSchema>;
 
-function parseReportedOutcome(value: string | null): ReportedOutcome | null {
+function parseReportedOutcome(value: string | null): ReportedOutcomeRecord | null {
   if (value === null) return null;
   const parsed: unknown = JSON.parse(value);
-  return reportedOutcomeSchema.parse(parsed);
+  return reportedOutcomeDbSchema.parse(parsed);
 }
 
 /** Parse a JSON-encoded TEXT column into validated provenance entries. */
@@ -248,7 +248,7 @@ export interface HandoffRecord {
   resolvedAt: string | null;
   taskVersion: number | null;
   resolutionReason: string | null;
-  reportedOutcome: ReportedOutcome | null;
+  reportedOutcome: ReportedOutcomeRecord | null;
   createdAt: string;
 }
 

--- a/src/db/rows.ts
+++ b/src/db/rows.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { reportedOutcomeSchema, type ReportedOutcome } from '../domain/schemas.js';
+
 /**
  * Row parsing lives here so the "never typecast" rule holds across the db layer:
  * every raw better-sqlite3 result enters as `unknown` and is narrowed by a Zod
@@ -65,6 +67,12 @@ export interface ProvenanceEntry {
 }
 
 const provenanceSchema = z.array(z.object({ field: z.string(), source: z.string() }));
+
+function parseReportedOutcome(value: string | null): ReportedOutcome | null {
+  if (value === null) return null;
+  const parsed: unknown = JSON.parse(value);
+  return reportedOutcomeSchema.parse(parsed);
+}
 
 /** Parse a JSON-encoded TEXT column into validated provenance entries. */
 export function parseProvenance(json: string): ProvenanceEntry[] {
@@ -223,6 +231,7 @@ export interface HandoffRecord {
   resolvedAt: string | null;
   taskVersion: number | null;
   resolutionReason: string | null;
+  reportedOutcome: ReportedOutcome | null;
   createdAt: string;
 }
 
@@ -256,6 +265,7 @@ const handoffDbRowSchema = z.object({
   resolved_at: z.string().nullable(),
   task_version: z.number().int().nullable(),
   resolution_reason: z.string().nullable(),
+  reported_outcome: z.string().nullable(),
   created_at: z.string(),
 });
 
@@ -281,6 +291,7 @@ export function parseHandoffRow(raw: unknown): HandoffRecord {
     resolvedAt: row.resolved_at,
     taskVersion: row.task_version,
     resolutionReason: row.resolution_reason,
+    reportedOutcome: parseReportedOutcome(row.reported_outcome),
     createdAt: row.created_at,
   };
 }

--- a/src/db/rows.ts
+++ b/src/db/rows.ts
@@ -1,7 +1,5 @@
 import { z } from 'zod';
 
-import { reportedOutcomeSchema, type ReportedOutcome } from '../domain/schemas.js';
-
 /**
  * Row parsing lives here so the "never typecast" rule holds across the db layer:
  * every raw better-sqlite3 result enters as `unknown` and is narrowed by a Zod
@@ -67,6 +65,25 @@ export interface ProvenanceEntry {
 }
 
 const provenanceSchema = z.array(z.object({ field: z.string(), source: z.string() }));
+
+export const reportedOutcomeSchema = z
+  .object({
+    source: z.enum(['agent', 'ci', 'review', 'human']),
+    acceptance: z.enum(['accepted', 'rejected', 'not_checked']).default('not_checked'),
+    integration: z.enum(['passed', 'failed', 'not_checked']).default('not_checked'),
+    human_intervention_ms: z.number().int().min(0).max(604_800_000).optional(),
+    rework_ms: z.number().int().min(0).max(604_800_000).optional(),
+  })
+  .strict()
+  .refine(
+    (value) =>
+      value.acceptance !== 'not_checked' ||
+      value.integration !== 'not_checked' ||
+      value.human_intervention_ms !== undefined ||
+      value.rework_ms !== undefined,
+    { message: 'reported_outcome must contain at least one measured result' },
+  );
+export type ReportedOutcome = z.infer<typeof reportedOutcomeSchema>;
 
 function parseReportedOutcome(value: string | null): ReportedOutcome | null {
   if (value === null) return null;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -220,4 +220,8 @@ export const migrations: readonly string[] = [
   `
   ALTER TABLE agent_endpoints ADD COLUMN receiver_expires_at TEXT;
   `,
+  // 010 — optional, structured outcome evidence attached to a finish/handoff.
+  `
+  ALTER TABLE handoffs ADD COLUMN reported_outcome TEXT;
+  `,
 ];

--- a/src/domain/operations.ts
+++ b/src/domain/operations.ts
@@ -58,6 +58,7 @@ type FinishEvidenceInput = Pick<
   | 'diff_size'
   | 'open_questions'
   | 'provenance'
+  | 'reported_outcome'
 >;
 
 export type HandoffInput = FinishEvidenceInput & {

--- a/src/domain/schemas.ts
+++ b/src/domain/schemas.ts
@@ -1,7 +1,5 @@
 import { z } from 'zod';
 
-import { reportedOutcomeSchema } from '../db/rows.js';
-
 /**
  * The five public MCP workflow contracts. Internal lifecycle operations derive
  * their TypeScript inputs from these shapes in operations.ts; they are not
@@ -78,6 +76,23 @@ const provenanceField = z
   .optional()
   .describe('Evidence source for review claims');
 
+export const reportedOutcomeSchema = z
+  .object({
+    source: z.enum(['agent', 'ci', 'review', 'human']),
+    acceptance: z.enum(['accepted', 'rejected', 'not_checked']).default('not_checked'),
+    integration: z.enum(['passed', 'failed', 'not_checked']).default('not_checked'),
+    human_intervention_ms: z.number().int().min(0).max(604_800_000).optional(),
+    rework_ms: z.number().int().min(0).max(604_800_000).optional(),
+  })
+  .strict()
+  .refine(
+    (value) =>
+      value.acceptance !== 'not_checked' ||
+      value.integration !== 'not_checked' ||
+      value.human_intervention_ms !== undefined ||
+      value.rework_ms !== undefined,
+    { message: 'reported_outcome must contain at least one measured result' },
+  );
 export type ReportedOutcome = z.infer<typeof reportedOutcomeSchema>;
 
 export const startWorkInputShape = {

--- a/src/domain/schemas.ts
+++ b/src/domain/schemas.ts
@@ -76,6 +76,25 @@ const provenanceField = z
   .optional()
   .describe('Evidence source for review claims');
 
+export const reportedOutcomeSchema = z
+  .object({
+    source: z.enum(['agent', 'ci', 'review', 'human']),
+    acceptance: z.enum(['accepted', 'rejected', 'not_checked']).default('not_checked'),
+    integration: z.enum(['passed', 'failed', 'not_checked']).default('not_checked'),
+    human_intervention_ms: z.number().int().min(0).max(604_800_000).optional(),
+    rework_ms: z.number().int().min(0).max(604_800_000).optional(),
+  })
+  .strict()
+  .refine(
+    (value) =>
+      value.acceptance !== 'not_checked' ||
+      value.integration !== 'not_checked' ||
+      value.human_intervention_ms !== undefined ||
+      value.rework_ms !== undefined,
+    { message: 'reported_outcome must contain at least one measured result' },
+  );
+export type ReportedOutcome = z.infer<typeof reportedOutcomeSchema>;
+
 export const startWorkInputShape = {
   task_id: taskIdField,
   title: claimMetadataField('Short human-readable title').min(1),
@@ -196,6 +215,9 @@ export const finishWorkInputShape = {
   diff_size: z.string().optional().describe('Rough diff size, e.g. +120 / -30'),
   open_questions: z.array(z.string()).optional().describe('Unresolved review questions'),
   provenance: provenanceField,
+  reported_outcome: reportedOutcomeSchema
+    .optional()
+    .describe('Optional measured acceptance, integration, or intervention result'),
   reason: z
     .string()
     .min(1)

--- a/src/domain/schemas.ts
+++ b/src/domain/schemas.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { reportedOutcomeSchema } from '../db/rows.js';
+
 /**
  * The five public MCP workflow contracts. Internal lifecycle operations derive
  * their TypeScript inputs from these shapes in operations.ts; they are not
@@ -76,23 +78,6 @@ const provenanceField = z
   .optional()
   .describe('Evidence source for review claims');
 
-export const reportedOutcomeSchema = z
-  .object({
-    source: z.enum(['agent', 'ci', 'review', 'human']),
-    acceptance: z.enum(['accepted', 'rejected', 'not_checked']).default('not_checked'),
-    integration: z.enum(['passed', 'failed', 'not_checked']).default('not_checked'),
-    human_intervention_ms: z.number().int().min(0).max(604_800_000).optional(),
-    rework_ms: z.number().int().min(0).max(604_800_000).optional(),
-  })
-  .strict()
-  .refine(
-    (value) =>
-      value.acceptance !== 'not_checked' ||
-      value.integration !== 'not_checked' ||
-      value.human_intervention_ms !== undefined ||
-      value.rework_ms !== undefined,
-    { message: 'reported_outcome must contain at least one measured result' },
-  );
 export type ReportedOutcome = z.infer<typeof reportedOutcomeSchema>;
 
 export const startWorkInputShape = {

--- a/src/tools/handoff.ts
+++ b/src/tools/handoff.ts
@@ -40,6 +40,9 @@ export function handleHandoff(repos: Repositories, input: HandoffInput): Handoff
       `Task ${input.task_id} version conflict: expected ${String(input.expected_version)}, current ${String(existing.version)}.`,
     );
   }
+  if (input.reported_outcome !== undefined && (input.provenance?.length ?? 0) === 0) {
+    throw new Error('provenance is required when reported_outcome is supplied.');
+  }
 
   const reviewReady = input.ready_for_review === true;
   const transact = repos.db.transaction(() => {
@@ -55,6 +58,7 @@ export function handleHandoff(repos: Repositories, input: HandoffInput): Handoff
       guardrailsChecked: input.guardrails_checked ?? [],
       needsReviewFrom: input.needs_review_from ?? [],
       nextSteps: input.next_steps ?? [],
+      reportedOutcome: input.reported_outcome ?? null,
     });
     repos.events.record({
       taskId: input.task_id,

--- a/src/tools/handoff.ts
+++ b/src/tools/handoff.ts
@@ -40,8 +40,11 @@ export function handleHandoff(repos: Repositories, input: HandoffInput): Handoff
       `Task ${input.task_id} version conflict: expected ${String(input.expected_version)}, current ${String(existing.version)}.`,
     );
   }
-  if (input.reported_outcome !== undefined && (input.provenance?.length ?? 0) === 0) {
-    throw new Error('provenance is required when reported_outcome is supplied.');
+  if (
+    input.reported_outcome !== undefined &&
+    !input.provenance?.some((entry) => entry.field === 'reported_outcome')
+  ) {
+    throw new Error('reported_outcome provenance is required when reported_outcome is supplied.');
   }
 
   const reviewReady = input.ready_for_review === true;

--- a/src/tools/workflow.ts
+++ b/src/tools/workflow.ts
@@ -385,6 +385,7 @@ export function handleFinishWork(
       diff_size: input.diff_size,
       open_questions: input.open_questions,
       provenance: input.provenance,
+      reported_outcome: input.reported_outcome,
       agent_id: input.agent_id,
       expected_version: input.expected_version,
     });

--- a/test/artifacts/artifacts.test.ts
+++ b/test/artifacts/artifacts.test.ts
@@ -28,6 +28,12 @@ describe('renderReviewPacketMarkdown', () => {
       what_changed: 'x',
       changed_files: ['src/billing/retry.ts'],
       decisions: ['use a queue'],
+      reported_outcome: {
+        source: 'review',
+        acceptance: 'accepted',
+        integration: 'passed',
+      },
+      provenance: [{ field: 'reported_outcome', source: 'review result' }],
     });
     const { review } = handleReviewReady(repos, {
       task_id: 'TASK-12',
@@ -42,6 +48,8 @@ describe('renderReviewPacketMarkdown', () => {
     expect(md).toContain('# Review Packet: TASK-12 — Retry');
     expect(md).toContain('- `src/billing/retry.ts`');
     expect(md).toContain('- use a queue');
+    expect(md).toContain('## Reported outcome');
+    expect(md).toContain('- Integration: passed');
     expect(md).toContain('- plan: agent reported');
   });
 });

--- a/test/cli/cli-commands.test.ts
+++ b/test/cli/cli-commands.test.ts
@@ -84,7 +84,7 @@ describe('CLI read/export commands', () => {
 
   it('doctor reports schema version and adoption', () => {
     const report = runDoctor(dir);
-    expect(report).toContain('schema v9, expected v9');
+    expect(report).toContain('schema v10, expected v10');
     expect(report).toContain('TASK-12');
     expect(report).toContain('start_work: yes');
     // The resolved workspace path is surfaced so agents don't have to hunt for it.

--- a/test/db/connection.test.ts
+++ b/test/db/connection.test.ts
@@ -13,7 +13,7 @@ describe('openDatabase', () => {
   it('applies all migrations (user_version at head) and creates tables', () => {
     const db = openDatabase(':memory:');
     const version: unknown = db.pragma('user_version', { simple: true });
-    expect(version).toBe(9);
+    expect(version).toBe(10);
 
     const raw: unknown = db.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all();
     const names = new Set(
@@ -73,7 +73,7 @@ describe('openDatabase', () => {
     const task = parseTaskRow(
       upgraded.prepare('SELECT * FROM tasks WHERE task_id = ?').get('LEGACY'),
     );
-    expect(upgraded.pragma('user_version', { simple: true })).toBe(9);
+    expect(upgraded.pragma('user_version', { simple: true })).toBe(10);
     expect(task.status).toBe('handed_off');
     expect(task.agentId).toBe('codex:old');
     expect(task.version).toBe(1);

--- a/test/db/storage.test.ts
+++ b/test/db/storage.test.ts
@@ -62,7 +62,7 @@ describe('migrations', () => {
   it('is idempotent when reopening (user_version already at head)', () => {
     const { db } = newRepos();
     const version: unknown = db.pragma('user_version', { simple: true });
-    expect(version).toBe(9);
+    expect(version).toBe(10);
   });
 });
 

--- a/test/tools/handoff.test.ts
+++ b/test/tools/handoff.test.ts
@@ -102,6 +102,23 @@ describe('handleHandoff', () => {
     ).toThrow(/provenance is required/u);
   });
 
+  it('rejects an outcome with provenance for another field', () => {
+    handleClaimWork(repos, { task_id: 'TASK-WRONG-SOURCE', title: 'Wrong source' });
+    expect(() =>
+      handleHandoff(repos, {
+        task_id: 'TASK-WRONG-SOURCE',
+        status: 'done',
+        what_changed: 'x',
+        reported_outcome: {
+          source: 'agent',
+          acceptance: 'accepted',
+          integration: 'not_checked',
+        },
+        provenance: [{ field: 'tests_run', source: 'pnpm test' }],
+      }),
+    ).toThrow(/reported_outcome provenance is required/u);
+  });
+
   it('produces a review packet when ready_for_review is set (folded review_ready)', () => {
     handleClaimWork(repos, { task_id: 'TASK-12', title: 'Retry', modules: ['billing'] });
     const result = handleHandoff(repos, {

--- a/test/tools/handoff.test.ts
+++ b/test/tools/handoff.test.ts
@@ -58,6 +58,50 @@ describe('handleHandoff', () => {
     expect(result.handoff.needsReviewFrom).toEqual(['alex', 'sam']);
   });
 
+  it('persists a provenance-backed reported outcome', () => {
+    handleClaimWork(repos, { task_id: 'TASK-OUTCOME', title: 'Outcome evidence' });
+    const result = handleHandoff(repos, {
+      task_id: 'TASK-OUTCOME',
+      status: 'done',
+      what_changed: 'Implemented and verified the change',
+      reported_outcome: {
+        source: 'ci',
+        acceptance: 'accepted',
+        integration: 'passed',
+        human_intervention_ms: 1200,
+        rework_ms: 300,
+      },
+      provenance: [{ field: 'reported_outcome', source: 'CI run 481' }],
+    });
+
+    expect(result.handoff.reportedOutcome).toEqual({
+      source: 'ci',
+      acceptance: 'accepted',
+      integration: 'passed',
+      human_intervention_ms: 1200,
+      rework_ms: 300,
+    });
+    expect(repos.handoffs.latestForTask('TASK-OUTCOME')?.reportedOutcome).toEqual(
+      result.handoff.reportedOutcome,
+    );
+  });
+
+  it('rejects an outcome without provenance', () => {
+    handleClaimWork(repos, { task_id: 'TASK-NO-SOURCE', title: 'No source' });
+    expect(() =>
+      handleHandoff(repos, {
+        task_id: 'TASK-NO-SOURCE',
+        status: 'done',
+        what_changed: 'x',
+        reported_outcome: {
+          source: 'agent',
+          acceptance: 'accepted',
+          integration: 'not_checked',
+        },
+      }),
+    ).toThrow(/provenance is required/u);
+  });
+
   it('produces a review packet when ready_for_review is set (folded review_ready)', () => {
     handleClaimWork(repos, { task_id: 'TASK-12', title: 'Retry', modules: ['billing'] });
     const result = handleHandoff(repos, {


### PR DESCRIPTION
## Summary

- add an optional, source-labelled reported outcome to `finish_work`
- persist measured acceptance, integration, intervention, and rework results with handoffs
- require provenance specifically bound to each reported outcome
- render reported outcomes in local handoff and review artifacts
- keep domain and persistence validation independent at their respective boundaries

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` — 333 passed
- `pnpm build`