### PR TITLE
perf: reduce redundant overlap/status work

### DIFF
--- a/src/artifacts/work-state-view.ts
+++ b/src/artifacts/work-state-view.ts
@@ -75,6 +75,10 @@ function touchesOf(task: TaskRecord): string {
 
 export function buildStatus(repos: Repositories, now: number = Date.now()): StatusView {
   const tasks = repos.tasks.list();
+  const agents = repos.agents.list();
+  const endpointsByAgent = new Map(
+    repos.agentEndpoints.list().map((endpoint) => [endpoint.agentId, endpoint] as const),
+  );
   const activeStatuses = new Set(['assigned', 'active', 'blocked', 'handoff_offered']);
   const active = tasks.filter((task) => activeStatuses.has(task.status));
 
@@ -93,7 +97,8 @@ export function buildStatus(repos: Repositories, now: number = Date.now()): Stat
         riskTags: task.riskTags,
         parentTaskId: task.parentTaskId,
       },
-      active.slice(index + 1),
+      active,
+      index + 1,
     )) {
       overlaps.push({ a: task.taskId, b: warning.taskId, reasons: warning.reasons });
     }
@@ -133,10 +138,10 @@ export function buildStatus(repos: Repositories, now: number = Date.now()): Stat
     overlaps,
     reviewReady,
     openQuestions,
-    presence: buildRoster(repos.agents.list(), now),
-    staleClaims: detectStaleClaims(tasks, repos.agents.list(), now),
-    communications: repos.agents.list().map((agent) => {
-      const endpoint = repos.agentEndpoints.getByAgent(agent.agentId);
+    presence: buildRoster(agents, now),
+    staleClaims: detectStaleClaims(tasks, agents, now),
+    communications: agents.map((agent) => {
+      const endpoint = endpointsByAgent.get(agent.agentId);
       return {
         agentId: agent.agentId,
         promptable: endpointPromptable(endpoint, now),

--- a/src/artifacts/work-state-view.ts
+++ b/src/artifacts/work-state-view.ts
@@ -79,8 +79,11 @@ export function buildStatus(repos: Repositories, now: number = Date.now()): Stat
   const active = tasks.filter((task) => activeStatuses.has(task.status));
 
   const overlaps: OverlapPair[] = [];
-  const seenPairs = new Set<string>();
-  for (const task of active) {
+  // Overlap is symmetric. Scan only the upper triangle so every task pair is
+  // evaluated once instead of A->B and B->A, and no deduplication set is needed.
+  for (let index = 0; index < active.length; index += 1) {
+    const task = active[index];
+    if (task === undefined) continue;
     for (const warning of detectOverlaps(
       {
         taskId: task.taskId,
@@ -90,13 +93,9 @@ export function buildStatus(repos: Repositories, now: number = Date.now()): Stat
         riskTags: task.riskTags,
         parentTaskId: task.parentTaskId,
       },
-      active,
+      active.slice(index + 1),
     )) {
-      const key = [task.taskId, warning.taskId].sort((x, y) => x.localeCompare(y)).join('::');
-      if (!seenPairs.has(key)) {
-        seenPairs.add(key);
-        overlaps.push({ a: task.taskId, b: warning.taskId, reasons: warning.reasons });
-      }
+      overlaps.push({ a: task.taskId, b: warning.taskId, reasons: warning.reasons });
     }
   }
 

--- a/src/domain/overlap.ts
+++ b/src/domain/overlap.ts
@@ -148,10 +148,12 @@ function detailsFor(
 export function detectOverlaps(
   candidate: OverlapSurface,
   existing: readonly TaskRecord[],
+  startIndex = 0,
 ): OverlapWarning[] {
   const warnings: OverlapWarning[] = [];
-  for (const task of existing) {
-    if (task.taskId === candidate.taskId || isParentChild(candidate, task)) {
+  for (let index = startIndex; index < existing.length; index += 1) {
+    const task = existing[index];
+    if (task === undefined || task.taskId === candidate.taskId || isParentChild(candidate, task)) {
       continue;
     }
     const { reasons, kinds } = detailsFor(candidate, surfaceOf(task));

--- a/test/domain/overlap.test.ts
+++ b/test/domain/overlap.test.ts
@@ -161,4 +161,17 @@ describe('detectOverlaps', () => {
       1,
     );
   });
+
+  it('skips an existing-task prefix when an offset is provided', () => {
+    const existing = [
+      task({ taskId: 'TASK-B', modules: ['billing'] }),
+      task({ taskId: 'TASK-C', domains: ['payments'] }),
+      task({ taskId: 'TASK-E', modules: ['signup'] }),
+    ];
+
+    const warnings = detectOverlaps(candidate, existing, 1);
+
+    expect(warnings.map((warning) => warning.taskId)).toEqual(['TASK-C']);
+    expect(warnings[0]?.reasons).toContain('shared domain(s): payments');
+  });
 });


### PR DESCRIPTION
## What & why

Reduce redundant work in the workspace status hot path without changing overlap semantics.

The status builder previously evaluated symmetric task pairs twice (`A→B` and `B→A`) and deduplicated them afterwards. This PR scans only the upper triangle, so each active-task pair is evaluated once.

Follow-up commits also:

- avoid allocating `active.slice(...)` arrays during the overlap scan by adding a `startIndex` offset to `detectOverlaps`;
- reuse a single agent list when building status;
- batch endpoint retrieval with one `agentEndpoints.list()` call instead of one endpoint lookup per agent;
- add a regression test for offset-based overlap scanning.

For `N` active tasks, detailed pair evaluation drops from approximately:

`N(N - 1)`

to:

`N(N - 1) / 2`

before the additional allocation/query reductions.

## Checklist

- [x] Follows the coding rules in CLAUDE.md (no `any`, no forbidden typecasts, layered modules)
- [x] The change is focused and reviewable
- [x] Added/updated tests for behaviour changes
- [ ] `pnpm lint && pnpm typecheck && pnpm test && pnpm build` passes locally
- [x] Checked for existing utilities/types before adding new ones

## Validation

- Greptile review on HEAD `b97e7d2`: **5/5 confidence**, no actionable correctness or security issues identified.
- Upstream GitHub Actions workflow is currently awaiting maintainer approval, so the local-command checkbox is intentionally left unchecked until an actual runner executes it.

## Notes for reviewers

This is intentionally a small performance patch with no intended behavioural change. The next optimization opportunity would be precomputing normalized overlap surfaces so path normalization/tokenization is not repeated for every task pair.