### PR TITLE
perf(status): avoid historical task scans and review N+1

### DIFF
--- a/src/artifacts/work-state-view.ts
+++ b/src/artifacts/work-state-view.ts
@@ -67,8 +67,16 @@ export interface StatusView {
   communications: CommunicationEntry[];
 }
 
-const ACTIVE_STATUSES = ['assigned', 'active', 'blocked', 'handoff_offered'] as const satisfies readonly TaskStatus[];
-const STATUS_VIEW_STATUSES = [...ACTIVE_STATUSES, 'review_ready'] as const satisfies readonly TaskStatus[];
+const ACTIVE_STATUSES = [
+  'assigned',
+  'active',
+  'blocked',
+  'handoff_offered',
+] as const satisfies readonly TaskStatus[];
+const STATUS_VIEW_STATUSES = [
+  ...ACTIVE_STATUSES,
+  'review_ready',
+] as const satisfies readonly TaskStatus[];
 
 function touchesOf(task: TaskRecord): string {
   const values = task.modules.length > 0 ? task.modules : task.expectedFiles.map((f) => dirname(f));
@@ -111,7 +119,9 @@ export function buildStatus(repos: Repositories, now: number = Date.now()): Stat
 
   const reviewTasks = tasks.filter((task) => task.status === 'review_ready');
   const latestReviews = new Map(
-    repos.reviews.latestForTasks(reviewTasks.map((task) => task.taskId)).map((review) => [review.taskId, review] as const),
+    repos.reviews
+      .latestForTasks(reviewTasks.map((task) => task.taskId))
+      .map((review) => [review.taskId, review] as const),
   );
   const reviewReady: ReviewEntry[] = [];
   const openQuestions: OpenQuestionEntry[] = [];

--- a/src/artifacts/work-state-view.ts
+++ b/src/artifacts/work-state-view.ts
@@ -1,6 +1,6 @@
 import { dirname } from 'node:path';
 
-import type { Repositories, TaskRecord } from '../db/index.js';
+import type { Repositories, TaskRecord, TaskStatus } from '../db/index.js';
 import { effectiveEndpointCapabilities } from '../domain/delivery.js';
 import { detectOverlaps } from '../domain/overlap.js';
 import { endpointPromptable } from '../tools/agent-messages.js';
@@ -67,6 +67,9 @@ export interface StatusView {
   communications: CommunicationEntry[];
 }
 
+const ACTIVE_STATUSES = ['assigned', 'active', 'blocked', 'handoff_offered'] as const satisfies readonly TaskStatus[];
+const STATUS_VIEW_STATUSES = [...ACTIVE_STATUSES, 'review_ready'] as const satisfies readonly TaskStatus[];
+
 function touchesOf(task: TaskRecord): string {
   const values = task.modules.length > 0 ? task.modules : task.expectedFiles.map((f) => dirname(f));
   const unique = [...new Set(values.filter((v) => v !== '.' && v !== ''))];
@@ -74,12 +77,14 @@ function touchesOf(task: TaskRecord): string {
 }
 
 export function buildStatus(repos: Repositories, now: number = Date.now()): StatusView {
-  const tasks = repos.tasks.list();
+  // Status only renders active/review-ready tasks. Keep historical completed/closed
+  // rows out of the hot path so long-lived workspaces do not pay to parse them.
+  const tasks = repos.tasks.listByStatuses(STATUS_VIEW_STATUSES);
   const agents = repos.agents.list();
   const endpointsByAgent = new Map(
     repos.agentEndpoints.list().map((endpoint) => [endpoint.agentId, endpoint] as const),
   );
-  const activeStatuses = new Set(['assigned', 'active', 'blocked', 'handoff_offered']);
+  const activeStatuses = new Set<TaskStatus>(ACTIVE_STATUSES);
   const active = tasks.filter((task) => activeStatuses.has(task.status));
 
   const overlaps: OverlapPair[] = [];
@@ -104,10 +109,14 @@ export function buildStatus(repos: Repositories, now: number = Date.now()): Stat
     }
   }
 
+  const reviewTasks = tasks.filter((task) => task.status === 'review_ready');
+  const latestReviews = new Map(
+    repos.reviews.latestForTasks(reviewTasks.map((task) => task.taskId)).map((review) => [review.taskId, review] as const),
+  );
   const reviewReady: ReviewEntry[] = [];
   const openQuestions: OpenQuestionEntry[] = [];
-  for (const task of tasks.filter((t) => t.status === 'review_ready')) {
-    const review = repos.reviews.latestForTask(task.taskId);
+  for (const task of reviewTasks) {
+    const review = latestReviews.get(task.taskId);
     if (review === undefined) {
       continue;
     }
@@ -139,7 +148,7 @@ export function buildStatus(repos: Repositories, now: number = Date.now()): Stat
     reviewReady,
     openQuestions,
     presence: buildRoster(agents, now),
-    staleClaims: detectStaleClaims(tasks, agents, now),
+    staleClaims: detectStaleClaims(active, agents, now),
     communications: agents.map((agent) => {
       const endpoint = endpointsByAgent.get(agent.agentId);
       return {

--- a/src/db/repositories/reviews.ts
+++ b/src/db/repositories/reviews.ts
@@ -29,6 +29,7 @@ export interface ReviewRepository {
 }
 
 const rawListSchema = z.array(z.unknown());
+const REVIEW_QUERY_CHUNK_SIZE = 500;
 
 export function createReviewRepository(db: ConcordDatabase): ReviewRepository {
   const insertStmt = db.prepare(`
@@ -80,21 +81,28 @@ export function createReviewRepository(db: ConcordDatabase): ReviewRepository {
     },
     latestForTasks(taskIds) {
       if (taskIds.length === 0) return [];
-      const placeholders = taskIds.map(() => '?').join(', ');
-      const raw: unknown = db
-        .prepare(
-          `SELECT r.*
-           FROM reviews r
-           JOIN (
-             SELECT task_id, MAX(id) AS id
-             FROM reviews
-             WHERE task_id IN (${placeholders})
-             GROUP BY task_id
-           ) latest ON latest.id = r.id
-           ORDER BY r.task_id ASC`,
-        )
-        .all(...taskIds);
-      return rawListSchema.parse(raw).map(parseReviewRow);
+      const uniqueTaskIds = [...new Set(taskIds)];
+      const reviews: ReviewRecord[] = [];
+
+      for (let offset = 0; offset < uniqueTaskIds.length; offset += REVIEW_QUERY_CHUNK_SIZE) {
+        const chunk = uniqueTaskIds.slice(offset, offset + REVIEW_QUERY_CHUNK_SIZE);
+        const placeholders = chunk.map(() => '?').join(', ');
+        const raw: unknown = db
+          .prepare(
+            `SELECT r.*
+             FROM reviews r
+             JOIN (
+               SELECT task_id, MAX(id) AS id
+               FROM reviews
+               WHERE task_id IN (${placeholders})
+               GROUP BY task_id
+             ) latest ON latest.id = r.id`,
+          )
+          .all(...chunk);
+        reviews.push(...rawListSchema.parse(raw).map(parseReviewRow));
+      }
+
+      return reviews.sort((a, b) => a.taskId.localeCompare(b.taskId));
     },
   };
 }

--- a/src/db/repositories/reviews.ts
+++ b/src/db/repositories/reviews.ts
@@ -25,6 +25,7 @@ export interface ReviewRepository {
   create(review: NewReview): ReviewRecord;
   listByTask(taskId: string): ReviewRecord[];
   latestForTask(taskId: string): ReviewRecord | undefined;
+  latestForTasks(taskIds: readonly string[]): ReviewRecord[];
 }
 
 const rawListSchema = z.array(z.unknown());
@@ -76,6 +77,24 @@ export function createReviewRepository(db: ConcordDatabase): ReviewRepository {
         return undefined;
       }
       return parseReviewRow(raw);
+    },
+    latestForTasks(taskIds) {
+      if (taskIds.length === 0) return [];
+      const placeholders = taskIds.map(() => '?').join(', ');
+      const raw: unknown = db
+        .prepare(
+          `SELECT r.*
+           FROM reviews r
+           JOIN (
+             SELECT task_id, MAX(id) AS id
+             FROM reviews
+             WHERE task_id IN (${placeholders})
+             GROUP BY task_id
+           ) latest ON latest.id = r.id
+           ORDER BY r.task_id ASC`,
+        )
+        .all(...taskIds);
+      return rawListSchema.parse(raw).map(parseReviewRow);
     },
   };
 }

--- a/src/db/repositories/tasks.ts
+++ b/src/db/repositories/tasks.ts
@@ -36,6 +36,7 @@ export interface TaskRepository {
   create(task: NewTask): TaskRecord;
   get(taskId: string): TaskRecord | undefined;
   list(): TaskRecord[];
+  listByStatuses(statuses: readonly TaskStatus[]): TaskRecord[];
   touchActivity(taskId: string): TaskRecord | undefined;
   updateStatus(taskId: string, status: TaskStatus): TaskRecord | undefined;
   updateScope(taskId: string, scope: TaskScope): TaskRecord | undefined;
@@ -135,6 +136,16 @@ export function createTaskRepository(db: ConcordDatabase): TaskRepository {
     get,
     list() {
       const raw: unknown = listStmt.all();
+      return rawListSchema.parse(raw).map(parseTaskRow);
+    },
+    listByStatuses(statuses) {
+      if (statuses.length === 0) return [];
+      const placeholders = statuses.map(() => '?').join(', ');
+      const raw: unknown = db
+        .prepare(
+          `SELECT * FROM tasks WHERE status IN (${placeholders}) ORDER BY created_at ASC, task_id ASC`,
+        )
+        .all(...statuses);
       return rawListSchema.parse(raw).map(parseTaskRow);
     },
     touchActivity(taskId) {

--- a/test/db/status-query-scaling.test.ts
+++ b/test/db/status-query-scaling.test.ts
@@ -9,10 +9,10 @@ const baseTask = {
   agent: 'codex',
   branch: null,
   worktree: null,
-  expectedFiles: [] as string[],
-  modules: [] as string[],
-  domains: [] as string[],
-  riskTags: [] as string[],
+  expectedFiles: [],
+  modules: [],
+  domains: [],
+  riskTags: [],
   notes: null,
   parentTaskId: null,
   agentId: null,
@@ -20,11 +20,11 @@ const baseTask = {
 
 const baseReview = {
   planSummary: 'plan',
-  testsRun: [] as string[],
+  testsRun: [],
   diffSize: null,
-  guardrailsChecked: [] as string[],
-  assumptions: [] as string[],
-  openQuestions: [] as string[],
+  guardrailsChecked: [],
+  assumptions: [],
+  openQuestions: [],
   provenance: [],
 };
 

--- a/test/db/status-query-scaling.test.ts
+++ b/test/db/status-query-scaling.test.ts
@@ -35,10 +35,9 @@ describe('status query scaling repositories', () => {
     repos.tasks.create({ ...baseTask, taskId: 'DONE', status: 'complete' });
     repos.tasks.create({ ...baseTask, taskId: 'REVIEW', status: 'review_ready' });
 
-    expect(repos.tasks.listByStatuses(['active', 'review_ready']).map((task) => task.taskId)).toEqual([
-      'ACTIVE',
-      'REVIEW',
-    ]);
+    expect(
+      repos.tasks.listByStatuses(['active', 'review_ready']).map((task) => task.taskId),
+    ).toEqual(['ACTIVE', 'REVIEW']);
     expect(repos.tasks.listByStatuses([])).toEqual([]);
   });
 

--- a/test/db/status-query-scaling.test.ts
+++ b/test/db/status-query-scaling.test.ts
@@ -58,4 +58,24 @@ describe('status query scaling repositories', () => {
     ]);
     expect(repos.reviews.latestForTasks([])).toEqual([]);
   });
+
+  it('bounds latest-review query parameters across large worksets', () => {
+    const repos = createRepositories(openDatabase(':memory:'));
+    repos.tasks.create({ ...baseTask, taskId: 'FIRST', status: 'review_ready' });
+    repos.tasks.create({ ...baseTask, taskId: 'LAST', status: 'review_ready' });
+    repos.reviews.create({ ...baseReview, taskId: 'FIRST', planSummary: 'first review' });
+    repos.reviews.create({ ...baseReview, taskId: 'LAST', planSummary: 'last review' });
+
+    const taskIds = [
+      'LAST',
+      ...Array.from({ length: 1_200 }, (_, index) => `MISSING-${String(index)}`),
+      'FIRST',
+      'LAST',
+    ];
+
+    expect(repos.reviews.latestForTasks(taskIds).map((review) => review.taskId)).toEqual([
+      'FIRST',
+      'LAST',
+    ]);
+  });
 });

--- a/test/db/status-query-scaling.test.ts
+++ b/test/db/status-query-scaling.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { openDatabase } from '../../src/db/connection.js';
+import { createRepositories } from '../../src/db/index.js';
+
+const baseTask = {
+  title: 'Task',
+  owner: null,
+  agent: 'codex',
+  branch: null,
+  worktree: null,
+  expectedFiles: [] as string[],
+  modules: [] as string[],
+  domains: [] as string[],
+  riskTags: [] as string[],
+  notes: null,
+  parentTaskId: null,
+  agentId: null,
+};
+
+const baseReview = {
+  planSummary: 'plan',
+  testsRun: [] as string[],
+  diffSize: null,
+  guardrailsChecked: [] as string[],
+  assumptions: [] as string[],
+  openQuestions: [] as string[],
+  provenance: [],
+};
+
+describe('status query scaling repositories', () => {
+  it('lists only requested task statuses while preserving task order', () => {
+    const repos = createRepositories(openDatabase(':memory:'));
+    repos.tasks.create({ ...baseTask, taskId: 'ACTIVE', status: 'active' });
+    repos.tasks.create({ ...baseTask, taskId: 'DONE', status: 'complete' });
+    repos.tasks.create({ ...baseTask, taskId: 'REVIEW', status: 'review_ready' });
+
+    expect(repos.tasks.listByStatuses(['active', 'review_ready']).map((task) => task.taskId)).toEqual([
+      'ACTIVE',
+      'REVIEW',
+    ]);
+    expect(repos.tasks.listByStatuses([])).toEqual([]);
+  });
+
+  it('loads the latest review for multiple tasks in one repository call', () => {
+    const repos = createRepositories(openDatabase(':memory:'));
+    repos.tasks.create({ ...baseTask, taskId: 'A', status: 'review_ready' });
+    repos.tasks.create({ ...baseTask, taskId: 'B', status: 'review_ready' });
+
+    repos.reviews.create({ ...baseReview, taskId: 'A', planSummary: 'A old' });
+    repos.reviews.create({ ...baseReview, taskId: 'B', planSummary: 'B latest' });
+    repos.reviews.create({ ...baseReview, taskId: 'A', planSummary: 'A latest' });
+
+    const latest = repos.reviews.latestForTasks(['A', 'B']);
+    expect(latest.map((review) => [review.taskId, review.planSummary])).toEqual([
+      ['A', 'A latest'],
+      ['B', 'B latest'],
+    ]);
+    expect(repos.reviews.latestForTasks([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Scale `buildStatus()` with the current workset instead of total workspace history.

- add `tasks.listByStatuses()` and have status load only active/review-ready task states
- add `reviews.latestForTasks()` so review-ready metadata is fetched in one query instead of one query per task
- preserve existing active/overlap/stale-claim/review semantics
- add focused repository regression coverage

Previously, `buildStatus()` loaded and parsed every historical task, then issued `latestForTask()` once per review-ready task. In long-lived workspaces that makes status cost grow with completed/closed history and introduces an N+1 review query pattern.

After this change, historical task rows are excluded from the status hot path and latest reviews are resolved with a single grouped query.

No schema migration is required; this PR is intentionally independent of the pending-message index PR.