### PR TITLE
fix: rescue ownerless orphaned claims and default the task owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Ownerless tasks are no longer permanently stranded when their claiming
+  session ends: an owner-registered agent may now `force`-reassign or reopen an
+  ownerless task once the claimant's derived liveness decays past idle.
+  Owned tasks keep strict same-owner arbitration; live claims and rescuers
+  without a registered human owner are still refused.
+- `start_work` calls that name no `owner` now default it from
+  `CONCORD_DEFAULT_OWNER`, else the repository's `git config user.name`, so new
+  tasks are no longer created ownerless. An explicit `owner` always wins.
+
 ## [0.10.3] - 2026-08-25
 
 ### Added

--- a/src/config/default-owner.ts
+++ b/src/config/default-owner.ts
@@ -1,0 +1,28 @@
+import { execFileSync } from 'node:child_process';
+
+/**
+ * Resolve the human owner to record when `start_work` does not name one.
+ *
+ * A task whose `owner` is null has no supervisor: if its claiming session ends,
+ * no other agent can ever force-reassign, reopen, or close it (see
+ * `isHumanSupervisor` in tools/task-lifecycle.ts). Sessions routinely forget to
+ * pass `owner`, so the server resolves a workspace default once at startup —
+ * `CONCORD_DEFAULT_OWNER` from the environment, else the repository's
+ * `git config user.name` — and applies it wherever a registration or claim
+ * arrives ownerless. An explicit `owner` on the call always wins.
+ */
+export function resolveDefaultOwner(env: NodeJS.ProcessEnv, repoRoot: string): string | null {
+  const fromEnv = env['CONCORD_DEFAULT_OWNER']?.trim();
+  if (fromEnv !== undefined && fromEnv.length > 0) {
+    return fromEnv;
+  }
+  try {
+    const name = execFileSync('git', ['-C', repoRoot, 'config', 'user.name'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    return name.length > 0 ? name : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 
 import { writeArtifacts } from './artifacts/index.js';
 import { startBackgroundUpdateCheck } from './update-notifier.js';
+import { resolveDefaultOwner } from './config/default-owner.js';
 import { resolveRepoRoot } from './config/paths.js';
 import { resolveIdentity } from './domain/identity.js';
 import { createServer } from './server.js';
@@ -28,8 +29,10 @@ async function main(): Promise<void> {
     workspaceRoot: () => workspaceManager.current().repoRoot,
     recordSessionStarted: true,
   });
+  const defaultOwner = resolveDefaultOwner(process.env, repoRoot);
   const server = createServer(workspaceManager.current().repos, {
     workspaceManager,
+    defaultOwner,
     ...(identity === undefined ? {} : { identity }),
     getAvailableUpdate: updateCheck.getAvailableUpdate,
     ...(telemetry === undefined ? {} : { telemetry }),

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,6 +32,8 @@ export interface ServerOptions {
   getAvailableUpdate?: () => AvailableUpdate | undefined;
   /** Receives whitelisted, content-free results from workflow handlers. */
   telemetry?: TelemetryRecorder;
+  /** Owner recorded for registrations/claims that do not name one. */
+  defaultOwner?: string | null;
 }
 
 /**
@@ -63,6 +65,7 @@ export function createServer(repos: Repositories, options: ServerOptions = {}): 
     options.getAvailableUpdate,
     undefined,
     options.telemetry,
+    options.defaultOwner ?? null,
   );
   return server;
 }

--- a/src/tools/task-lifecycle.ts
+++ b/src/tools/task-lifecycle.ts
@@ -6,6 +6,7 @@ import type {
   TaskStatus,
   ToolName,
 } from '../db/index.js';
+import { deriveLiveness } from '../domain/presence.js';
 import type {
   AcceptTaskInput,
   AssignTaskInput,
@@ -56,6 +57,28 @@ function taskAtVersion(repos: Repositories, taskId: string, expectedVersion: num
 
 function isHumanSupervisor(actor: AgentRecord, task: TaskRecord): boolean {
   return actor.owner !== null && task.owner !== null && actor.owner === task.owner;
+}
+
+/**
+ * An ownerless task whose claiming agent has gone away is orphaned: no human
+ * owner exists to arbitrate, and the only identity allowed to touch it can
+ * never return (session-derived agent ids are minted per session). Without a
+ * rescue path such tasks are permanently stuck. Rescue is deliberately narrow:
+ * only for tasks with no `owner`, only once the claimant's derived liveness has
+ * decayed past `idle`, and only for an actor registered to a human owner —
+ * anonymous agents cannot scoop orphans, and owner arbitration for owned tasks
+ * is unchanged.
+ */
+function isOrphanedClaim(repos: Repositories, task: TaskRecord, now: number): boolean {
+  if (task.owner !== null || task.agentId === null) {
+    return false;
+  }
+  const claimant = repos.agents.get(task.agentId);
+  if (claimant === undefined) {
+    return true;
+  }
+  const liveness = deriveLiveness(claimant.lastSeen, now);
+  return liveness === 'away' || liveness === 'archived';
 }
 
 function requireOwner(task: TaskRecord, actor: AgentRecord): void {
@@ -209,9 +232,10 @@ export function handleReassignTask(
   registeredAgent(repos, input.to_agent_id);
   const task = taskAtVersion(repos, input.task_id, input.expected_version);
   if (task.agentId !== actor.agentId) {
-    if (input.force !== true || !isHumanSupervisor(actor, task)) {
+    const orphanRescue = actor.owner !== null && isOrphanedClaim(repos, task, now);
+    if (input.force !== true || (!isHumanSupervisor(actor, task) && !orphanRescue)) {
       throw new Error(
-        `Only the current owner or a registered agent for human owner ${task.owner ?? '(none)'} can force-reassign ${task.taskId}.`,
+        `Only the current owner, a registered agent for human owner ${task.owner ?? '(none)'}, or — for an ownerless task whose claiming agent is gone — an owner-registered agent with force=true can reassign ${task.taskId}.`,
       );
     }
   }
@@ -246,13 +270,23 @@ export function handleCloseTask(repos: Repositories, input: CloseTaskInput): Tas
   });
 }
 
-export function handleReopenTask(repos: Repositories, input: ReopenTaskInput): TaskLifecycleResult {
+export function handleReopenTask(
+  repos: Repositories,
+  input: ReopenTaskInput,
+  now: number = Date.now(),
+): TaskLifecycleResult {
   const actor = registeredAgent(repos, input.agent_id);
   const task = taskAtVersion(repos, input.task_id, input.expected_version);
   if (!['closed', 'complete', 'handed_off', 'review_ready'].includes(task.status)) {
     throw new Error(`Task ${task.taskId} is ${task.status}, not a terminal/review state.`);
   }
-  if (task.agentId !== null && task.agentId !== actor.agentId && !isHumanSupervisor(actor, task)) {
+  const orphanRescue = actor.owner !== null && isOrphanedClaim(repos, task, now);
+  if (
+    task.agentId !== null &&
+    task.agentId !== actor.agentId &&
+    !isHumanSupervisor(actor, task) &&
+    !orphanRescue
+  ) {
     throw new Error(`Agent ${actor.agentId} cannot reopen ${task.taskId}.`);
   }
   return applyTransition(repos, {

--- a/src/tools/workflow.ts
+++ b/src/tools/workflow.ts
@@ -90,11 +90,19 @@ function taskOrThrow(repos: Repositories, taskId: string): TaskRecord {
  * operation. Existing assignments, addressed handoffs, proposed tasks, and
  * terminal tasks are resumed through the same proven lifecycle handlers.
  */
-function startWork(repos: Repositories, input: WithActor<StartWorkInput>): StartWorkResult {
+function startWork(
+  repos: Repositories,
+  input: WithActor<StartWorkInput>,
+  defaultOwner: string | null = null,
+): StartWorkResult {
+  // An ownerless task loses its only supervisor when its session ends (see
+  // isHumanSupervisor in task-lifecycle.ts), so a missing owner falls back to
+  // the workspace default resolved at server startup.
+  const owner = input.owner ?? defaultOwner ?? undefined;
   const registration = handleRegisterAgent(repos, {
     agent_id: input.agent_id,
     kind: input.kind,
-    owner: input.owner,
+    owner,
     model: input.model,
     summary: input.summary ?? input.title,
     status: 'active',
@@ -165,7 +173,7 @@ function startWork(repos: Repositories, input: WithActor<StartWorkInput>): Start
   const claim = handleClaimWork(repos, {
     task_id: input.task_id,
     title: input.title,
-    owner: input.owner,
+    owner,
     agent: input.kind,
     agent_id: agentId,
     branch: input.branch,
@@ -184,8 +192,9 @@ function startWork(repos: Repositories, input: WithActor<StartWorkInput>): Start
 export function handleStartWork(
   repos: Repositories,
   input: WithActor<StartWorkInput>,
+  defaultOwner: string | null = null,
 ): StartWorkResult {
-  const transact = repos.db.transaction(() => startWork(repos, input));
+  const transact = repos.db.transaction(() => startWork(repos, input, defaultOwner));
   return transact();
 }
 
@@ -444,6 +453,7 @@ export function registerWorkflowTools(
   getAvailableUpdate?: () => AvailableUpdate | undefined,
   dispatcher: AgentMessageDispatcher = new SocketAgentMessageDispatcher(),
   telemetry?: TelemetryRecorder,
+  defaultOwner: string | null = null,
 ): void {
   interface WorkflowToolResponse {
     content: { type: 'text'; text: string }[];
@@ -563,10 +573,14 @@ export function registerWorkflowTools(
       // The session's kind wins alongside its id: the id embeds the kind, so
       // registering under a different one would describe an agent that is not
       // the one being addressed.
-      const result = handleStartWork(repos, {
-        ...withActor(args),
-        kind: session?.kind ?? args.kind,
-      });
+      const result = handleStartWork(
+        repos,
+        {
+          ...withActor(args),
+          kind: session?.kind ?? args.kind,
+        },
+        defaultOwner,
+      );
       const startedTaskFlowId = taskFlowId(result.claim.task.taskId);
       if (startedTaskFlowId !== undefined) {
         telemetry?.recordEvent({

--- a/test/config/default-owner.test.ts
+++ b/test/config/default-owner.test.ts
@@ -1,0 +1,31 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { resolveDefaultOwner } from '../../src/config/default-owner.js';
+
+function gitRepoWithLocalUserName(name: string): string {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'concord-owner-')));
+  execFileSync('git', ['-C', root, 'init', '--quiet']);
+  execFileSync('git', ['-C', root, 'config', 'user.name', name]);
+  return root;
+}
+
+describe('resolveDefaultOwner', () => {
+  it('prefers CONCORD_DEFAULT_OWNER over git config', () => {
+    const root = gitRepoWithLocalUserName('From Git');
+    expect(resolveDefaultOwner({ CONCORD_DEFAULT_OWNER: ' From Env ' }, root)).toBe('From Env');
+  });
+
+  it('falls back to the repository git user.name', () => {
+    const root = gitRepoWithLocalUserName('Repo Local Owner');
+    expect(resolveDefaultOwner({}, root)).toBe('Repo Local Owner');
+  });
+
+  it('returns null when neither source resolves', () => {
+    expect(resolveDefaultOwner({}, join(tmpdir(), 'concord-owner-does-not-exist'))).toBeNull();
+  });
+});

--- a/test/tools/task-lifecycle.test.ts
+++ b/test/tools/task-lifecycle.test.ts
@@ -236,3 +236,131 @@ describe('versioned task lifecycle', () => {
     expect(completed.task.status).toBe('complete');
   });
 });
+
+describe('orphaned ownerless claims', () => {
+  const THIRTY_ONE_MINUTES = 31 * 60 * 1000;
+  let repos: Repositories;
+
+  beforeEach(() => {
+    repos = createRepositories(openDatabase(':memory:'));
+    // A session that claimed work without ever naming a human owner, then died.
+    handleRegisterAgent(repos, { agent_id: 'opencode:ghost', kind: 'opencode' });
+    handleRegisterAgent(repos, { agent_id: 'claude:rescuer', kind: 'claude-code', owner: 'alex' });
+    handleRegisterAgent(repos, { agent_id: 'codex:anonymous', kind: 'codex' });
+    handleClaimWork(repos, { task_id: 'TASK-GHOST', title: 'Orphaned', agent_id: 'opencode:ghost' });
+  });
+
+  it('lets an owner-registered agent force-take an ownerless task once its claimant is away', () => {
+    const rescued = handleReassignTask(
+      repos,
+      {
+        task_id: 'TASK-GHOST',
+        to_agent_id: 'claude:rescuer',
+        agent_id: 'claude:rescuer',
+        expected_version: 1,
+        force: true,
+        reason: 'claimant session ended',
+      },
+      Date.now() + THIRTY_ONE_MINUTES,
+    );
+    expect(rescued.task.status).toBe('assigned');
+    expect(rescued.task.assignedAgentId).toBe('claude:rescuer');
+    expect(
+      repos.ownershipEvents.listByTask('TASK-GHOST').map((event) => event.transition),
+    ).toContain('force_reassign');
+  });
+
+  it('still refuses while the ownerless claimant is live', () => {
+    expect(() =>
+      handleReassignTask(repos, {
+        task_id: 'TASK-GHOST',
+        to_agent_id: 'claude:rescuer',
+        agent_id: 'claude:rescuer',
+        expected_version: 1,
+        force: true,
+        reason: 'too eager',
+      }),
+    ).toThrow(/can (?:force-)?reassign/);
+  });
+
+  it('refuses rescue by an agent with no registered human owner', () => {
+    expect(() =>
+      handleReassignTask(
+        repos,
+        {
+          task_id: 'TASK-GHOST',
+          to_agent_id: 'codex:anonymous',
+          agent_id: 'codex:anonymous',
+          expected_version: 1,
+          force: true,
+          reason: 'anonymous scoop',
+        },
+        Date.now() + THIRTY_ONE_MINUTES,
+      ),
+    ).toThrow(/can (?:force-)?reassign/);
+  });
+
+  it('never widens takeover of a task that names a different human owner', () => {
+    handleRegisterAgent(repos, { agent_id: 'opencode:sams', kind: 'opencode', owner: 'sam' });
+    handleClaimWork(repos, {
+      task_id: 'TASK-SAM',
+      title: 'Owned by sam',
+      owner: 'sam',
+      agent_id: 'opencode:sams',
+    });
+    expect(() =>
+      handleReassignTask(
+        repos,
+        {
+          task_id: 'TASK-SAM',
+          to_agent_id: 'claude:rescuer',
+          agent_id: 'claude:rescuer',
+          expected_version: 1,
+          force: true,
+          reason: 'not my task',
+        },
+        Date.now() + THIRTY_ONE_MINUTES,
+      ),
+    ).toThrow(/can (?:force-)?reassign/);
+  });
+
+  it('lets an owner-registered agent reopen an ownerless terminal task once its claimant is away', () => {
+    const closed = handleCloseTask(repos, {
+      task_id: 'TASK-GHOST',
+      agent_id: 'opencode:ghost',
+      expected_version: 1,
+      reason: 'done',
+      outcome: 'complete',
+    });
+    const reopened = handleReopenTask(
+      repos,
+      {
+        task_id: 'TASK-GHOST',
+        agent_id: 'claude:rescuer',
+        expected_version: closed.task.version,
+        reason: 'closure record incomplete',
+      },
+      Date.now() + THIRTY_ONE_MINUTES,
+    );
+    expect(reopened.task.status).toBe('active');
+    expect(reopened.task.agentId).toBe('claude:rescuer');
+  });
+
+  it('still refuses reopen of an ownerless terminal task while its claimant is live', () => {
+    const closed = handleCloseTask(repos, {
+      task_id: 'TASK-GHOST',
+      agent_id: 'opencode:ghost',
+      expected_version: 1,
+      reason: 'done',
+      outcome: 'complete',
+    });
+    expect(() =>
+      handleReopenTask(repos, {
+        task_id: 'TASK-GHOST',
+        agent_id: 'claude:rescuer',
+        expected_version: closed.task.version,
+        reason: 'too eager',
+      }),
+    ).toThrow(/cannot reopen/);
+  });
+});

--- a/test/tools/workflow.test.ts
+++ b/test/tools/workflow.test.ts
@@ -9,7 +9,7 @@ import { drainInbox, registerPullEndpoint } from '../../src/cli/commands/inbox.j
 import type { AvailableUpdate } from '../../src/update-notifier.js';
 import { resolveIdentity, type AgentIdentity } from '../../src/domain/identity.js';
 import type { SemanticTelemetryEvent, TelemetryRecorder } from '../../src/telemetry/events.js';
-import { PUBLIC_WORKFLOW_TOOLS } from '../../src/tools/workflow.js';
+import { handleStartWork, PUBLIC_WORKFLOW_TOOLS } from '../../src/tools/workflow.js';
 
 interface Harness {
   client: Client;
@@ -938,5 +938,46 @@ describe('one identity per session', () => {
     } finally {
       await close(harness);
     }
+  });
+});
+
+describe('start_work owner defaulting', () => {
+  it('records the workspace default owner when the call names none', () => {
+    const repos = createRepositories(openDatabase(':memory:'));
+    const result = handleStartWork(
+      repos,
+      { task_id: 'TASK-DEFAULT', title: 'Ownerless call', kind: 'claude-code', agent_id: 'claude:s1' },
+      'alex',
+    );
+    expect(result.claim.task.owner).toBe('alex');
+    expect(repos.agents.get('claude:s1')?.owner).toBe('alex');
+  });
+
+  it('lets an explicit owner override the workspace default', () => {
+    const repos = createRepositories(openDatabase(':memory:'));
+    const result = handleStartWork(
+      repos,
+      {
+        task_id: 'TASK-EXPLICIT',
+        title: 'Named owner',
+        kind: 'claude-code',
+        agent_id: 'claude:s2',
+        owner: 'sam',
+      },
+      'alex',
+    );
+    expect(result.claim.task.owner).toBe('sam');
+    expect(repos.agents.get('claude:s2')?.owner).toBe('sam');
+  });
+
+  it('still records null when no default resolves', () => {
+    const repos = createRepositories(openDatabase(':memory:'));
+    const result = handleStartWork(repos, {
+      task_id: 'TASK-NONE',
+      title: 'No owner anywhere',
+      kind: 'claude-code',
+      agent_id: 'claude:s3',
+    });
+    expect(result.claim.task.owner).toBeNull();
   });
 });


### PR DESCRIPTION
## Problem

Two related defects make tasks permanently untouchable once their claiming session ends:

1. `isHumanSupervisor` requires `actor.owner === task.owner`, so a task claimed without an `owner` has **no possible supervisor** — force-reassign, reopen, and close are all refused forever once its agent id is gone. Session-scoped agent ids (e.g. Claude Code's per-session hashes) can never return, so the claim is held by an identity that no longer exists.
2. Nothing defaults the owner, and sessions routinely omit it.

We hit this in production coordination: four fully-delivered tasks were stranded ownerless when their claiming session ended, with every recovery route refused.

## Fix

- **Orphan rescue** (`tools/task-lifecycle.ts`): an owner-registered agent may `force`-reassign or reopen an *ownerless* task once the claimant's derived liveness (`domain/presence.ts`) decays past idle (away/archived, or claimant unregistered). Deliberately narrow: owned tasks keep strict same-owner arbitration, live claims are untouchable, and agents without a registered human owner cannot rescue.
- **Default owner** (`config/default-owner.ts`): `start_work` registrations/claims that name no `owner` fall back to `CONCORD_DEFAULT_OWNER`, else the repository's `git config user.name`, resolved once at server startup. An explicit `owner` always wins.

## Verification

- 6 new lifecycle tests (2 rescue paths + 4 refusal preservation controls), 3 config resolver tests, 3 `start_work` defaulting tests
- Full suite 346/346, `pnpm lint`, `pnpm typecheck` clean
- Exercised against a real workspace: the four stranded tasks were rescued and closed through these handlers with full `ownership_events` audit trails

🤖 Generated with [Claude Code](https://claude.com/claude-code)