### PR TITLE
perf(relay): phase-spread heartbeat refreshes

### DIFF
--- a/src/relay/server.ts
+++ b/src/relay/server.ts
@@ -93,6 +93,16 @@ function authenticated(supplied: string, expected: string): boolean {
   );
 }
 
+/** Deterministically spread relay heartbeat phases across one interval. */
+export function relayHeartbeatPhaseDelay(endpointId: string, intervalMs: number): number {
+  let hash = 2_166_136_261;
+  for (let index = 0; index < endpointId.length; index += 1) {
+    hash ^= endpointId.charCodeAt(index);
+    hash = Math.imul(hash, 16_777_619);
+  }
+  return Math.floor(((hash >>> 0) / 0x1_0000_0000) * intervalMs);
+}
+
 /** Host a one-frame, local-only delivery endpoint owned by one live session. */
 export async function startAgentRelay(
   options: AgentRelayServerOptions,
@@ -194,21 +204,27 @@ export async function startAgentRelay(
     });
   };
   storeEndpoint();
-  const heartbeat = setInterval(
-    () => {
-      if (closed) return;
-      const current = options.repos.agentEndpoints.getByAgent(options.agentId);
-      if (current?.endpointId !== endpointId) {
-        clearInterval(heartbeat);
-        closed = true;
-        server.close();
-        return;
-      }
-      storeEndpoint();
-    },
-    Math.max(1_000, Math.floor(ttlMs / 3)),
-  );
-  heartbeat.unref();
+
+  const heartbeatIntervalMs = Math.max(1_000, Math.floor(ttlMs / 3));
+  let heartbeat: ReturnType<typeof setInterval> | undefined;
+  const heartbeatOnce = (): void => {
+    if (closed) return;
+    const current = options.repos.agentEndpoints.getByAgent(options.agentId);
+    if (current?.endpointId !== endpointId) {
+      if (heartbeat !== undefined) clearInterval(heartbeat);
+      closed = true;
+      server.close();
+      return;
+    }
+    storeEndpoint();
+  };
+  const heartbeatStarter = setTimeout(() => {
+    heartbeatOnce();
+    if (closed) return;
+    heartbeat = setInterval(heartbeatOnce, heartbeatIntervalMs);
+    heartbeat.unref();
+  }, relayHeartbeatPhaseDelay(endpointId, heartbeatIntervalMs));
+  heartbeatStarter.unref();
 
   return {
     endpointId,
@@ -216,7 +232,8 @@ export async function startAgentRelay(
     close: async () => {
       if (closed) return;
       closed = true;
-      clearInterval(heartbeat);
+      clearTimeout(heartbeatStarter);
+      if (heartbeat !== undefined) clearInterval(heartbeat);
       const current = options.repos.agentEndpoints.getByAgent(options.agentId);
       const ownsAddress = current?.endpointId === endpointId;
       if (ownsAddress) options.repos.agentEndpoints.disconnect(endpointId);

--- a/src/relay/server.ts
+++ b/src/relay/server.ts
@@ -94,7 +94,10 @@ function authenticated(supplied: string, expected: string): boolean {
 }
 
 /** Deterministically spread relay heartbeat phases across one interval. */
-export function relayHeartbeatPhaseDelay(endpointId: string, intervalMs: number): number {
+export function relayHeartbeatPhaseDelay(
+  endpointId: string,
+  intervalMs: number,
+): number {
   let hash = 2_166_136_261;
   for (let index = 0; index < endpointId.length; index += 1) {
     hash ^= endpointId.charCodeAt(index);

--- a/src/relay/server.ts
+++ b/src/relay/server.ts
@@ -94,10 +94,7 @@ function authenticated(supplied: string, expected: string): boolean {
 }
 
 /** Deterministically spread relay heartbeat phases across one interval. */
-export function relayHeartbeatPhaseDelay(
-  endpointId: string,
-  intervalMs: number,
-): number {
+export function relayHeartbeatPhaseDelay(endpointId: string, intervalMs: number): number {
   let hash = 2_166_136_261;
   for (let index = 0; index < endpointId.length; index += 1) {
     hash ^= endpointId.charCodeAt(index);
@@ -221,12 +218,15 @@ export async function startAgentRelay(
     }
     storeEndpoint();
   };
-  const heartbeatStarter = setTimeout(() => {
-    heartbeatOnce();
-    if (closed) return;
-    heartbeat = setInterval(heartbeatOnce, heartbeatIntervalMs);
-    heartbeat.unref();
-  }, relayHeartbeatPhaseDelay(endpointId, heartbeatIntervalMs));
+  const heartbeatStarter = setTimeout(
+    () => {
+      heartbeatOnce();
+      if (closed) return;
+      heartbeat = setInterval(heartbeatOnce, heartbeatIntervalMs);
+      heartbeat.unref();
+    },
+    relayHeartbeatPhaseDelay(endpointId, heartbeatIntervalMs),
+  );
   heartbeatStarter.unref();
 
   return {

--- a/test/relay/relay.test.ts
+++ b/test/relay/relay.test.ts
@@ -8,7 +8,11 @@ import { openDatabase } from '../../src/db/connection.js';
 import { createRepositories, type Repositories } from '../../src/db/index.js';
 import { relayAddress } from '../../src/relay/address.js';
 import { CodexAppServerAdapter } from '../../src/relay/adapters.js';
-import { startAgentRelay, type AgentSessionDelivery } from '../../src/relay/server.js';
+import {
+  relayHeartbeatPhaseDelay,
+  startAgentRelay,
+  type AgentSessionDelivery,
+} from '../../src/relay/server.js';
 import { SocketAgentMessageDispatcher } from '../../src/relay/socket-dispatcher.js';
 import { registerPullEndpoint } from '../../src/cli/commands/inbox.js';
 import { handleSendAgentMessageWithDelivery } from '../../src/tools/agent-messages.js';
@@ -27,6 +31,20 @@ function register(repos: Repositories, agentId: string): void {
     status: 'active',
   });
 }
+
+describe('relay heartbeat phase spreading', () => {
+  it('is deterministic, bounded, and separates endpoint phases', () => {
+    const intervalMs = 5_000;
+    const endpointIds = ['endpoint-a', 'endpoint-b', 'endpoint-c', 'endpoint-d'];
+    const delays = endpointIds.map((endpointId) =>
+      relayHeartbeatPhaseDelay(endpointId, intervalMs),
+    );
+
+    expect(relayHeartbeatPhaseDelay('endpoint-a', intervalMs)).toBe(delays[0]);
+    expect(delays.every((delay) => delay >= 0 && delay < intervalMs)).toBe(true);
+    expect(new Set(delays).size).toBeGreaterThan(2);
+  });
+});
 
 describe('local IPC relay', () => {
   let repos: Repositories;


### PR DESCRIPTION
## Summary

Spread relay heartbeat phases deterministically across the existing refresh interval so multiple sessions started together do not keep refreshing SQLite in lockstep.

- derive a stable phase from `endpointId` using a tiny in-process FNV-1a hash
- delay only the first heartbeat, then keep the existing fixed heartbeat interval
- preserve the same average heartbeat frequency and TTL semantics
- no new dependencies
- add regression coverage for determinism, bounds, and phase separation

This targets burstiness rather than throughput: relays still refresh at the same cadence, but their refreshes are distributed across the interval instead of tending to align after simultaneous startup.